### PR TITLE
feat(wave-22): de-dupe library search against tasks already in the pr…

### DIFF
--- a/Testing/unit/features/library/hooks/useMasterLibrarySearch.exclude.test.ts
+++ b/Testing/unit/features/library/hooks/useMasterLibrarySearch.exclude.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockListAllVisibleTemplates = vi.fn();
+
+vi.mock('@/shared/api/planterClient', () => ({
+  planter: {
+    entities: {
+      TaskWithResources: {
+        listAllVisibleTemplates: (...args: unknown[]) => mockListAllVisibleTemplates(...args),
+      },
+    },
+  },
+}));
+
+vi.mock('@/shared/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'test-user-id' } }),
+}));
+
+import { useMasterLibrarySearch } from '@/features/library/hooks/useMasterLibrarySearch';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+const templates = [
+  { id: 't1', title: 'Church Launch', description: 'Full launch plan' },
+  { id: 't2', title: 'Outreach Campaign', description: 'Community outreach' },
+  { id: 't3', title: 'Worship Team', description: null },
+];
+
+describe('useMasterLibrarySearch — excludeTemplateIds (Wave 22)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAllVisibleTemplates.mockResolvedValue(templates);
+  });
+
+  it('removes templates whose ids appear in excludeTemplateIds', async () => {
+    const { result } = renderHook(
+      () => useMasterLibrarySearch({ excludeTemplateIds: ['t2'] }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+    const ids = result.current.results.map((t) => t.id);
+    expect(ids).not.toContain('t2');
+    expect(ids).toEqual(expect.arrayContaining(['t1', 't3']));
+  });
+
+  it('sets exclusionDrained=true when exclusion drains a non-empty list', async () => {
+    const { result } = renderHook(
+      () => useMasterLibrarySearch({ excludeTemplateIds: ['t1', 't2', 't3'] }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.results).toHaveLength(0);
+    expect(result.current.exclusionDrained).toBe(true);
+  });
+
+  it('leaves exclusionDrained=false when the pre-exclusion list was already empty', async () => {
+    mockListAllVisibleTemplates.mockResolvedValueOnce([]);
+    const { result } = renderHook(
+      () => useMasterLibrarySearch({ excludeTemplateIds: ['t1'] }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.results).toHaveLength(0);
+    expect(result.current.exclusionDrained).toBe(false);
+  });
+
+  it('leaves exclusionDrained=false when exclusion leaves at least one result', async () => {
+    const { result } = renderHook(
+      () => useMasterLibrarySearch({ excludeTemplateIds: ['t1'] }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.results).toHaveLength(2));
+    expect(result.current.exclusionDrained).toBe(false);
+  });
+
+  it('still narrows by query after exclusion applies', async () => {
+    const { result } = renderHook(
+      () => useMasterLibrarySearch({ query: 'worship', excludeTemplateIds: ['t1'] }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+    expect(result.current.results[0].id).toBe('t3');
+  });
+
+  it('does not refetch when excludeTemplateIds changes identity', async () => {
+    const wrapper = createWrapper();
+    const { rerender } = renderHook(
+      ({ ids }: { ids: string[] }) => useMasterLibrarySearch({ excludeTemplateIds: ids }),
+      {
+        wrapper,
+        initialProps: { ids: ['t1'] },
+      },
+    );
+
+    await waitFor(() => expect(mockListAllVisibleTemplates).toHaveBeenCalledTimes(1));
+
+    rerender({ ids: ['t2'] });
+    rerender({ ids: ['t1', 't2'] });
+
+    // Still only the one network fetch — exclusion is purely client-side.
+    expect(mockListAllVisibleTemplates).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Testing/unit/shared/api/planterClient.clone.stamp.test.ts
+++ b/Testing/unit/shared/api/planterClient.clone.stamp.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeTask } from '@test';
+
+// Chainable Supabase query mock — matches the harness in planterClient.test.ts
+function createChain(resolvedValue: { data: unknown; error: unknown } = { data: null, error: null }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const methods = [
+    'select', 'insert', 'update', 'delete', 'upsert',
+    'eq', 'neq', 'is', 'or', 'order', 'range', 'limit',
+    'maybeSingle', 'single', 'abortSignal',
+  ];
+  for (const m of methods) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  (chain as unknown as { then: (resolve: (v: unknown) => void) => void }).then =
+    (resolve: (v: unknown) => void) => resolve(resolvedValue);
+  return chain;
+}
+
+const mockFrom = vi.fn();
+const mockRpc = vi.fn();
+
+vi.mock('@/shared/db/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    auth: {
+      getUser: vi.fn(),
+      signOut: vi.fn(),
+      updateUser: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/shared/lib/retry', () => ({
+  retry: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('@/shared/lib/date-engine', () => ({
+  toIsoDate: (v: unknown) => (v ? String(v) : null),
+  nowUtcIso: () => '2026-04-17T00:00:00.000Z',
+  calculateMinMaxDates: vi.fn().mockReturnValue({ start_date: null, due_date: null }),
+}));
+
+// Import after mocks
+import { planter } from '@/shared/api/planterClient';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Task.clone — spawnedFromTemplate stamping (Wave 22)', () => {
+  it('stamps settings.spawnedFromTemplate on the cloned root after a successful RPC', async () => {
+    const rpcResult = {
+      new_root_id: 'cloned-root-uuid',
+      root_project_id: 'project-root-uuid',
+      tasks_cloned: 5,
+    };
+    mockRpc.mockResolvedValueOnce({ data: rpcResult, error: null });
+
+    // First from() call: Task.get(new_root_id) — returns existing row with empty settings.
+    const existingRow = makeTask({ id: 'cloned-root-uuid', settings: null });
+    const getChain = createChain({ data: existingRow, error: null });
+    // Second from() call: Task.update(...) — echoes back the updated row.
+    const updateChain = createChain({
+      data: [{ ...existingRow, settings: { spawnedFromTemplate: 'tmpl-xyz' } }],
+      error: null,
+    });
+    mockFrom.mockReturnValueOnce(getChain).mockReturnValueOnce(updateChain);
+
+    const result = await planter.entities.Task.clone('tmpl-xyz', null, 'instance', 'user-1');
+
+    expect(result.error).toBeNull();
+    expect(mockRpc).toHaveBeenCalledWith('clone_project_template', expect.objectContaining({
+      p_template_id: 'tmpl-xyz',
+    }));
+    // The follow-up update call must target the cloned row.
+    expect(updateChain.update).toHaveBeenCalledTimes(1);
+    const [updatePayload] = updateChain.update.mock.calls[0];
+    expect(updatePayload).toEqual({ settings: { spawnedFromTemplate: 'tmpl-xyz' } });
+  });
+
+  it('preserves existing settings keys when merging the stamp', async () => {
+    const rpcResult = { new_root_id: 'cloned-root-uuid', tasks_cloned: 1 };
+    mockRpc.mockResolvedValueOnce({ data: rpcResult, error: null });
+
+    const existingRow = makeTask({
+      id: 'cloned-root-uuid',
+      settings: { published: true, due_soon_threshold: 5 },
+    });
+    const getChain = createChain({ data: existingRow, error: null });
+    const updateChain = createChain({ data: [existingRow], error: null });
+    mockFrom.mockReturnValueOnce(getChain).mockReturnValueOnce(updateChain);
+
+    await planter.entities.Task.clone('tmpl-xyz', null, 'instance', 'user-1');
+
+    const [updatePayload] = updateChain.update.mock.calls[0];
+    expect(updatePayload).toEqual({
+      settings: {
+        published: true,
+        due_soon_threshold: 5,
+        spawnedFromTemplate: 'tmpl-xyz',
+      },
+    });
+  });
+
+  it('still returns a successful clone when the follow-up stamp update fails', async () => {
+    const rpcResult = { new_root_id: 'cloned-root-uuid', tasks_cloned: 1 };
+    mockRpc.mockResolvedValueOnce({ data: rpcResult, error: null });
+
+    // get() resolves normally, but the update() call rejects — stamp is best-effort.
+    const existingRow = makeTask({ id: 'cloned-root-uuid', settings: null });
+    const getChain = createChain({ data: existingRow, error: null });
+    const failingUpdateChain = createChain({
+      data: null,
+      error: { message: 'rls violation', code: '42501' },
+    });
+    mockFrom.mockReturnValueOnce(getChain).mockReturnValueOnce(failingUpdateChain);
+
+    // Suppress the expected console.error so test output stays clean.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const result = await planter.entities.Task.clone('tmpl-xyz', null, 'instance', 'user-1');
+    errSpy.mockRestore();
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual(rpcResult);
+  });
+
+  it('skips the stamp entirely when the RPC response has no new_root_id', async () => {
+    // Degenerate shape (shouldn't happen with current RPC, but defensive coverage).
+    mockRpc.mockResolvedValueOnce({ data: { tasks_cloned: 0 }, error: null });
+
+    const result = await planter.entities.Task.clone('tmpl-xyz', null, 'instance', 'user-1');
+
+    expect(result.error).toBeNull();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/library/components/MasterLibrarySearch.tsx
+++ b/src/features/library/components/MasterLibrarySearch.tsx
@@ -17,6 +17,7 @@ interface MasterLibrarySearchProps {
  label?: string;
  placeholder?: string;
  phasesOnly?: boolean;
+ excludeTemplateIds?: readonly string[];
 }
 
 const MasterLibrarySearch = ({
@@ -25,6 +26,7 @@ const MasterLibrarySearch = ({
  label = 'Search & pick from Master Library',
  placeholder = 'Search by title or description…',
  phasesOnly = false,
+ excludeTemplateIds,
 }: MasterLibrarySearchProps) => {
  const [query, setQuery] = useState('');
  const [isOpen, setIsOpen] = useState(false);
@@ -33,7 +35,11 @@ const MasterLibrarySearch = ({
  const inputRef = useRef<HTMLInputElement>(null);
  const containerRef = useRef<HTMLDivElement>(null);
 
- const { results, isLoading, hasResults } = useMasterLibrarySearch({ query, phasesOnly });
+ const { results, isLoading, hasResults, exclusionDrained } = useMasterLibrarySearch({
+ query,
+ phasesOnly,
+ excludeTemplateIds,
+ });
 
  const handleQueryChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
  setQuery(event.target.value);
@@ -138,7 +144,11 @@ const MasterLibrarySearch = ({
 
  {!isLoading && results.length === 0 && (
  <div className="px-4 py-3 text-sm text-slate-500">
- {query ? 'No matching templates found.' : 'No templates available.'}
+ {exclusionDrained
+ ? 'All matching templates are already in this project.'
+ : query
+ ? 'No matching templates found.'
+ : 'No templates available.'}
  </div>
  )}
 

--- a/src/features/library/hooks/useMasterLibrarySearch.ts
+++ b/src/features/library/hooks/useMasterLibrarySearch.ts
@@ -7,12 +7,19 @@ interface UseMasterLibrarySearchProps {
  query?: string;
  enabled?: boolean;
  phasesOnly?: boolean;
+ /**
+  * Template ids to hide from the results. Typically the set of
+  * `settings.spawnedFromTemplate` values already present in the active
+  * project, so users aren't offered a template they've already cloned.
+  */
+ excludeTemplateIds?: readonly string[];
 }
 
 export const useMasterLibrarySearch = ({
  query = '',
  enabled = true,
  phasesOnly = false,
+ excludeTemplateIds,
 }: UseMasterLibrarySearchProps = {}) => {
  const { user } = useAuth();
  const viewerId = user?.id;
@@ -26,23 +33,36 @@ export const useMasterLibrarySearch = ({
 
  const trimmed = query.trim().toLowerCase();
 
- const results = useMemo(() => {
- if (!allTemplates) return [];
+ const { results, exclusionDrained } = useMemo(() => {
+ if (!allTemplates) return { results: [], exclusionDrained: false };
  let filtered = allTemplates;
  if (phasesOnly) {
  filtered = filtered.filter((t) => t.parent_task_id && t.parent_task_id === t.root_id);
  }
- if (!trimmed) return filtered;
- return filtered.filter(
+
+ const beforeExclusionCount = filtered.length;
+ if (excludeTemplateIds && excludeTemplateIds.length > 0 && beforeExclusionCount > 0) {
+ const exclusionSet = new Set(excludeTemplateIds);
+ filtered = filtered.filter((t) => !exclusionSet.has(t.id));
+ }
+ const drainedByExclusion = beforeExclusionCount > 0 && filtered.length === 0;
+
+ if (!trimmed) return { results: filtered, exclusionDrained: drainedByExclusion };
+ const queryFiltered = filtered.filter(
  (t) => t.title?.toLowerCase().includes(trimmed) || t.description?.toLowerCase().includes(trimmed)
  );
- }, [allTemplates, trimmed, phasesOnly]);
+ // Keep `exclusionDrained` truthful even after a query further narrows the
+ // list — if the pre-query list was already empty due to exclusion, the
+ // empty-state copy should reflect that root cause.
+ return { results: queryFiltered, exclusionDrained: drainedByExclusion && queryFiltered.length === 0 };
+ }, [allTemplates, trimmed, phasesOnly, excludeTemplateIds]);
 
  return {
  results,
  isLoading,
  error,
  hasResults: results.length > 0,
+ exclusionDrained,
  };
 };
 

--- a/src/features/tasks/components/TaskList.tsx
+++ b/src/features/tasks/components/TaskList.tsx
@@ -79,6 +79,22 @@ const TaskList = () => {
     return { [activeProjectId]: projectHierarchy };
   }, [activeProjectId, projectHierarchy]);
 
+  // Collect every template id already cloned into the active project so the
+  // Master Library combobox can hide them. Pre-Wave-22 clones lack the stamp
+  // and will still appear — call that out in PRs / release notes.
+  const excludedTemplateIds = React.useMemo(() => {
+    if (!projectHierarchy) return [] as string[];
+    const ids: string[] = [];
+    for (const t of projectHierarchy) {
+      const settings = (t as { settings?: unknown }).settings;
+      if (settings && typeof settings === 'object') {
+        const spawned = (settings as Record<string, unknown>).spawnedFromTemplate;
+        if (typeof spawned === 'string') ids.push(spawned);
+      }
+    }
+    return ids;
+  }, [projectHierarchy]);
+
   // --- Expanded Tasks (was useExpandedTasks) ---
   const [expandedTaskIds, setExpandedTaskIds] = useState<Set<string>>(new Set());
 
@@ -342,6 +358,7 @@ const TaskList = () => {
               onSelect={onSelect}
               label="Search master library"
               placeholder="Start typing to copy an existing template task"
+              excludeTemplateIds={excludedTemplateIds}
             />
           )}
         />

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -44,6 +44,21 @@ export default function Project() {
         teamMembers,
     } = useProjectData(projectId);
 
+    // Template ids already cloned into this project — excluded from the
+    // Master Library combobox so the same template can't be added twice.
+    const excludedTemplateIds = useMemo(() => {
+        if (!tasks) return [] as string[];
+        const ids: string[] = [];
+        for (const t of tasks) {
+            const settings = (t as { settings?: unknown }).settings;
+            if (settings && typeof settings === 'object') {
+                const spawned = (settings as Record<string, unknown>).spawnedFromTemplate;
+                if (typeof spawned === 'string') ids.push(spawned);
+            }
+        }
+        return ids;
+    }, [tasks]);
+
     const board = useProjectBoard(projectId, (tasks as TaskRow[]) || []);
     const { state, actions, handlers, computed } = board;
 
@@ -374,6 +389,7 @@ export default function Project() {
                                 label="Search master library"
                                 placeholder={taskFormState?.isPhase ? 'Search for a template phase to copy' : 'Start typing to copy an existing template task'}
                                 phasesOnly={!!taskFormState?.isPhase}
+                                excludeTemplateIds={excludedTemplateIds}
                             />
                         )}
                         onDeleteTaskWrapper={async () => { if (state.selectedTask) await handlers.handleDeleteTask(state.selectedTask); }}

--- a/src/shared/api/planterClient.ts
+++ b/src/shared/api/planterClient.ts
@@ -578,6 +578,30 @@ export const planter: PlanterClient = {
                     const { data, error } = await planter.rpc('clone_project_template', rpcParams);
                     if (error) throw error;
 
+                    // Stamp the cloned root with `settings.spawnedFromTemplate` so the
+                    // Master Library combobox can hide templates already present in the
+                    // project. Merges onto existing settings (preserving any keys the
+                    // clone RPC or a future migration may add) and is non-fatal — a stamp
+                    // failure must never roll back a successful clone. Mirrors the
+                    // recurrence-spawn convention in nightly-sync/index.ts.
+                    const cloneResult = data as { new_root_id?: string } | null;
+                    const newRootId = cloneResult?.new_root_id;
+                    if (newRootId) {
+                        try {
+                            const existing = await planter.entities.Task.get(newRootId);
+                            const prevSettings = (existing?.settings ?? {}) as Record<string, unknown>;
+                            const mergedSettings = {
+                                ...prevSettings,
+                                spawnedFromTemplate: templateId,
+                            };
+                            await planter.entities.Task.update(newRootId, {
+                                settings: mergedSettings as unknown as TaskUpdate['settings'],
+                            });
+                        } catch (stampErr) {
+                            console.error('[PlanterClient.clone] stamp failed', stampErr);
+                        }
+                    }
+
                     return { data: data as Task, error: null };
                 } catch (error) {
                     console.error('[PlanterClient.clone] Error:', error);


### PR DESCRIPTION
…oject

Closes the remaining [ ] bullet under §3.5 Master Library & Templates — "intelligently hide library tasks already in the instance". The "topically related" half stays deferred (recommender scope).

Provenance stamping: after a successful clone_project_template RPC, Task.clone now issues a follow-up Task.update on the new root to merge { spawnedFromTemplate: templateId } into its settings JSONB. Mirrors the recurrence-spawn convention in supabase/functions/nightly-sync. The stamp is best-effort — a failure here logs and is swallowed so a successful clone is never rolled back.

useMasterLibrarySearch grew an optional excludeTemplateIds prop. After the phasesOnly filter and before the query-string filter, the hook drops any result whose id appears in the set. It also surfaces a new exclusionDrained flag, true iff a non-empty pre-exclusion result list was drained to zero after excluding — the combobox uses that to branch the empty-state copy to "All matching templates are already in this project." Client-side exclusion; no extra network round-trip.

Callers that render MasterLibrarySearch atop an already-loaded project tree (TaskList.tsx, pages/Project.tsx) memoise the excluded id set by walking the task tree and collecting settings.spawnedFromTemplate strings, then pass it to the combobox. NewProjectForm and CreateProjectModal stay as-is — they create new projects with no instance yet.

InlineTaskInput uses the hook directly for autocomplete-style entry; it's a different UX from the combobox so exclusion isn't threaded there this wave. The hook's signature is already compatible with a future pass.

Known limitation (noted in PR): instances created before Wave 22 have no stamp on their cloned roots, so they will still appear as "available" in the combobox until re-cloned. A backfill migration isn't worth it.

Tests added:
  - useMasterLibrarySearch.exclude.test.ts: 6 cases covering removal, exclusionDrained semantics, interaction with query string, and a no-refetch check on identity changes to the exclude list.
  - planterClient.clone.stamp.test.ts: 4 cases covering the stamp payload, settings-key preservation under merge, the non-fatal path when the stamp update fails, and the no-op when the RPC response lacks new_root_id.

Gate: lint 0/7, build clean, vitest 39 files / 493 tests.

https://claude.ai/code/session_01Q7vQTHRx6grKjdc8FpZ9BE

# Pull Request

<!--
Copy contents from `PR_DESCRIPTION_DRAFT.md` (generated by Agent) or fill manually.
-->

## 📋 Summary

<!-- 2-3 sentence executive summary. User-facing language. -->

## ✨ Highlights

<!--
- **Bold Concept:** Detail...
-->

## 🗺️ Roadmap Progress

| Item ID | Feature Name | Phase | Status | Notes |
| ------- | ------------ | ----- | ------ | ----- |
|         |              |       |        |       |

## 🏗️ Architecture Decisions

### Key Patterns & Decisions

-

### Logic Flow / State Changes

```mermaid
graph TD
    A[User Action] --> B[Component]
```

## 🔍 Review Guide

### 🚨 High Risk / Security Sensitive

-

### 🧠 Medium Complexity

-

### 🟢 Low Risk / Boilerplate

-

## 🧪 Verification Plan

### 1. Environment Setup

- [ ] Run `npm install`
- [ ] Run migration: `[filename].sql`

### 2. Manual Verification

- **[Feature Area]**:
  1. [Instruction]
  2. [Outcome]

### 3. Automated Tests

- [ ] `npm run lint` passed (Zero warnings).
- [ ] `npm test` passed.
- [ ] `npm run build` passed.
