### PR TITLE
feat: implement inline task creation

### DIFF
--- a/src/features/projects/components/MilestoneSection.jsx
+++ b/src/features/projects/components/MilestoneSection.jsx
@@ -5,7 +5,7 @@ import { Progress } from '@shared/ui/progress';
 import { ChevronRight, Plus } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { TASK_STATUS } from '@app/constants/index';
-import TaskItem from '@features/tasks/components/TaskItem'; // UPDATED
+import TaskItem from '@features/tasks/components/TaskItem';
 
 export default function MilestoneSection({
   milestone,
@@ -14,6 +14,8 @@ export default function MilestoneSection({
   onAddTask,
   onAddChildTask,
   onTaskClick,
+  onInlineCommit,
+  onInlineCancel,
 }) {
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -90,6 +92,9 @@ export default function MilestoneSection({
                         onTaskClick={onTaskClick}
                         onStatusChange={(id, status) => onTaskUpdate(id, { status })}
                         onAddChildTask={onAddChildTask}
+                        isAddingInline={task.isAddingInline}
+                        onInlineCommit={onInlineCommit}
+                        onInlineCancel={onInlineCancel}
                       />
                     ))}
                   <Button

--- a/src/features/tasks/components/InlineTaskInput.jsx
+++ b/src/features/tasks/components/InlineTaskInput.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
+import { cn } from '@shared/lib/utils';
+import PropTypes from 'prop-types';
+
+/**
+ * Renders an inline input for creating a new task.
+ * Supports auto-focus, commit on Enter, cancel on Esc.
+ */
+const InlineTaskInput = ({
+    onCommit,
+    onCancel,
+    loading = false,
+    level = 0
+}) => {
+    const [title, setTitle] = useState('');
+    const inputRef = useRef(null);
+
+    // Auto-focus on mount
+    useEffect(() => {
+        if (inputRef.current) {
+            inputRef.current.focus();
+        }
+    }, []);
+
+    const handleKeyDown = (e) => {
+        if (loading) return;
+
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            if (title.trim()) {
+                onCommit(title.trim());
+                setTitle(''); // Optimistic clear, parent handles close
+            }
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            onCancel();
+        }
+    };
+
+    const handleBlur = (e) => {
+        // Optional: Auto-cancel on blur if empty, or just stay open?
+        // Let's auto-cancel if empty, otherwise keep it focused or commit.
+        // For now, let's just cancel if the user clicks away without typing anything.
+        if (!title.trim() && !loading) {
+            onCancel();
+        }
+    };
+
+    const indentWidth = (level + 1) * 20;
+
+    return (
+        <div
+            className="flex items-center gap-3 py-3 px-4 mb-2 rounded-xl border border-dashed border-brand-300 bg-brand-50/50 animate-in fade-in duration-200"
+            style={{ marginLeft: `${indentWidth}px` }}
+        >
+            <div className="w-4 h-4 rounded-full border-2 border-brand-200 flex-shrink-0" />
+            <input
+                ref={inputRef}
+                type="text"
+                className="flex-1 bg-transparent border-none p-0 text-sm font-medium focus:ring-0 placeholder:text-muted-foreground/70"
+                placeholder="Type a task name..."
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                disabled={loading}
+            />
+            {loading && <Loader2 className="w-3 H-3 animate-spin text-brand-500" />}
+            <span className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider hidden sm:block">
+                Enter to save • Esc to cancel
+            </span>
+        </div>
+    );
+};
+
+InlineTaskInput.propTypes = {
+    onCommit: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    loading: PropTypes.bool,
+    level: PropTypes.number,
+};
+
+export default InlineTaskInput;

--- a/src/features/tasks/components/TaskItem.jsx
+++ b/src/features/tasks/components/TaskItem.jsx
@@ -9,6 +9,8 @@ import ErrorBoundary from '@shared/ui/ErrorBoundary';
 import { Lock, Link as LinkIcon, GripVertical } from 'lucide-react';
 import TaskStatusSelect from './TaskStatusSelect';
 import TaskControlButtons from './TaskControlButtons';
+// [NEW] Inline Task Input
+import InlineTaskInput from './InlineTaskInput';
 
 const TaskItem = ({
   task,
@@ -25,6 +27,10 @@ const TaskItem = ({
   onDelete = null,
   hideExpansion = false,
   disableDrag = false,
+  // [NEW] Inline Props
+  isAddingInline = false,
+  onInlineCommit,
+  onInlineCancel,
 }) => {
   const hasChildren = task.children && task.children.length > 0;
   const indentWidth = level * 20;
@@ -48,7 +54,9 @@ const TaskItem = ({
     if (
       e.target.closest('.expand-button') ||
       e.target.closest('select') ||
-      e.target.closest('button')
+      e.target.closest('button') ||
+      // [NEW] Ignore clicks inside valid inputs to prevent closing/navigation
+      e.target.closest('input')
     ) {
       return;
     }
@@ -184,6 +192,17 @@ const TaskItem = ({
             strategy={verticalListSortingStrategy}
             id={`sortable-context-${task.id}`}
           >
+            {/* [NEW] Inline Input renders BEFORE children */}
+            {isAddingInline && (
+              <div className="ml-6 mb-2">
+                <InlineTaskInput
+                  onCommit={(title) => onInlineCommit(task.id, title)}
+                  onCancel={onInlineCancel}
+                  level={level + 1}
+                />
+              </div>
+            )}
+
             {task.children && task.children.length > 0 ? (
               task.children.map((child) => (
                 <SortableTaskItem
@@ -198,12 +217,19 @@ const TaskItem = ({
                   onToggleExpand={onToggleExpand}
                   onEdit={onEdit}
                   onDelete={onDelete}
+                  // Pass Props Down
+                  isAddingInline={child.isAddingInline}
+                  onInlineCommit={onInlineCommit}
+                  onInlineCancel={onInlineCancel}
                 />
               ))
             ) : (
-              <div className="py-2 px-4 text-xs text-slate-400 italic border-2 border-dashed border-slate-100 rounded-lg ml-6">
-                Drop subtasks here
-              </div>
+              // Only show "Drop here" if NOT adding inline and truly empty
+              !isAddingInline && (
+                <div className="py-2 px-4 text-xs text-slate-400 italic border-2 border-dashed border-slate-100 rounded-lg ml-6">
+                  Drop subtasks here
+                </div>
+              )
             )}
           </SortableContext>
         </div>

--- a/src/tests/integration/inline-task-creation.spec.jsx
+++ b/src/tests/integration/inline-task-creation.spec.jsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Project from '@pages/Project';
+import { useProjectData } from '@features/projects/hooks/useProjectData';
+import { useTaskSubscription } from '@features/tasks/hooks/useTaskSubscription';
+import { projectService } from '@features/projects/services/projectService';
+import { planter } from '@shared/api/planterClient';
+import { DndContext } from '@dnd-kit/core';
+
+// Mocks
+vi.mock('@features/projects/hooks/useProjectData');
+vi.mock('@features/tasks/hooks/useTaskSubscription');
+vi.mock('@features/projects/services/projectService');
+vi.mock('@shared/api/planterClient');
+
+// Mock child components to isolate Project.jsx logic
+vi.mock('@features/projects/components/ProjectHeader', () => ({
+    default: () => <div data-testid="project-header">Header</div>
+}));
+vi.mock('@features/projects/components/ProjectTabs', () => ({
+    default: ({ onTabChange }) => (
+        <div>
+            <button onClick={() => onTabChange('board')}>Board</button>
+        </div>
+    )
+}));
+vi.mock('@layouts/DashboardLayout', () => ({
+    default: ({ children }) => <div data-testid="dashboard-layout">{children}</div>
+}));
+
+// Mock Drag and drop to just render children
+vi.mock('@dnd-kit/core', async () => {
+    const actual = await vi.importActual('@dnd-kit/core');
+    return {
+        ...actual,
+        DndContext: ({ children }) => <div>{children}</div>,
+        DragOverlay: () => null,
+    };
+});
+
+// Mock MilestoneSection to verify props passed
+vi.mock('@features/projects/components/MilestoneSection', () => ({
+    default: ({ tasks, onAddChildTask }) => (
+        <div data-testid="milestone-section">
+            {tasks.map(t => (
+                <div key={t.id} data-testid={`task-${t.id}`}>
+                    {t.title}
+                    <button
+                        data-testid={`add-child-${t.id}`}
+                        onClick={() => onAddChildTask(t)}
+                    >
+                        +
+                    </button>
+                    {t.isAddingInline && (
+                        <input
+                            data-testid={`inline-input-${t.id}`}
+                            placeholder="New Task"
+                        />
+                    )}
+                </div>
+            ))}
+        </div>
+    )
+}));
+
+describe('Inline Task Creation', () => {
+    const mockTasks = [
+        { id: 't1', title: 'Task 1', parent_task_id: 'm1', position: 100 },
+    ];
+
+    // Setup generic mocks
+    beforeEach(() => {
+        useProjectData.mockReturnValue({
+            project: { id: 'p1', title: 'Test Project' },
+            loadingProject: false,
+            phases: [{ id: 'ph1', position: 1, title: 'Phase 1' }],
+            milestones: [{ id: 'm1', parent_task_id: 'ph1', position: 1, title: 'Milestone 1' }],
+            tasks: mockTasks,
+            teamMembers: [],
+        });
+        useTaskSubscription.mockImplementation(() => { });
+        planter.entities.Task.create.mockResolvedValue({ data: { id: 'new-task' }, error: null });
+    });
+
+    it('activates inline input when add child is triggered', async () => {
+        const queryClient = new QueryClient({
+            defaultOptions: { queries: { retry: false } }
+        });
+
+        const wrapper = ({ children }) => (
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={['/project/p1']}>
+                    <Routes>
+                        <Route path="/project/:projectId" element={children} />
+                    </Routes>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        render(<Project />, { wrapper });
+
+        // This test mostly verifies that the Project page *manages* the state correctly.
+        // Since we mocked MilestoneSection, we are testing the prop passing and state update.
+
+        // 1. Initial render - no inline input
+        expect(screen.queryByTestId('inline-input-t1')).not.toBeInTheDocument();
+
+        // 2. Click Add Child
+        fireEvent.click(screen.getByTestId('add-child-t1'));
+
+        // 3. We need to mock the re-render with the new state
+        // In a real integration test without full component mocks, the setExpandedTaskId would trigger a re-render.
+        // However, useProjectData returns a static list here. 
+        // The Project component maps tasks and adds 'isAddingInline' based on internal state.
+
+        // Wait for state update
+        await waitFor(() => {
+            // Note: Since we mocked MilestoneSection to read `t.isAddingInline`, success means Project.jsx
+            // correctly correctly mapped the tasks with that flag.
+            expect(screen.getByTestId('inline-input-t1')).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Implemented inline task creation for milestones and tasks.
This allows creating tasks quickly within the list view by pressing Enter.

## Changes
- `InlineTaskInput.jsx` component added.
- `TaskItem.jsx` logic for inline adding.
- `Project.jsx` state management for inline adds.
- `inline-task-creation.spec.jsx` integration test.

## Verification
- Run `npm test` against the new spec file.