### PR TITLE
chore(wave-23): rename check_project_ownership → check_project_creato…

### DIFF
--- a/docs/architecture/auth-rbac.md
+++ b/docs/architecture/auth-rbac.md
@@ -32,6 +32,33 @@ The Auth & RBAC system manages application-level authentication, user account li
 | **Invite / Manage Users** | Yes | No | No | No |
 | **Edit project settings** | Yes | No | No | No |
 
+### Creatorship vs. Ownership (Wave 23 audit)
+
+Historically `public.check_project_ownership(pid, uid)` has been used as the
+"is this user allowed to act on a project"-gate in RLS policies on
+`public.project_members`. The function actually checks `tasks.creator =
+uid` — i.e. whether the user was the original *creator* — **not** whether
+they currently hold the `owner` role in `project_members`. A user who
+creates a project and is later removed still passes the check.
+
+Wave 23 splits the two concepts at the name level only (no behavior
+change): a new `public.check_project_creatorship(pid, uid)` holds the
+original body; the legacy `check_project_ownership` becomes a thin SQL
+shim delegating to the new name so existing policies keep working
+unchanged. Each of the four callsites on `public.project_members` now
+carries an inline intent comment (see `docs/db/schema.sql`).
+
+| Policy | Op | Inferred intent | Follow-up action |
+| --- | --- | --- | --- |
+| `members_delete_policy` | DELETE | **Ownership** — creator branch is a convenient bypass, not documented intent. | Replace `check_project_ownership` with a genuine `role = 'owner'` helper. |
+| `members_insert_policy` | INSERT | **Creatorship (bootstrap)** — the project creator must self-insert as the initial `owner` row before any `owner`-role rows exist. | Migrate to `check_project_creatorship` directly. |
+| `members_select_policy` | SELECT | **Redundant** — `is_active_member` OR the `user_id` self-check already covers every legitimate read. The creatorship branch only fires for removed creators — the exact leak called out in dev-notes. | Delete the creatorship clause. |
+| `members_update_policy` | UPDATE | **Ownership** — same rationale as delete. | Replace with the real `role = 'owner'` helper. |
+
+The rewrite + shim removal belong to a follow-up wave once each row's
+intent is confirmed with the domain owner. The shim is scoped to one
+release of runway.
+
 ## Integration Points
 * **Supabase Client:** Handles session persistence and edge-function authentication tokens.
 * **Team Management:** Feeds contextual role data into the UI (e.g., `RoleIndicator.tsx`) to conditionally render administrative components.

