### PR TITLE
fix(build+lint): restore clean baseline before Wave 26 Task 1

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'build', 'coverage', 'node_modules', 'playwright-report', '.features-gen'] },
   {
     extends: [
       eslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^19.2.5",
     "react-error-boundary": "^6.1.1",
     "react-hook-form": "^7.71.2",
+    "react-is": "^19.2.5",
     "react-router-dom": "^7.13.0",
     "recharts": "^3.7.0",
     "sonner": "^2.0.7",

--- a/src/features/library/hooks/useTreeState.ts
+++ b/src/features/library/hooks/useTreeState.ts
@@ -31,7 +31,7 @@ export const useTreeState = (rootTasks: TreeNode[]): UseTreeStateReturn => {
     // (reorders, status changes, lazily-loaded children) so we can't derive via useMemo.
     useEffect(() => {
         if (rootTasks && rootTasks.length > 0) {
-            setTreeData(() => mergeTaskUpdates(rootTasks));
+            setTreeData(mergeTaskUpdates(rootTasks));
         } else if (rootTasks) {
             setTreeData([]);
         }

--- a/src/features/library/hooks/useTreeState.ts
+++ b/src/features/library/hooks/useTreeState.ts
@@ -31,7 +31,6 @@ export const useTreeState = (rootTasks: TreeNode[]): UseTreeStateReturn => {
     // (reorders, status changes, lazily-loaded children) so we can't derive via useMemo.
     useEffect(() => {
         if (rootTasks && rootTasks.length > 0) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
             setTreeData(() => mergeTaskUpdates(rootTasks));
         } else if (rootTasks) {
             setTreeData([]);
@@ -40,7 +39,6 @@ export const useTreeState = (rootTasks: TreeNode[]): UseTreeStateReturn => {
 
     // Effect 2: Sync persistent expansion state onto the tree. Same rationale as above.
     useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setTreeData((prevTree) => updateTreeExpansion(prevTree, expandedTaskIds));
     }, [expandedTaskIds]);
 

--- a/src/features/people/components/PeopleList.tsx
+++ b/src/features/people/components/PeopleList.tsx
@@ -65,7 +65,6 @@ export default function PeopleList({ projectId, canEdit = false }: PeopleListPro
     }, [projectId]);
 
     useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount sets loading/people via loadPeople
         loadPeople();
     }, [loadPeople]);
 

--- a/src/features/settings/hooks/useSettings.ts
+++ b/src/features/settings/hooks/useSettings.ts
@@ -43,7 +43,6 @@ export function useSettings() {
     // so derived-memo won't work — we intentionally seed state from the auth user.
     useEffect(() => {
         if (user) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
             setProfile({
                 full_name: String(user.user_metadata?.full_name || ''),
                 email: user.email || '',


### PR DESCRIPTION
## Summary

Second of two hotfix PRs to unblock Wave 26 Task 1's verification gate. PR #152 (merged) fixed the 17 test failures; this PR fixes the remaining two gate failures.

- `npm run build` now **passes** (1.84s, all chunks produced).
- `npm run lint` now reports **4 warnings, 0 errors** — all 4 are pre-existing `AuthContext.tsx` warnings already counted toward the Wave 25 baseline.
- `npm test` still **577/577 passing**.

## Changes

**1. `react-is@^19` added to `dependencies`** ([3ae00ff](https://github.com/JoelA510/PlanterPlan-Alpha/commit/3ae00ff))

recharts 3.8.1 declares `react-is` as a peer dep. npm 10+ does not auto-install peer deps, so Rolldown could not resolve `react-is` from `recharts/es6/util/ReactUtils.js` and `npm run build` failed with:

```
Error: [vite]: Rolldown failed to resolve import "react-is" from
"node_modules/recharts/es6/util/ReactUtils.js".
```

Pinning `react-is@^19` to match the existing `react@^19.2.5` resolves the transitive dep.

**2. Lint ignores + stale disable-directive cleanup** ([1561861](https://github.com/JoelA510/PlanterPlan-Alpha/commit/1561861))

Previous state: **11 warnings** (vs wave baseline of 7).

- `eslint.config.js` `ignores` only had `['dist']`. Added `build`, `coverage`, `node_modules`, `playwright-report`, `.features-gen` — generated files were producing 3 "Unused eslint-disable directive" warnings on every run.
- Removed 4 stale `// eslint-disable-next-line react-hooks/set-state-in-effect` comments in `useTreeState.ts` (×2), `PeopleList.tsx`, `useSettings.ts`. The react-hooks plugin no longer reports that rule on those lines, so the directives themselves were the only warning source.

Remaining 4 warnings (pre-existing AuthContext churn — unchanged) are under the 7-warning baseline.

## Verification

```
npm test   → 577 passed (577)
npm run build → ✓ built in 1.84s
npm run lint  → ✖ 4 problems (0 errors, 4 warnings)
```

## Test plan

- [x] Full unit suite green.
- [x] Build produces all expected chunks (vendor, charts, motion, index).
- [x] Lint at or below the 7-warning wave baseline.
- [ ] Reviewer: confirm `react-is@^19` is the right pin (peer range is `^16.8 || ^17 || ^18 || ^19`; we match `react@^19`).