### PR TITLE
Replace hardcoded colors with design tokens for charts and homepage

### DIFF
--- a/src/features/reports/components/PhaseBarChart.jsx
+++ b/src/features/reports/components/PhaseBarChart.jsx
@@ -12,11 +12,11 @@ import {
 const chartConfig = {
     completed: {
         label: "Completed",
-        color: "#10b981", // emerald-500
+        color: "var(--color-brand-500)",
     },
     remaining: {
         label: "Remaining",
-        color: "#e2e8f0", // slate-200
+        color: "var(--color-muted)",
     },
 };
 
@@ -31,7 +31,11 @@ const PhaseBarChart = memo(function PhaseBarChart({ data }) {
                         layout="vertical"
                         margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
                     >
-                        <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#e2e8f0" />
+                        <CartesianGrid
+                            strokeDasharray="3 3"
+                            horizontal={false}
+                            stroke="var(--color-border)"
+                        />
                         <XAxis type="number" hide />
                         <YAxis
                             type="category"

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -117,7 +117,7 @@ export default function Home() {
           <svg viewBox="0 0 1440 120" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path
               d="M0 120L60 110C120 100 240 80 360 70C480 60 600 60 720 65C840 70 960 80 1080 85C1200 90 1320 90 1380 90L1440 90V120H1380C1320 120 1200 120 1080 120C960 120 840 120 720 120C600 120 480 120 360 120C240 120 120 120 60 120H0Z"
-              fill="#f8fafc"
+              fill="var(--color-background)"
             />
           </svg>
         </div>

--- a/src/shared/ui/chart.jsx
+++ b/src/shared/ui/chart.jsx
@@ -23,7 +23,7 @@ const ChartContainer = React.forwardRef(({ id, className, children, config, ...p
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          'flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_*]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_*]:stroke-border [&_.recharts-sector]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none',
           className
         )}
         {...props}


### PR DESCRIPTION
### Motivation
- Remove hardcoded hex values and brittle CSS selectors in charts and homepage SVGs to ensure theme/dark-mode parity and make visuals respect the design system tokens. 
- Reduce UI drift across light/dark themes by centralizing colors into existing CSS variables while keeping runtime behavior unchanged.

### Description
- Replaced brittle chart utility selector and removed inline hex stroke selectors in `src/shared/ui/chart.jsx` so chart CSS relies on token-driven rules (improves selector resilience and token compatibility). 
- Swapped hardcoded color literals in `src/features/reports/components/PhaseBarChart.jsx` for CSS tokens and changed the `CartesianGrid` stroke to `var(--color-border)` so charts follow theme variables. 
- Aligned the Home hero wave SVG fill in `src/pages/Home.jsx` to use `var(--color-background)` instead of a literal `#f8fafc` to maintain consistent theme mapping. 
- Files touched: `src/shared/ui/chart.jsx`, `src/features/reports/components/PhaseBarChart.jsx`, `src/pages/Home.jsx`.

### Testing
- Started the local dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the app (server ready). 
- Ran a headless Playwright navigation that opened `http://127.0.0.1:4173` and captured a screenshot, which succeeded and produced `artifacts/home-page.png`. 
- No unit tests or linter runs were executed as part of this change; please run `npm run lint` and the project test suite in CI for full verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864886731c8327b5648ab76e96383d)