--- a/docs/db/migrations/2026_04_17_rename_project_creatorship.sql
+++ b/docs/db/migrations/2026_04_17_rename_project_creatorship.sql
@@ -1,0 +1,67 @@
+-- Migration: Wave 23 — Rename check_project_ownership → check_project_creatorship
+-- Date: 2026-04-17
+-- Description:
+--   The existing `public.check_project_ownership(p_id, u_id)` function is
+--   misleadingly named: it actually checks `tasks.creator = u_id`, not the
+--   `owner` role on `project_members`. Every RLS policy that references it on
+--   `public.project_members` is making a decision that does not match the
+--   function's name, so the name has been a latent auth footgun since Wave 1.
+--
+--   This migration is **audit-only** — no behavior change:
+--     1. Introduces `public.check_project_creatorship(p_id, u_id)` with the
+--        exact body of today's `check_project_ownership`.
+--     2. Converts `public.check_project_ownership` to a thin SQL shim that
+--        delegates to the new function. The four existing RLS policies on
+--        `project_members` continue calling the shim unchanged, so runtime
+--        semantics are byte-for-byte identical.
+--
+--   The per-callsite intent audit (creatorship vs. ownership) is captured in
+--   docs/architecture/auth-rbac.md and as inline comments in docs/db/schema.sql.
+--   A follow-up wave will rewrite each policy to the correct helper and, once
+--   that lands, drop the shim.
+--
+--   Revert path:
+--     Restore the previous plpgsql body of public.check_project_ownership from
+--     git history (see commit prior to this migration) and
+--     `DROP FUNCTION IF EXISTS public.check_project_creatorship(uuid, uuid);`.
+
+-- 1. New, correctly-named implementation ------------------------------------
+
+CREATE OR REPLACE FUNCTION public.check_project_creatorship(p_id uuid, u_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.tasks
+    WHERE id = p_id
+      AND creator = u_id
+  );
+END;
+$$;
+
+ALTER FUNCTION public.check_project_creatorship(uuid, uuid) OWNER TO postgres;
+
+-- 2. Backwards-compatibility shim ------------------------------------------
+--
+-- Keeps the old name resolvable by existing RLS policies and any yet-undiscovered
+-- external caller. Drop once every callsite has migrated to the new name in a
+-- follow-up wave.
+
+CREATE OR REPLACE FUNCTION public.check_project_ownership(p_id uuid, u_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+  SELECT public.check_project_creatorship(p_id, u_id);
+$$;
+
+ALTER FUNCTION public.check_project_ownership(uuid, uuid) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.check_project_ownership(uuid, uuid) IS
+  'Deprecated shim (Wave 23). Delegates to public.check_project_creatorship. Kept one release for the RLS policy audit; drop once every callsite migrates.';

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -178,11 +178,15 @@ $$;
 ALTER FUNCTION "public"."check_phase_unlock"() OWNER TO "postgres";
 
 
-CREATE OR REPLACE FUNCTION "public"."check_project_ownership"("p_id" "uuid", "u_id" "uuid") RETURNS boolean
+CREATE OR REPLACE FUNCTION "public"."check_project_creatorship"("p_id" "uuid", "u_id" "uuid") RETURNS boolean
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''
     AS $$
 BEGIN
+  -- Wave 23: correctly-named replacement for `check_project_ownership`.
+  -- Checks whether `u_id` CREATED the project (tasks.creator), not whether
+  -- they are an `owner`-role member in project_members.
+  -- See docs/db/migrations/2026_04_17_rename_project_creatorship.sql.
   RETURN EXISTS (
     SELECT 1
     FROM public.tasks
@@ -193,7 +197,28 @@ END;
 $$;
 
 
+ALTER FUNCTION "public"."check_project_creatorship"("p_id" "uuid", "u_id" "uuid") OWNER TO "postgres";
+
+
+-- Wave 23: `check_project_ownership` was misleadingly named — it actually
+-- checks `tasks.creator`, not the `owner` role. Kept here as a thin shim for
+-- one release so the four RLS policies below continue to work byte-for-byte
+-- identically while the per-callsite intent audit (see comments on each
+-- policy) is completed. Drop in a follow-up wave once every caller migrates
+-- to either `check_project_creatorship` or a genuine ownership helper.
+CREATE OR REPLACE FUNCTION "public"."check_project_ownership"("p_id" "uuid", "u_id" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+  SELECT public.check_project_creatorship(p_id, u_id);
+$$;
+
+
 ALTER FUNCTION "public"."check_project_ownership"("p_id" "uuid", "u_id" "uuid") OWNER TO "postgres";
+
+
+COMMENT ON FUNCTION "public"."check_project_ownership"("p_id" "uuid", "u_id" "uuid") IS
+  'Deprecated shim (Wave 23). Delegates to public.check_project_creatorship. Kept one release for the RLS policy audit; drop once every callsite migrates.';
 
 
 CREATE OR REPLACE FUNCTION "public"."clone_project_template"("p_template_id" "uuid", "p_new_parent_id" "uuid", "p_new_origin" "text", "p_user_id" "uuid") RETURNS "jsonb"
@@ -1733,22 +1758,40 @@ CREATE POLICY "View resources" ON "public"."task_resources" FOR SELECT USING (((
 ALTER TABLE "public"."admin_users" ENABLE ROW LEVEL SECURITY;
 
 
+-- Wave 23 audit (intent: OWNERSHIP). Allowing the row's creator to delete
+-- any project_members row is a convenient bypass, not the documented intent.
+-- The OR (project_id IN ... role = 'owner') clause is the right gate; a
+-- follow-up wave should replace `check_project_ownership` here with a helper
+-- that queries `project_members.role = 'owner'`.
 CREATE POLICY "members_delete_policy" ON "public"."project_members" FOR DELETE USING ((("user_id" = (SELECT (auth.jwt() ->> 'sub')::uuid)) OR "public"."check_project_ownership"("project_id", (SELECT (auth.jwt() ->> 'sub')::uuid)) OR ("project_id" IN ( SELECT "project_members_1"."project_id"
    FROM "public"."project_members" "project_members_1"
   WHERE (("project_members_1"."user_id" = (SELECT (auth.jwt() ->> 'sub')::uuid)) AND ("project_members_1"."role" = 'owner'::"text"))))));
 
 
 
+-- Wave 23 audit (intent: CREATORSHIP — bootstrap). The project creator
+-- needs to self-insert as the initial `owner` row in project_members before
+-- any `owner`-role rows exist, so the creator check is genuinely required
+-- here. Safe to migrate to `check_project_creatorship` directly.
 CREATE POLICY "members_insert_policy" ON "public"."project_members" FOR INSERT WITH CHECK (("public"."check_project_ownership"("project_id", (SELECT (auth.jwt() ->> 'sub')::uuid)) OR ("project_id" IN ( SELECT "project_members_1"."project_id"
    FROM "public"."project_members" "project_members_1"
   WHERE (("project_members_1"."user_id" = (SELECT (auth.jwt() ->> 'sub')::uuid)) AND ("project_members_1"."role" = 'owner'::"text"))))));
 
 
 
+-- Wave 23 audit (intent: REDUNDANT — safe to drop). `is_active_member` OR
+-- the user_id self-check already covers every legitimate read. The
+-- creatorship branch only fires for a creator who has been removed from
+-- project_members — the exact "removed-user still sees rows" leak called
+-- out in dev-notes. A follow-up wave should delete the clause entirely.
 CREATE POLICY "members_select_policy" ON "public"."project_members" FOR SELECT USING ((("user_id" = (SELECT (auth.jwt() ->> 'sub')::uuid)) OR "public"."is_active_member"("project_id", (SELECT (auth.jwt() ->> 'sub')::uuid)) OR "public"."check_project_ownership"("project_id", (SELECT (auth.jwt() ->> 'sub')::uuid))));
 
 
 
+-- Wave 23 audit (intent: OWNERSHIP). Same rationale as members_delete_policy
+-- — the creator-based bypass is a latent leak; the `role = 'owner'` branch
+-- is the documented intent. Migrate to a real ownership helper in a
+-- follow-up wave.
 CREATE POLICY "members_update_policy" ON "public"."project_members" FOR UPDATE USING (("public"."check_project_ownership"("project_id", (SELECT (auth.jwt() ->> 'sub')::uuid)) OR ("project_id" IN ( SELECT "project_members_1"."project_id"
    FROM "public"."project_members" "project_members_1"
   WHERE (("project_members_1"."user_id" = (SELECT (auth.jwt() ->> 'sub')::uuid)) AND ("project_members_1"."role" = 'owner'::"text")))))) WITH CHECK ((("user_id" <> (SELECT (auth.jwt() ->> 'sub')::uuid)) OR ("role" <> 'viewer'::"text")));
@@ -1951,6 +1994,8 @@ GRANT USAGE ON SCHEMA "public" TO "service_role";
 
 
 
+REVOKE ALL ON FUNCTION "public"."check_project_creatorship"("p_id" "uuid", "u_id" "uuid") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."check_project_creatorship"("p_id" "uuid", "u_id" "uuid") TO "authenticated";
 REVOKE ALL ON FUNCTION "public"."check_project_ownership"("p_id" "uuid", "u_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."check_project_ownership"("p_id" "uuid", "u_id" "uuid") TO "authenticated";
 

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -29,6 +29,6 @@ If these two fields get out of sync (e.g., `status` is set to `'completed'` but 
 
 ### `check_project_ownership` is a latent auth bug
 
-The `check_project_ownership(pid, uid)` function checks `tasks.creator = uid`, **not** the `owner` role in `project_members`. This means if someone creates a project and later gets removed as a member, they still pass this check. The `project_members` RLS policies that use this function could grant access to removed users.
+**Renamed + audited (Wave 23).** `public.check_project_creatorship(pid, uid)` now holds the original body; `public.check_project_ownership` is a thin SQL shim delegating to the new name so the four RLS policies on `public.project_members` continue evaluating byte-for-byte identically. Each callsite has an inline intent comment in `docs/db/schema.sql`, and `docs/architecture/auth-rbac.md` carries the full per-policy audit table. Migration: `docs/db/migrations/2026_04_17_rename_project_creatorship.sql`.
 
-Fix: rewrite `check_project_ownership` to check `project_members.role = 'owner'` instead of `tasks.creator`, or rename it to `check_project_creatorship` to avoid confusion and audit all call sites.
+**Behavior-change still deferred.** The leak (a removed creator still passing the check) is not closed yet — this wave was audit-only. A follow-up wave will rewrite each policy to either `check_project_creatorship` (bootstrap-only) or a genuine ownership helper that queries `project_members.role = 'owner'`, then drop the shim.

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # PlanterPlan — Project Specification
 
-> **Version**: 1.9.0 (Wave 22 — Supervisor Dispatch, Library Dedupe & Coaching Tags) 
+> **Version**: 1.9.1 (Wave 23 — Coach Auto-Assign, Creatorship Audit, Completion-Flag Trigger) 
 > **Last Updated**: 2026-04-17 
 > **Status**: Active Development
 


### PR DESCRIPTION
…rship + audit callers

Audit-only — no behavior change. The legacy
`public.check_project_ownership(pid, uid)` was misleadingly named: it checks `tasks.creator = uid`, not the `owner` role in `project_members`. A user who creates a project and is later removed still passes the check, which is the latent auth bug called out in docs/dev-notes.md.

This wave splits the two concepts at the name level:

- Adds `public.check_project_creatorship(pid, uid)` carrying the exact original body.
- Rewrites `public.check_project_ownership` to a thin SQL shim delegating to the new name so the four RLS policies on `public.project_members` continue evaluating byte-for-byte identically.
- Per-callsite intent audit captured inline in docs/db/schema.sql and in a new "Creatorship vs. Ownership (Wave 23 audit)" table in docs/architecture/auth-rbac.md.

Rewriting each policy to the correct helper and dropping the shim is a follow-up wave's job.

Files:
- docs/db/migrations/2026_04_17_rename_project_creatorship.sql (new)
- docs/db/schema.sql — mirror both functions + inline audit comments on the four project_members policies + GRANTs for the new function
- docs/architecture/auth-rbac.md — new audit sub-section with per-policy intent table
- docs/dev-notes.md — flip to "Renamed + audited (Wave 23)"; keeps the "behavior-change still deferred" note
- spec.md — bump to 1.9.1

https://claude.ai/code/session_013BwAN1PaeffWVe6EXcGWKk

# Pull Request

<!--
Copy contents from `PR_DESCRIPTION_DRAFT.md` (generated by Agent) or fill manually.
-->

## 📋 Summary

<!-- 2-3 sentence executive summary. User-facing language. -->

## ✨ Highlights

<!--
- **Bold Concept:** Detail...
-->

## 🗺️ Roadmap Progress

| Item ID | Feature Name | Phase | Status | Notes |
| ------- | ------------ | ----- | ------ | ----- |
|         |              |       |        |       |

## 🏗️ Architecture Decisions

### Key Patterns & Decisions

-

### Logic Flow / State Changes

```mermaid
graph TD
    A[User Action] --> B[Component]
```

## 🔍 Review Guide

### 🚨 High Risk / Security Sensitive

-

### 🧠 Medium Complexity

-

### 🟢 Low Risk / Boilerplate

-

## 🧪 Verification Plan

### 1. Environment Setup

- [ ] Run `npm install`
- [ ] Run migration: `[filename].sql`

### 2. Manual Verification

- **[Feature Area]**:
  1. [Instruction]
  2. [Outcome]

### 3. Automated Tests

- [ ] `npm run lint` passed (Zero warnings).
- [ ] `npm test` passed.
- [ ] `npm run build` passed.
