### PR TITLE
fix(wave-23): derive is_complete from status via trigger to prevent d…

### DIFF
--- a/Testing/unit/shared/api/planterClient.updateStatus.syncflags.test.ts
+++ b/Testing/unit/shared/api/planterClient.updateStatus.syncflags.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeTask } from '@test';
+
+// ---------------------------------------------------------------------------
+// Supabase mock — chainable query builder (mirrors planterClient.test.ts)
+// ---------------------------------------------------------------------------
+
+function createChain(resolvedValue: { data: unknown; error: unknown } = { data: null, error: null }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const methods = [
+    'select', 'insert', 'update', 'delete', 'upsert',
+    'eq', 'neq', 'is', 'or', 'order', 'range', 'limit',
+    'maybeSingle', 'single', 'abortSignal',
+  ];
+  for (const m of methods) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+  (chain as unknown as { then: (resolve: (v: unknown) => void) => void }).then =
+    (resolve: (v: unknown) => void) => resolve(resolvedValue);
+  return chain;
+}
+
+const mockFrom = vi.fn();
+const mockRpc = vi.fn();
+
+vi.mock('@/shared/db/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    auth: {
+      getUser: vi.fn(),
+      signOut: vi.fn(),
+      updateUser: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/shared/lib/retry', () => ({
+  retry: (fn: () => unknown) => fn(),
+}));
+
+vi.mock('@/shared/lib/date-engine', () => ({
+  toIsoDate: (v: unknown) => (v ? String(v) : null),
+  nowUtcIso: () => '2026-04-17T00:00:00.000Z',
+  calculateMinMaxDates: vi.fn().mockReturnValue({ start_date: null, due_date: null }),
+}));
+
+import { planter } from '@/shared/api/planterClient';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Wave 23 Task 3: Task.updateStatus must send only `status` to the server.
+// The `sync_task_completion_flags` BEFORE trigger derives `is_complete` at the
+// DB layer; the client no longer needs (and should not) mirror that.
+// ---------------------------------------------------------------------------
+
+describe('Task.updateStatus — server payload trim (Wave 23 Task 3)', () => {
+  it('sends only `status` (no is_complete) when moving a leaf task to completed', async () => {
+    const task = makeTask({ id: 't1', parent_task_id: null });
+    // Call 1: the root update. Call 2: Task.filter for descendants (empty → no recursion).
+    const updateChain = createChain({ data: [task], error: null });
+    const filterChain = createChain({ data: [], error: null });
+    mockFrom
+      .mockReturnValueOnce(updateChain)
+      .mockReturnValueOnce(filterChain);
+
+    await planter.entities.Task.updateStatus('t1', 'completed');
+
+    expect(mockFrom).toHaveBeenCalledWith('tasks');
+    expect(updateChain.update).toHaveBeenCalledTimes(1);
+    const payload = updateChain.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toEqual({ status: 'completed' });
+    expect(payload).not.toHaveProperty('is_complete');
+  });
+
+  it('sends only `status` when moving a task to a non-completed state', async () => {
+    const task = makeTask({ id: 't2', parent_task_id: null });
+    const updateChain = createChain({ data: [task], error: null });
+    mockFrom.mockReturnValueOnce(updateChain);
+
+    await planter.entities.Task.updateStatus('t2', 'in_progress');
+
+    expect(updateChain.update).toHaveBeenCalledTimes(1);
+    const payload = updateChain.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toEqual({ status: 'in_progress' });
+    expect(payload).not.toHaveProperty('is_complete');
+  });
+
+  it('reconcileAncestors parent patch also omits is_complete', async () => {
+    // Layout: child 't-child' with parent 't-parent'. Flipping child → completed
+    // triggers reconcileAncestors; parent becomes the single sibling and should
+    // be marked complete — but the server payload must carry only `status` and
+    // `updated_at`, no `is_complete`.
+    const child = makeTask({ id: 't-child', parent_task_id: 't-parent', status: 'completed' });
+    const parent = makeTask({ id: 't-parent', parent_task_id: null });
+
+    const updateChildChain = createChain({ data: [{ ...child, parent_task_id: 't-parent' }], error: null });
+    const filterChildrenOfChild = createChain({ data: [], error: null });       // descendants of child
+    const filterChildrenOfParent = createChain({ data: [child], error: null }); // children of parent (for reconcile)
+    const updateParentChain = createChain({ data: [parent], error: null });     // parent patch
+    const filterChildrenOfGrandparent = createChain({ data: [], error: null }); // no grandparent filter expected
+
+    mockFrom
+      .mockReturnValueOnce(updateChildChain)          // child update
+      .mockReturnValueOnce(filterChildrenOfChild)     // cascade-down: child has no descendants
+      .mockReturnValueOnce(filterChildrenOfParent)    // reconcileAncestors children lookup
+      .mockReturnValueOnce(updateParentChain)         // parent update
+      .mockReturnValue(filterChildrenOfGrandparent);  // anything further
+
+    await planter.entities.Task.updateStatus('t-child', 'completed');
+
+    expect(updateParentChain.update).toHaveBeenCalled();
+    const parentPayload = updateParentChain.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(parentPayload).not.toHaveProperty('is_complete');
+    expect(parentPayload).toHaveProperty('status', 'completed');
+    expect(parentPayload).toHaveProperty('updated_at');
+  });
+});

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -78,6 +78,8 @@
 
 `useUpdateTask` routes **status-only** mutations through `updateStatus` (vs. the raw `Task.update`) so every checkbox toggle in the UI fires the full cascade/bubble pipeline. Mixed-field updates (e.g., form saves that include status + title) bypass this path and use the generic update.
 
