### PR TITLE
feat(search): debounced SearchContext + fetchFilteredTasks() + Supabase trigram indexes

### DIFF
--- a/src/components/Search/SearchBar.js
+++ b/src/components/Search/SearchBar.js
@@ -1,18 +1,31 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useSearch } from '../contexts/SearchContext';
 
 const SearchBar = ({ onToggleResults }) => {
   const {
-    searchFilters,
-    updateTextSearch,
-    clearAllFilters,
+    filters,
+    setFilters,
+    isLoading,
+    count,
     isSearchActive,
-    isSearching,
+    reset,
   } = useSearch();
 
-  const handleChange = (event) => {
-    updateTextSearch(event.target.value);
-  };
+  const handleChange = useCallback(
+    (event) => {
+      const { value } = event.target;
+      setFilters((prev) => ({
+        ...prev,
+        text: value,
+        from: 0,
+      }));
+    },
+    [setFilters]
+  );
+
+  const handleClear = useCallback(() => {
+    reset();
+  }, [reset]);
 
   return (
     <div className="search-container" style={{ marginBottom: '20px' }}>
@@ -31,8 +44,8 @@ const SearchBar = ({ onToggleResults }) => {
         <span style={{ color: '#6b7280', fontSize: '16px' }}>🔍</span>
         <input
           type="text"
-          placeholder="Search tasks..."
-          value={searchFilters.text}
+          placeholder="Search tasks…"
+          value={filters.text}
           onChange={handleChange}
           style={{
             border: 'none',
@@ -41,14 +54,15 @@ const SearchBar = ({ onToggleResults }) => {
             fontSize: '16px',
             backgroundColor: 'transparent',
           }}
+          aria-label="Search tasks"
         />
-        {isSearching && (
+        {isLoading && (
           <span style={{ fontSize: '12px', color: '#6b7280' }}>Searching…</span>
         )}
         {isSearchActive && (
           <button
             type="button"
-            onClick={clearAllFilters}
+            onClick={handleClear}
             style={{
               background: 'none',
               border: 'none',
@@ -77,7 +91,7 @@ const SearchBar = ({ onToggleResults }) => {
               transition: 'background-color 0.15s ease',
             }}
           >
-            Results
+            Results ({isSearchActive ? count : 0})
           </button>
         )}
       </div>

--- a/src/components/contexts/__tests__/SearchContext.test.js
+++ b/src/components/contexts/__tests__/SearchContext.test.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, fireEvent, screen, act, waitFor } from '@testing-library/react';
+import { SearchProvider, useSearch } from '../SearchContext';
+import { fetchFilteredTasks } from '../../../services/taskService';
+
+jest.mock('../../../services/taskService', () => ({
+  fetchFilteredTasks: jest.fn(),
+}));
+
+const TestConsumer = () => {
+  const { filters, setFilters, results, isLoading, reset } = useSearch();
+
+  return (
+    <div>
+      <input
+        data-testid='search-input'
+        value={filters.text}
+        onChange={(event) =>
+          setFilters((prev) => ({
+            ...prev,
+            text: event.target.value,
+          }))
+        }
+      />
+      <span data-testid='results-count'>{results.length}</span>
+      {isLoading ? <span data-testid='loading'>loading</span> : null}
+      <button type='button' data-testid='reset-button' onClick={reset}>
+        reset
+      </button>
+    </div>
+  );
+};
+
+describe('SearchContext', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchFilteredTasks.mockReset();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('debounces filter updates and exposes latest results', async () => {
+    fetchFilteredTasks
+      .mockResolvedValueOnce({ data: [], count: 0 })
+      .mockResolvedValueOnce({ data: [{ id: 'final' }], count: 1 });
+
+    render(
+      <SearchProvider>
+        <TestConsumer />
+      </SearchProvider>
+    );
+
+    expect(fetchFilteredTasks).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    expect(fetchFilteredTasks).toHaveBeenCalledTimes(1);
+
+    const input = screen.getByTestId('search-input');
+
+    fireEvent.change(input, { target: { value: 'f' } });
+    fireEvent.change(input, { target: { value: 'fo' } });
+    fireEvent.change(input, { target: { value: 'foo' } });
+
+    expect(fetchFilteredTasks).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(fetchFilteredTasks).toHaveBeenCalledTimes(2);
+    const lastCall = fetchFilteredTasks.mock.calls.at(-1)[0];
+    expect(lastCall.text).toBe('foo');
+    expect(lastCall.from).toBe(0);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('results-count').textContent).toBe('1')
+    );
+  });
+
+  it('resets filters and triggers a new search', async () => {
+    fetchFilteredTasks
+      .mockResolvedValueOnce({ data: [], count: 0 })
+      .mockResolvedValueOnce({ data: [{ id: 'after-change' }], count: 1 })
+      .mockResolvedValueOnce({ data: [], count: 0 });
+
+    render(
+      <SearchProvider>
+        <TestConsumer />
+      </SearchProvider>
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    const input = screen.getByTestId('search-input');
+    fireEvent.change(input, { target: { value: 'bar' } });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(fetchFilteredTasks).toHaveBeenCalledTimes(2);
+
+    const resetButton = screen.getByTestId('reset-button');
+    fireEvent.click(resetButton);
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(fetchFilteredTasks).toHaveBeenCalledTimes(3);
+    expect(screen.getByTestId('search-input')).toHaveValue('');
+  });
+});

--- a/src/services/__tests__/taskService.fetchFilteredTasks.test.js
+++ b/src/services/__tests__/taskService.fetchFilteredTasks.test.js
@@ -1,0 +1,85 @@
+const { supabase } = require('../../supabaseClient');
+const { fetchFilteredTasks } = require('../taskService');
+
+const createBuilder = (state) => {
+  const builder = {};
+  builder.select = jest.fn(() => builder);
+  builder.eq = jest.fn(() => builder);
+  builder.in = jest.fn(() => builder);
+  builder.or = jest.fn(() => builder);
+  builder.range = jest.fn(() => {
+    const next =
+      state.resultQueue.length > 0
+        ? state.resultQueue.shift()
+        : { data: [], error: null, count: 0 };
+    return Promise.resolve(next);
+  });
+  return builder;
+};
+
+describe('fetchFilteredTasks', () => {
+  const originalFrom = supabase.from;
+  let state;
+
+  beforeEach(() => {
+    state = { resultQueue: [] };
+    state.builder = createBuilder(state);
+    supabase.from = jest.fn(() => state.builder);
+  });
+
+  afterEach(() => {
+    supabase.from = originalFrom;
+  });
+
+  it('applies filters and returns data with count', async () => {
+    const sample = [{ id: 'a', title: 'Foo task' }];
+    state.resultQueue.push({ data: sample, error: null, count: 1 });
+
+    const result = await fetchFilteredTasks({
+      text: 'foo',
+      status: ['open', 'done'],
+      taskType: 'template',
+      assigneeId: 'user-123',
+      projectId: 'project-456',
+      limit: 10,
+      from: 5,
+    });
+
+    const query = state.builder;
+
+    expect(supabase.from).toHaveBeenCalledWith('tasks');
+    expect(query.select).toHaveBeenCalledWith('*', { count: 'exact' });
+    expect(query.in).toHaveBeenCalledWith('status', ['open', 'done']);
+    expect(query.eq).toHaveBeenCalledWith('project_id', 'project-456');
+    expect(query.eq).toHaveBeenCalledWith('task_type', 'template');
+    expect(query.eq).toHaveBeenCalledWith('assignee_id', 'user-123');
+    expect(query.or).toHaveBeenCalledWith('title.ilike.%foo%,description.ilike.%foo%');
+    expect(query.range).toHaveBeenCalledWith(5, 14);
+    expect(result).toEqual({ data: sample, count: 1 });
+  });
+
+  it('supports scalar status filters and escapes text patterns', async () => {
+    state.resultQueue.push({ data: [], error: null, count: 0 });
+
+    await fetchFilteredTasks({
+      text: '100%_match',
+      status: 'open',
+      taskType: ['instance', 'template'],
+    });
+
+    const query = state.builder;
+
+    expect(query.eq).toHaveBeenCalledWith('status', 'open');
+    expect(query.in).toHaveBeenCalledWith('task_type', ['instance', 'template']);
+    expect(query.or).toHaveBeenCalledWith(
+      'title.ilike.%100\\%\\_match%,description.ilike.%100\\%\\_match%'
+    );
+  });
+
+  it('throws when Supabase returns an error', async () => {
+    const error = { message: 'Boom' };
+    state.resultQueue.push({ data: null, error, count: null });
+
+    await expect(fetchFilteredTasks()).rejects.toEqual(error);
+  });
+});

--- a/supabase/migrations/20251029025048_tasks_search_indexes.sql
+++ b/supabase/migrations/20251029025048_tasks_search_indexes.sql
@@ -1,0 +1,11 @@
+-- Enable trigram search for fast ILIKE/%% queries
+create extension if not exists pg_trgm;
+
+-- Trigram indexes for title + description
+create index if not exists tasks_title_trgm_idx on tasks using gin (title gin_trgm_ops);
+create index if not exists tasks_description_trgm_idx on tasks using gin (description gin_trgm_ops);
+
+-- Optional full-text index if you prefer to_tsquery/websearch_to_tsquery
+-- alter table tasks add column if not exists fts tsvector
+--   generated always as (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(description,''))) stored;
+-- create index if not exists tasks_fts_idx on tasks using gin (fts);


### PR DESCRIPTION
## Summary

Implements Phase 1.2 search integration. Adds fast server-side search indexes, a typed filterable service `fetchFilteredTasks()`, a debounced `SearchContext` (300 ms) that drives results, and wires `SearchBar` to update filters and trigger searches.

## Changes

* **DB migration**

  * Enable `pg_trgm` and add GIN trigram indexes: `tasks_title_trgm_idx`, `tasks_description_trgm_idx`.
* **Service**

  * `fetchFilteredTasks({ text, status, taskType, assigneeId, projectId, from, limit })` in `src/services/taskService.js`
  * Supports `ilike` OR on `title`/`description`, exact count, pagination.
* **State**

  * `SearchContext`: exposes `{filters, setFilters, results, count, isLoading, error, reset}` and debounces calls by 300 ms.
* **UI**

  * `SearchBar` uses `SearchContext`; updating the input updates `filters.text` and re-queries.
* **Tests**

  * Service unit tests (query composition).
  * Context tests with `jest.useFakeTimers()` to assert single debounced call.

## User impact

* Search is responsive and consistent across the app.
* No breaking changes; existing pages render normally.

## Risks

* **DB**: Requires `pg_trgm` extension enabled. On hosts that disallow extensions, indexes won’t create.
  Mitigation: guard with `create extension if not exists pg_trgm;`.
* **Perf**: Initial index creation takes time on large tables. Queries thereafter speed up significantly.

## Proof

* Typing in the search input triggers one network call per pause ≥300 ms.
* Service tests validate filter → query mapping (status/taskType/assignee/project scopes, text).
* Context tests confirm debounce behavior and result propagation.

## Rollback plan

* Revert this PR; optional DB cleanup:

  ```sql
  drop index if exists tasks_title_trgm_idx;
  drop index if exists tasks_description_trgm_idx;
  -- leave pg_trgm enabled (safe), or drop extension if desired:
  -- drop extension if exists pg_trgm;
  ```

## Follow-ups

* Add result list virtualization if large sets.
* Expose pagination controls (next/prev).
* Optional: switch to full-text (`tsvector` + `websearch_to_tsquery`) if richer ranking is needed.
* Surface additional filters (date range, archived, priority) in the UI.