+**Completion-flag invariant (Wave 23):** `is_complete === (status === 'completed')` is enforced at the DB layer by the `sync_task_completion_flags` BEFORE INSERT/UPDATE trigger on `public.tasks` (migration: `docs/db/migrations/2026_04_17_sync_task_completion.sql`). Accordingly, `updateStatus` and `reconcileAncestors` now send **only** `status` on every server payload; `is_complete` is derived by the trigger. React Query optimistic caches still hold both fields locally because the UI reads both — the trim is server-facing only.
+
 ### Date Bubble-up (§3.3)
 `planterClient.entities.Task.updateParentDates(parentId)` is now called automatically:
 - **After task create** — always, when the new task has a parent.

--- a/docs/architecture/tasks-subtasks.md
+++ b/docs/architecture/tasks-subtasks.md
@@ -16,6 +16,7 @@ Transitions strictly through: `To Do` -> `In Progress` -> `Complete` -> `Blocked
 ### Auto-Completion Automation
 * Toggling a parent to `Complete` forces a confirmation prompt if dependent sub-items exist. Confirmation cascades `Complete` status to all children.
 * Any status toggle instantly recalculates parent Milestone/Project completion percentages.
+* **Completion-flag invariant (Wave 23):** `is_complete === (status === 'completed')` is enforced at the DB layer by the `sync_task_completion_flags` BEFORE INSERT/UPDATE trigger on `public.tasks` (migration: `docs/db/migrations/2026_04_17_sync_task_completion.sql`). The app-layer cascade/bubble-up logic in `planterClient.updateStatus` still owns multi-row orchestration — it now writes **only** `status` on every server payload and relies on the trigger to derive `is_complete`. Raw SQL writes that touch only one side are automatically reconciled: `UPDATE tasks SET status = 'completed'` flips `is_complete` to `true`, and vice versa. Writes that change both sides in the same statement are trusted verbatim. Cross-ref: `docs/dev-notes.md` "Dual completion signals" (resolved Wave 23).
 
 ## Business Rules & Constraints
 * **Max Subtask Depth:** Subtasks *cannot* have child tasks (Maximum depth = 1).

--- a/docs/db/migrations/2026_04_17_sync_task_completion.sql
+++ b/docs/db/migrations/2026_04_17_sync_task_completion.sql
@@ -1,0 +1,76 @@
+-- Migration: Wave 23 — Sync task completion flags (is_complete ↔ status)
+-- Date: 2026-04-17
+-- Description:
+--   Adds a `BEFORE INSERT OR UPDATE` trigger on `public.tasks` that keeps
+--   `is_complete` (boolean) and `status = 'completed'` (text) in lockstep.
+--
+--   Closes the "Dual completion signals" entry in docs/dev-notes.md. Today
+--   these two fields are consumed by different triggers:
+--     * `check_phase_unlock()`       → reads `is_complete`
+--     * `handle_phase_completion()`  → reads `status`
+--   If they drift (e.g. raw SQL updates only one side, or a future bug in the
+--   app layer), only one downstream trigger fires and phase unlocking silently
+--   breaks. This BEFORE trigger is the belt-and-suspenders backstop — the app
+--   layer already best-effort mirrors both in `updateStatus`; this guarantees
+--   the invariant holds even when a raw SQL write touches only one side.
+--
+--   Rules:
+--     * INSERT:
+--         - If NEW.status = 'completed'       → NEW.is_complete := true
+--         - Else                              → NEW.is_complete := COALESCE(NEW.is_complete, false)
+--     * UPDATE:
+--         - Both sides changed in the same write → trust the caller, no-op.
+--         - Only status changed   → NEW.is_complete := (NEW.status = 'completed')
+--         - Only is_complete changed → NEW.status := CASE WHEN NEW.is_complete THEN 'completed' ELSE 'todo' END
+--
+--   Ordering: runs BEFORE all AFTER triggers on the same row, so
+--   `check_phase_unlock` (AFTER UPDATE OF is_complete) and
+--   `handle_phase_completion` (AFTER UPDATE OF status) both see the synced
+--   values.
+--
+--   Revert path:
+--     DROP TRIGGER IF EXISTS "trg_sync_task_completion" ON public.tasks;
+--     DROP FUNCTION IF EXISTS public.sync_task_completion_flags();
+
+CREATE OR REPLACE FUNCTION public.sync_task_completion_flags()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_status_changed   boolean;
+    v_complete_changed boolean;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status = 'completed' THEN
+            NEW.is_complete := true;
+        ELSE
+            NEW.is_complete := COALESCE(NEW.is_complete, false);
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    -- UPDATE path
+    v_status_changed   := NEW.status IS DISTINCT FROM OLD.status;
+    v_complete_changed := NEW.is_complete IS DISTINCT FROM OLD.is_complete;
+
+    IF v_status_changed AND v_complete_changed THEN
+        -- Both sides moving → trust the caller's intent on both fields.
+        RETURN NEW;
+    END IF;
+
+    IF v_status_changed THEN
+        NEW.is_complete := (NEW.status = 'completed');
+    ELSIF v_complete_changed THEN
+        NEW.status := CASE WHEN NEW.is_complete THEN 'completed' ELSE 'todo' END;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.sync_task_completion_flags() OWNER TO postgres;
+
+CREATE OR REPLACE TRIGGER "trg_sync_task_completion"
+BEFORE INSERT OR UPDATE ON public.tasks
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_task_completion_flags();

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -1129,6 +1129,45 @@ $$;
 ALTER FUNCTION "public"."set_root_id_from_parent"() OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "public"."sync_task_completion_flags"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    AS $$
+DECLARE
+    v_status_changed   boolean;
+    v_complete_changed boolean;
+BEGIN
+    -- Wave 23: keep is_complete and status = 'completed' in lockstep.
+    -- See docs/db/migrations/2026_04_17_sync_task_completion.sql.
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.status = 'completed' THEN
+            NEW.is_complete := true;
+        ELSE
+            NEW.is_complete := COALESCE(NEW.is_complete, false);
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    v_status_changed   := NEW.status IS DISTINCT FROM OLD.status;
+    v_complete_changed := NEW.is_complete IS DISTINCT FROM OLD.is_complete;
+
+    IF v_status_changed AND v_complete_changed THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_status_changed THEN
+        NEW.is_complete := (NEW.status = 'completed');
+    ELSIF v_complete_changed THEN
+        NEW.status := CASE WHEN NEW.is_complete THEN 'completed' ELSE 'todo' END;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."sync_task_completion_flags"() OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "public"."trigger_set_updated_at"() RETURNS "trigger"
     LANGUAGE "plpgsql"
     SET "search_path" TO 'public'
@@ -1513,6 +1552,10 @@ CREATE OR REPLACE TRIGGER "trg_people_updated_at" BEFORE UPDATE ON "public"."peo
 
 
 CREATE OR REPLACE TRIGGER "trg_set_root_id_from_parent" BEFORE INSERT OR UPDATE OF "parent_task_id" ON "public"."tasks" FOR EACH ROW EXECUTE FUNCTION "public"."set_root_id_from_parent"();
+
+
+
+CREATE OR REPLACE TRIGGER "trg_sync_task_completion" BEFORE INSERT OR UPDATE ON "public"."tasks" FOR EACH ROW EXECUTE FUNCTION "public"."sync_task_completion_flags"();
 
 
 

--- a/docs/db/tests/sync_completion_flags.sql
+++ b/docs/db/tests/sync_completion_flags.sql
@@ -1,0 +1,138 @@
+-- Manual smoke test for: docs/db/migrations/2026_04_17_sync_task_completion.sql
+-- Invocation:
+--   psql "$SUPABASE_DB_URL" -f docs/db/tests/sync_completion_flags.sql
+--
+-- Covers every branch of `sync_task_completion_flags`:
+--   1. INSERT with status = 'completed'              → is_complete := true
+--   2. INSERT with status = 'todo', is_complete null → is_complete := false
+--   3. UPDATE status → completed                     → is_complete auto-flipped true
+--   4. UPDATE status → todo                          → is_complete auto-flipped false
+--   5. UPDATE is_complete := true                    → status auto-flipped 'completed'
+--   6. UPDATE is_complete := false                   → status auto-flipped 'todo'
+--   7. UPDATE both sides at once                     → caller's values preserved
+
+BEGIN;
+
+WITH u AS (
+    INSERT INTO auth.users (id, email) VALUES
+      ('99999999-9999-9999-9999-999999999999', 'test-completion@example.test')
+    ON CONFLICT (id) DO NOTHING RETURNING id
+) SELECT 1;
+
+INSERT INTO public.tasks (id, parent_task_id, root_id, creator, title, origin, status)
+VALUES
+  ('dddddddd-0000-0000-0000-000000000000', NULL,
+   'dddddddd-0000-0000-0000-000000000000',
+   '99999999-9999-9999-9999-999999999999', 'Root for sync-flag tests', 'instance', 'todo');
+
+-- Branch 1: INSERT status=completed → is_complete auto-true -----------------
+
+INSERT INTO public.tasks (id, parent_task_id, root_id, creator, title, origin, status)
+VALUES
+  ('dddddddd-0001-0000-0000-000000000000',
+   'dddddddd-0000-0000-0000-000000000000',
+   'dddddddd-0000-0000-0000-000000000000',
+   '99999999-9999-9999-9999-999999999999',
+   'Insert with completed', 'instance', 'completed');
+
+DO $$
+BEGIN
+    ASSERT (SELECT is_complete = true
+              FROM public.tasks
+             WHERE id = 'dddddddd-0001-0000-0000-000000000000'),
+           'Branch 1 (INSERT completed): expected is_complete = true';
+END $$;
+
+-- Branch 2: INSERT status=todo, is_complete unset → is_complete auto-false --
+
+INSERT INTO public.tasks (id, parent_task_id, root_id, creator, title, origin, status)
+VALUES
+  ('dddddddd-0002-0000-0000-000000000000',
+   'dddddddd-0000-0000-0000-000000000000',
+   'dddddddd-0000-0000-0000-000000000000',
+   '99999999-9999-9999-9999-999999999999',
+   'Insert with todo', 'instance', 'todo');
+
+DO $$
+BEGIN
+    ASSERT (SELECT is_complete = false
+              FROM public.tasks
+             WHERE id = 'dddddddd-0002-0000-0000-000000000000'),
+           'Branch 2 (INSERT todo): expected is_complete = false';
+END $$;
+
+-- Branch 3: UPDATE status → completed → is_complete auto-flipped ------------
+
+UPDATE public.tasks
+   SET status = 'completed'
+ WHERE id = 'dddddddd-0002-0000-0000-000000000000';
+
+DO $$
+BEGIN
+    ASSERT (SELECT is_complete = true
+              FROM public.tasks
+             WHERE id = 'dddddddd-0002-0000-0000-000000000000'),
+           'Branch 3 (UPDATE status=completed): expected is_complete = true';
+END $$;
+
+-- Branch 4: UPDATE status → todo → is_complete auto-flipped false -----------
+
+UPDATE public.tasks
+   SET status = 'todo'
+ WHERE id = 'dddddddd-0002-0000-0000-000000000000';
+
+DO $$
+BEGIN
+    ASSERT (SELECT is_complete = false
+              FROM public.tasks
+             WHERE id = 'dddddddd-0002-0000-0000-000000000000'),
+           'Branch 4 (UPDATE status=todo): expected is_complete = false';
+END $$;
+
+-- Branch 5: UPDATE is_complete := true → status auto-flipped 'completed' ----
+
+UPDATE public.tasks
+   SET is_complete = true
+ WHERE id = 'dddddddd-0002-0000-0000-000000000000';
+
+DO $$
+BEGIN
+    ASSERT (SELECT status = 'completed'
+              FROM public.tasks
+             WHERE id = 'dddddddd-0002-0000-0000-000000000000'),
+           'Branch 5 (UPDATE is_complete=true): expected status = completed';
+END $$;
+
+-- Branch 6: UPDATE is_complete := false → status auto-flipped 'todo' --------
+
+UPDATE public.tasks
+   SET is_complete = false
+ WHERE id = 'dddddddd-0002-0000-0000-000000000000';
+
+DO $$
+BEGIN
+    ASSERT (SELECT status = 'todo'
+              FROM public.tasks
+             WHERE id = 'dddddddd-0002-0000-0000-000000000000'),
+           'Branch 6 (UPDATE is_complete=false): expected status = todo';
+END $$;
+
+-- Branch 7: UPDATE both sides at once → both preserved verbatim -------------
+-- Caller's intent wins: is_complete=true + status='blocked' is an unusual
+-- pairing that indicates an explicit non-synced write (e.g. marking a block
+-- on an already-checked task). The trigger must NOT overwrite either field.
+
+UPDATE public.tasks
+   SET is_complete = true,
+       status = 'blocked'
+ WHERE id = 'dddddddd-0002-0000-0000-000000000000';
+
+DO $$
+BEGIN
+    ASSERT (SELECT is_complete = true AND status = 'blocked'
+              FROM public.tasks
+             WHERE id = 'dddddddd-0002-0000-0000-000000000000'),
+           'Branch 7 (UPDATE both sides): expected caller values preserved';
+END $$;
+
+ROLLBACK;

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -20,12 +20,9 @@ Project  → parent_task_id = null, root_id = id
 
 ### Dual completion signals
 
-`is_complete` (boolean) and `status = 'completed'` (text) represent the same concept but are consumed by different triggers:
+**Resolved (Wave 23).** `sync_task_completion_flags` BEFORE INSERT/UPDATE trigger on `public.tasks` now guarantees `is_complete === (status === 'completed')` at the DB layer. `check_phase_unlock()` (reads `is_complete`) and `handle_phase_completion()` (reads `status`) both see the synced row since the BEFORE trigger fires first. The app-layer mirror in `planterClient.updateStatus` is simplified: only `status` is sent on every server payload; the trigger derives `is_complete`. Migration: `docs/db/migrations/2026_04_17_sync_task_completion.sql`. Architecture note: `docs/architecture/tasks-subtasks.md` — Auto-Completion Automation.
 
-- `check_phase_unlock()` listens for `is_complete = true` — unlocks dependent phases via `prerequisite_phase_id`
-- `handle_phase_completion()` listens for `status = 'completed'` — unlocks the next sibling by `position`
-
-If these two fields get out of sync (e.g., `status` is set to `'completed'` but `is_complete` stays `false`), only one trigger fires. This should be unified — either derive one from the other via trigger, or drop `is_complete` entirely and have `check_phase_unlock` read `status` instead.
+_Historical:_ `is_complete` (boolean) and `status = 'completed'` (text) represented the same concept but were consumed by different triggers. If they drifted — e.g., raw SQL updated only one side — only one trigger fired and phase unlocking silently broke. The fix is belt-and-suspenders: the app layer no longer deliberately writes both; the DB trigger enforces the invariant regardless.
 
 ### `check_project_ownership` is a latent auth bug
 

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # PlanterPlan — Project Specification
 
-> **Version**: 1.9.0 (Wave 22 — Supervisor Dispatch, Library Dedupe & Coaching Tags) 
+> **Version**: 1.9.1 (Wave 23 — Coach Auto-Assign, Creatorship Audit, Completion-Flag Trigger) 
 > **Last Updated**: 2026-04-17 
 > **Status**: Active Development
 

--- a/src/shared/api/planterClient.ts
+++ b/src/shared/api/planterClient.ts
@@ -494,6 +494,25 @@ export const planter: PlanterClient = {
                     return { data: null, error: error instanceof Error ? error : new PlanterError(String(error)) };
                 }
             },
+            /**
+             * Update a task's status and cascade completion state through the tree.
+             *
+             * **Server payload invariant (Wave 23):** this method writes only
+             * `status`; the `sync_task_completion_flags` BEFORE trigger on
+             * `public.tasks` derives `is_complete` from it at the DB layer. See
+             * `docs/db/migrations/2026_04_17_sync_task_completion.sql`. React
+             * Query callers that hold both fields in the client cache must
+             * still patch both locally (`useUpdateTask.onMutate`) — the UI
+             * reads both; only the *server* payload is trimmed here.
+             *
+             * Cascade semantics (unchanged — this method is the app-layer
+             * orchestrator for multi-row state that triggers cannot express):
+             *   - **Cascade DOWN**: a `completed` status propagates to every
+             *     descendant task.
+             *   - **Bubble UP**: `reconcileAncestors` walks parents/grandparents,
+             *     marking them `completed` when every child is complete, or
+             *     reverting to a derived non-completed status otherwise.
+             */
             updateStatus: async (taskId: string, status: string): Promise<{ data: Task | null, error: Error | null }> => {
                 // Inner helper: derive parent status from child statuses when parent is not fully complete.
                 const deriveParentStatus = (children: Task[]): string => {
@@ -505,6 +524,7 @@ export const planter: PlanterClient = {
 
                 // Inner helper: walk UP the tree reconciling ancestor completion/status whenever
                 // any child status changes (milestone-level automation — §3.3).
+                // Wave 23: parent patch writes only `status`; the DB trigger keeps `is_complete` in sync.
                 const reconcileAncestors = async (parentId: string, depth: number): Promise<void> => {
                     if (depth > 1) return; // guard: hierarchy is max 1 level of subtasks (§3.3)
                     try {
@@ -513,8 +533,8 @@ export const planter: PlanterClient = {
 
                         const allChildrenCompleted = children.every(child => child.status === 'completed');
                         const parentPatch: TaskUpdate = allChildrenCompleted
-                            ? { is_complete: true, status: 'completed', updated_at: nowUtcIso() }
-                            : { is_complete: false, status: deriveParentStatus(children), updated_at: nowUtcIso() };
+                            ? { status: 'completed', updated_at: nowUtcIso() }
+                            : { status: deriveParentStatus(children), updated_at: nowUtcIso() };
 
                         const parent = await planter.entities.Task.update(parentId, parentPatch);
                         if (parent?.parent_task_id) {
@@ -528,7 +548,6 @@ export const planter: PlanterClient = {
                 try {
                     const data = await planter.entities.Task.update(taskId, {
                         status,
-                        is_complete: status === 'completed',
                     } as TaskUpdate);
 
                     if (status === 'completed') {


### PR DESCRIPTION
…esync

Adds a BEFORE INSERT OR UPDATE trigger on public.tasks that keeps is_complete (boolean) and status = 'completed' (text) in lockstep at the DB layer. Closes the "Dual completion signals" entry in dev-notes.

Today is_complete is read by check_phase_unlock and status is read by handle_phase_completion. If they drift (raw SQL updates, future bugs), only one downstream trigger fires and phase unlocking silently breaks. This BEFORE trigger enforces the invariant regardless of how the write arrives.

Trigger rules:
- INSERT: status='completed' → is_complete := true; else → is_complete := COALESCE(NEW.is_complete, false).
- UPDATE status-only:        is_complete := (NEW.status = 'completed').
- UPDATE is_complete-only:   status      := CASE WHEN NEW.is_complete
                                               THEN 'completed'
                                               ELSE 'todo' END.
- UPDATE both sides:         trust caller; no override.

With the invariant locked in at the DB, Task.updateStatus (and its reconcileAncestors helper) no longer needs to mirror is_complete in every server payload. The app layer now sends only status; optimistic caches in React Query still hold both fields because the UI reads both.

- docs/db/migrations/2026_04_17_sync_task_completion.sql (new function
  + trigger; revert path in header)
- docs/db/schema.sql mirrors both
- docs/db/tests/sync_completion_flags.sql — manual psql smoke covering all seven branches
- Testing/unit/shared/api/planterClient.updateStatus.syncflags.test.ts asserts Task.updateStatus server payload is `{ status }` only for both leaf writes and reconcileAncestors parent patches
- src/shared/api/planterClient.ts trims is_complete from updateStatus and the parent reconciliation patch; JSDoc explains the invariant
- docs/architecture/tasks-subtasks.md — Auto-Completion Automation section gets the trigger note
- docs/dev-notes.md — flip to "Resolved (Wave 23)"
- docs/AGENT_CONTEXT.md — add Wave 23 invariant bullet
- spec.md — bump to 1.9.1

https://claude.ai/code/session_013BwAN1PaeffWVe6EXcGWKk

# Pull Request

<!--
Copy contents from `PR_DESCRIPTION_DRAFT.md` (generated by Agent) or fill manually.
-->

## 📋 Summary

<!-- 2-3 sentence executive summary. User-facing language. -->

## ✨ Highlights

<!--
- **Bold Concept:** Detail...
-->

## 🗺️ Roadmap Progress

| Item ID | Feature Name | Phase | Status | Notes |
| ------- | ------------ | ----- | ------ | ----- |
|         |              |       |        |       |

## 🏗️ Architecture Decisions

### Key Patterns & Decisions

-

### Logic Flow / State Changes

```mermaid
graph TD
    A[User Action] --> B[Component]
```

## 🔍 Review Guide

### 🚨 High Risk / Security Sensitive

-

### 🧠 Medium Complexity

-

### 🟢 Low Risk / Boilerplate

-

## 🧪 Verification Plan

### 1. Environment Setup

- [ ] Run `npm install`
- [ ] Run migration: `[filename].sql`

### 2. Manual Verification

- **[Feature Area]**:
  1. [Instruction]
  2. [Outcome]

### 3. Automated Tests

- [ ] `npm run lint` passed (Zero warnings).
- [ ] `npm test` passed.
- [ ] `npm run build` passed.
