### PR TITLE
feat(wave-26): task_comments table + threading + RLS

### DIFF
--- a/docs/architecture/auth-rbac.md
+++ b/docs/architecture/auth-rbac.md
@@ -74,3 +74,5 @@ Migration: `docs/db/migrations/2026_04_18_rewrite_project_members_policies.sql`.
 ## Resolved
 
 * **Coach Role Tagging (Wave 22, 2026-04-17):** Resolved. Tasks intended for coach editing are now flagged via `settings -> 'is_coaching_task' = true`. A project owner or editor tags the task through the "Coaching task" checkbox in TaskForm; TaskDetailsView surfaces a "Coaching" badge. An additive RLS UPDATE policy — `"Enable update for coaches on coaching tasks"` (see `docs/db/migrations/2026_04_17_coaching_task_rls.sql`) — allows any user with the project `coach` role to update rows where the flag is true, scoped to non-template origins. The pre-existing owner/editor/admin UPDATE policy is unchanged, so coaches retain zero access to non-coaching rows.
+
+* **Comments (Wave 26):** SELECT inherits project membership; INSERT requires `author_id = auth.uid()`; UPDATE restricted to authors on undeleted rows; DELETE allowed for authors, project owners (`check_project_ownership_by_role`), or admins. Full policy text in `docs/architecture/tasks-subtasks.md`.

--- a/docs/architecture/tasks-subtasks.md
+++ b/docs/architecture/tasks-subtasks.md
@@ -175,6 +175,34 @@ zero or many follow-ups.
 RLS policy needed. Owners / editors already have UPDATE access on
 instance tasks.
 
+## Comments (Wave 26)
+
+Threaded task comments live in `public.task_comments`. Each row carries
+`task_id` (the comment's target), `root_id` (auto-filled from the parent
+task's root via `trg_task_comments_set_root_id`, mirrors the
+`set_root_id_from_parent` pattern on `public.tasks`), and an optional
+`parent_comment_id` self-FK for replies. The DB places **no depth cap** on
+threading — the UI in `src/features/tasks/components/TaskComments/`
+enforces a single-level visual nest with chain-lift for reply-to-reply.
+
+**Soft-delete contract**: callers issue `UPDATE ... SET deleted_at = now(),
+body = ''` (clearing the body to scrub the cached query payload).
+`useTaskComments` filters `deleted_at IS NULL` by default. Hard `DELETE` is
+reserved for admin/cleanup paths.
+
+**RLS** (migration `docs/db/migrations/2026_04_18_task_comments.sql`):
+* SELECT — any project member via `is_active_member(root_id, auth.uid())`.
+* INSERT — any project member; `author_id` pinned to `auth.uid()` via
+  `WITH CHECK`.
+* UPDATE — author of the comment, undeleted only. Immutable fields:
+  `task_id`, `root_id`, `parent_comment_id`, `author_id`.
+* DELETE — author, project owner (`check_project_ownership_by_role`), or
+  admin.
+
+**Realtime** — table is in the `supabase_realtime` publication; the
+per-task channel in `src/features/tasks/hooks/useTaskCommentsRealtime.ts`
+invalidates `['taskComments', taskId]` on any payload.
+
 ## Integration Points
 * **Date Engine:** Dragging tasks triggers date inheritance logic (`dateInheritance.ts`) to adjust bounds automatically.
 * **Dashboard:** Feeds raw status counts.

--- a/docs/db/migrations/2026_04_18_task_comments.sql
+++ b/docs/db/migrations/2026_04_18_task_comments.sql
@@ -1,0 +1,123 @@
+-- Migration: Wave 26 — task_comments table
+-- Date: 2026-04-18
+-- Description:
+--   First column of the §3.3 Collaboration Suite. Adds a threaded comments table
+--   scoped to project membership via tasks.root_id, with soft-delete semantics so
+--   the Wave 27 activity log can report deletion events without losing the row.
+--
+--   Threading is unbounded at the DB layer (`parent_comment_id` is a self-FK with
+--   no depth check) — the UI in Wave 26 Task 2 enforces a 1-level visual cap with
+--   reply-to-reply chain-lift. This split keeps the data faithful while keeping
+--   the UI predictable.
+--
+-- Revert path:
+--   ALTER PUBLICATION supabase_realtime DROP TABLE public.task_comments;
+--   DROP TABLE IF EXISTS public.task_comments CASCADE;
+--   DROP FUNCTION IF EXISTS public.set_task_comments_root_id();
+
+CREATE TABLE public.task_comments (
+  id                uuid          PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_id           uuid          NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+  root_id           uuid          NOT NULL REFERENCES public.tasks(id) ON DELETE CASCADE,
+  parent_comment_id uuid          REFERENCES public.task_comments(id) ON DELETE CASCADE,
+  author_id         uuid          NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  body              text          NOT NULL CHECK (length(trim(body)) BETWEEN 1 AND 10000),
+  mentions          text[]        NOT NULL DEFAULT ARRAY[]::text[],
+  created_at        timestamptz   NOT NULL DEFAULT now(),
+  updated_at        timestamptz   NOT NULL DEFAULT now(),
+  edited_at         timestamptz,
+  deleted_at        timestamptz
+);
+
+CREATE INDEX idx_task_comments_task_id           ON public.task_comments (task_id, created_at DESC);
+CREATE INDEX idx_task_comments_root_id           ON public.task_comments (root_id, created_at DESC);
+CREATE INDEX idx_task_comments_parent_comment_id ON public.task_comments (parent_comment_id) WHERE parent_comment_id IS NOT NULL;
+
+-- root_id auto-fill (mirrors the set_root_id_from_parent pattern on public.tasks)
+CREATE OR REPLACE FUNCTION public.set_task_comments_root_id()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_root uuid;
+BEGIN
+  SELECT COALESCE(t.root_id, t.id) INTO v_root
+  FROM public.tasks t
+  WHERE t.id = NEW.task_id;
+  IF v_root IS NULL THEN
+    RAISE EXCEPTION 'task_comments: parent task % not found', NEW.task_id;
+  END IF;
+  NEW.root_id := v_root;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.set_task_comments_root_id() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.set_task_comments_root_id() TO authenticated;
+
+CREATE TRIGGER trg_task_comments_set_root_id
+BEFORE INSERT ON public.task_comments
+FOR EACH ROW
+EXECUTE FUNCTION public.set_task_comments_root_id();
+
+CREATE TRIGGER trg_task_comments_handle_updated_at
+BEFORE UPDATE ON public.task_comments
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_updated_at();
+
+-- Realtime publication add (required for Task 3's channel subscription)
+ALTER PUBLICATION supabase_realtime ADD TABLE public.task_comments;
+
+ALTER TABLE public.task_comments ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: any project member, plus admin
+CREATE POLICY "Comments select by project members"
+ON public.task_comments
+FOR SELECT
+TO authenticated
+USING (
+  is_active_member(root_id, auth.uid())
+  OR public.is_admin(auth.uid())
+);
+
+-- INSERT: any project member; author must be self
+CREATE POLICY "Comments insert by project members"
+ON public.task_comments
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  author_id = auth.uid()
+  AND (
+    is_active_member(root_id, auth.uid())
+    OR public.is_admin(auth.uid())
+  )
+);
+
+-- UPDATE: author edits own undeleted comments only; immutable fields enforced via WITH CHECK
+CREATE POLICY "Comments update by author"
+ON public.task_comments
+FOR UPDATE
+TO authenticated
+USING (
+  (author_id = auth.uid() AND deleted_at IS NULL)
+  OR public.is_admin(auth.uid())
+)
+WITH CHECK (
+  task_id           = (SELECT task_id           FROM public.task_comments WHERE id = task_comments.id)
+  AND root_id       = (SELECT root_id           FROM public.task_comments WHERE id = task_comments.id)
+  AND parent_comment_id IS NOT DISTINCT FROM (SELECT parent_comment_id FROM public.task_comments WHERE id = task_comments.id)
+  AND author_id     = (SELECT author_id         FROM public.task_comments WHERE id = task_comments.id)
+);
+
+-- DELETE: author, project owner, or admin (soft-delete preferred via UPDATE)
+CREATE POLICY "Comments delete by author or owner"
+ON public.task_comments
+FOR DELETE
+TO authenticated
+USING (
+  author_id = auth.uid()
+  OR public.check_project_ownership_by_role(root_id, auth.uid())
+  OR public.is_admin(auth.uid())
+);

--- a/docs/db/migrations/2026_04_18_task_comments.sql
+++ b/docs/db/migrations/2026_04_18_task_comments.sql
@@ -105,10 +105,10 @@ USING (
   OR public.is_admin(auth.uid())
 )
 WITH CHECK (
-  task_id           = (SELECT task_id           FROM public.task_comments WHERE id = task_comments.id)
-  AND root_id       = (SELECT root_id           FROM public.task_comments WHERE id = task_comments.id)
-  AND parent_comment_id IS NOT DISTINCT FROM (SELECT parent_comment_id FROM public.task_comments WHERE id = task_comments.id)
-  AND author_id     = (SELECT author_id         FROM public.task_comments WHERE id = task_comments.id)
+  task_id           = (SELECT task_comments_1.task_id           FROM public.task_comments task_comments_1 WHERE task_comments_1.id = task_comments.id)
+  AND root_id       = (SELECT task_comments_1.root_id           FROM public.task_comments task_comments_1 WHERE task_comments_1.id = task_comments.id)
+  AND parent_comment_id IS NOT DISTINCT FROM (SELECT task_comments_1.parent_comment_id FROM public.task_comments task_comments_1 WHERE task_comments_1.id = task_comments.id)
+  AND author_id     = (SELECT task_comments_1.author_id         FROM public.task_comments task_comments_1 WHERE task_comments_1.id = task_comments.id)
 );
 
 -- DELETE: author, project owner, or admin (soft-delete preferred via UPDATE)

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -1377,6 +1377,28 @@ $$;
 
 ALTER FUNCTION "public"."trigger_set_updated_at"() OWNER TO "postgres";
 
+
+CREATE OR REPLACE FUNCTION "public"."set_task_comments_root_id"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_root uuid;
+BEGIN
+  SELECT COALESCE(t.root_id, t.id) INTO v_root
+  FROM public.tasks t
+  WHERE t.id = NEW.task_id;
+  IF v_root IS NULL THEN
+    RAISE EXCEPTION 'task_comments: parent task % not found', NEW.task_id;
+  END IF;
+  NEW.root_id := v_root;
+  RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."set_task_comments_root_id"() OWNER TO "postgres";
+
 SET default_tablespace = '';
 
 SET default_table_access_method = "heap";
@@ -1538,6 +1560,24 @@ COMMENT ON COLUMN "public"."tasks"."settings" IS 'Project-level settings (e.g., 
 
 COMMENT ON COLUMN "public"."tasks"."supervisor_email" IS 'Optional supervisor recipient for monthly Project Status Reports. Only meaningful on project roots (parent_task_id IS NULL). UI gates the field to roots; no DB-level check constraint.';
 
+
+CREATE TABLE IF NOT EXISTS "public"."task_comments" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "task_id" "uuid" NOT NULL,
+    "root_id" "uuid" NOT NULL,
+    "parent_comment_id" "uuid",
+    "author_id" "uuid" NOT NULL,
+    "body" "text" NOT NULL,
+    "mentions" "text"[] DEFAULT ARRAY[]::"text"[] NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "edited_at" timestamp with time zone,
+    "deleted_at" timestamp with time zone,
+    CONSTRAINT "task_comments_body_check" CHECK (("length"("trim"("body")) BETWEEN 1 AND 10000))
+);
+
+
+ALTER TABLE "public"."task_comments" OWNER TO "postgres";
 
 
 CREATE OR REPLACE VIEW "public"."tasks_with_primary_resource" AS
@@ -1749,6 +1789,18 @@ CREATE INDEX "task_resources_type_idx" ON "public"."task_resources" USING "btree
 
 
 
+CREATE INDEX "idx_task_comments_task_id" ON "public"."task_comments" USING "btree" ("task_id", "created_at" DESC);
+
+
+
+CREATE INDEX "idx_task_comments_root_id" ON "public"."task_comments" USING "btree" ("root_id", "created_at" DESC);
+
+
+
+CREATE INDEX "idx_task_comments_parent_comment_id" ON "public"."task_comments" USING "btree" ("parent_comment_id") WHERE ("parent_comment_id" IS NOT NULL);
+
+
+
 CREATE OR REPLACE TRIGGER "trg_people_updated_at" BEFORE UPDATE ON "public"."people" FOR EACH ROW EXECUTE FUNCTION "public"."handle_updated_at"();
 
 
@@ -1790,6 +1842,14 @@ CREATE OR REPLACE TRIGGER "trigger_phase_unlock" AFTER UPDATE OF "is_complete" O
 
 
 CREATE OR REPLACE TRIGGER "trigger_tasks_set_updated_at" BEFORE UPDATE ON "public"."tasks" FOR EACH ROW EXECUTE FUNCTION "public"."trigger_set_updated_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "trg_task_comments_set_root_id" BEFORE INSERT ON "public"."task_comments" FOR EACH ROW EXECUTE FUNCTION "public"."set_task_comments_root_id"();
+
+
+
+CREATE OR REPLACE TRIGGER "trg_task_comments_handle_updated_at" BEFORE UPDATE ON "public"."task_comments" FOR EACH ROW EXECUTE FUNCTION "public"."handle_updated_at"();
 
 
 
@@ -1845,6 +1905,26 @@ ALTER TABLE ONLY "public"."task_relationships"
 
 ALTER TABLE ONLY "public"."task_resources"
     ADD CONSTRAINT "task_resources_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."task_comments"
+    ADD CONSTRAINT "task_comments_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "public"."tasks"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."task_comments"
+    ADD CONSTRAINT "task_comments_root_id_fkey" FOREIGN KEY ("root_id") REFERENCES "public"."tasks"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."task_comments"
+    ADD CONSTRAINT "task_comments_parent_comment_id_fkey" FOREIGN KEY ("parent_comment_id") REFERENCES "public"."task_comments"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."task_comments"
+    ADD CONSTRAINT "task_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;
 
 
 
@@ -2044,9 +2124,27 @@ ALTER TABLE "public"."task_resources" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."tasks" ENABLE ROW LEVEL SECURITY;
 
 
+ALTER TABLE "public"."task_comments" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "Comments select by project members" ON "public"."task_comments" FOR SELECT TO "authenticated" USING (("public"."is_active_member"("root_id", "auth"."uid"()) OR "public"."is_admin"("auth"."uid"())));
+
+
+CREATE POLICY "Comments insert by project members" ON "public"."task_comments" FOR INSERT TO "authenticated" WITH CHECK ((("author_id" = "auth"."uid"()) AND ("public"."is_active_member"("root_id", "auth"."uid"()) OR "public"."is_admin"("auth"."uid"()))));
+
+
+CREATE POLICY "Comments update by author" ON "public"."task_comments" FOR UPDATE TO "authenticated" USING (((("author_id" = "auth"."uid"()) AND ("deleted_at" IS NULL)) OR "public"."is_admin"("auth"."uid"()))) WITH CHECK ((("task_id" = (SELECT "task_comments_1"."task_id" FROM "public"."task_comments" "task_comments_1" WHERE ("task_comments_1"."id" = "task_comments"."id"))) AND ("root_id" = (SELECT "task_comments_1"."root_id" FROM "public"."task_comments" "task_comments_1" WHERE ("task_comments_1"."id" = "task_comments"."id"))) AND ("parent_comment_id" IS NOT DISTINCT FROM (SELECT "task_comments_1"."parent_comment_id" FROM "public"."task_comments" "task_comments_1" WHERE ("task_comments_1"."id" = "task_comments"."id"))) AND ("author_id" = (SELECT "task_comments_1"."author_id" FROM "public"."task_comments" "task_comments_1" WHERE ("task_comments_1"."id" = "task_comments"."id")))));
+
+
+CREATE POLICY "Comments delete by author or owner" ON "public"."task_comments" FOR DELETE TO "authenticated" USING ((("author_id" = "auth"."uid"()) OR "public"."check_project_ownership_by_role"("root_id", "auth"."uid"()) OR "public"."is_admin"("auth"."uid"())));
+
+
 
 
 ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";
+
+
+ALTER PUBLICATION "supabase_realtime" ADD TABLE "public"."task_comments";
 
 
 
@@ -2267,6 +2365,9 @@ GRANT ALL ON FUNCTION "public"."is_active_member"("p_project_id" "uuid", "p_user
 REVOKE ALL ON FUNCTION "public"."is_admin"("p_user_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."is_admin"("p_user_id" "uuid") TO "authenticated";
 GRANT ALL ON FUNCTION "public"."is_admin"("p_user_id" "uuid") TO "service_role";
+
+REVOKE ALL ON FUNCTION "public"."set_task_comments_root_id"() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION "public"."set_task_comments_root_id"() TO "authenticated";
 
 
 

--- a/docs/db/tests/task_comments_rls.sql
+++ b/docs/db/tests/task_comments_rls.sql
@@ -1,0 +1,358 @@
+-- EXPECT: every persona-row pair returns the documented oracle
+-- Manual smoke test for: docs/db/migrations/2026_04_18_task_comments.sql
+-- Invocation (against a disposable local Supabase):
+--   psql "$SUPABASE_DB_URL" -f docs/db/tests/task_comments_rls.sql
+--
+-- Covers:
+--   1. set_task_comments_root_id correctness (phase row vs. leaf task).
+--   2. SELECT policy across owner / editor / viewer / non-member / admin.
+--   3. INSERT policy: author pinned via WITH CHECK; non-members blocked.
+--   4. UPDATE policy: only the author on undeleted rows; immutable fields
+--      (task_id / root_id / parent_comment_id / author_id) enforced via
+--      WITH CHECK.
+--   5. DELETE policy: author, project owner, admin. Non-owner non-author
+--      blocked.
+--   6. Soft-delete vs. hard-delete branches: UPDATE ... SET deleted_at is
+--      allowed by the update policy (author); DELETE is only allowed by
+--      the three roles above.
+
+BEGIN;
+
+-- Fixtures -------------------------------------------------------------------
+
+INSERT INTO auth.users (id, email) VALUES
+  ('10000000-0000-0000-0000-000000000001', 'owner@example.test'),
+  ('10000000-0000-0000-0000-000000000002', 'editor@example.test'),
+  ('10000000-0000-0000-0000-000000000003', 'viewer@example.test'),
+  ('10000000-0000-0000-0000-000000000004', 'nonmember@example.test'),
+  ('10000000-0000-0000-0000-000000000005', 'admin@example.test')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.admin_users (user_id, email) VALUES
+  ('10000000-0000-0000-0000-000000000005', 'admin@example.test')
+ON CONFLICT (user_id) DO NOTHING;
+
+-- Project (root task) + phase (depth-1) + leaf task (depth-2) ---------------
+
+INSERT INTO public.tasks (id, parent_task_id, root_id, creator, title, origin)
+VALUES
+  ('20000000-0000-0000-0000-000000000000', NULL,
+   '20000000-0000-0000-0000-000000000000',
+   '10000000-0000-0000-0000-000000000001',
+   'RLS smoke project', 'instance');
+
+INSERT INTO public.tasks (id, parent_task_id, creator, title, origin)
+VALUES
+  ('20000000-0000-0000-0000-000000000001',
+   '20000000-0000-0000-0000-000000000000',
+   '10000000-0000-0000-0000-000000000001',
+   'Phase A', 'instance');
+
+INSERT INTO public.tasks (id, parent_task_id, creator, title, origin)
+VALUES
+  ('20000000-0000-0000-0000-000000000002',
+   '20000000-0000-0000-0000-000000000001',
+   '10000000-0000-0000-0000-000000000001',
+   'Leaf task A.1', 'instance');
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('20000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000001', 'owner'),
+  ('20000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000002', 'editor'),
+  ('20000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000003', 'viewer');
+
+-- Helpers to switch personas -------------------------------------------------
+
+CREATE OR REPLACE FUNCTION pg_temp.act_as(p_user_id uuid) RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub', p_user_id::text, true);
+  PERFORM set_config('request.jwt.claim.role', 'authenticated', true);
+  PERFORM set_config('role', 'authenticated', true);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.reset_actor() RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM set_config('request.jwt.claim.sub', '', true);
+  PERFORM set_config('request.jwt.claim.role', '', true);
+  PERFORM set_config('role', '', true);
+END;
+$$;
+
+-- Branch 1: set_task_comments_root_id on a leaf task -------------------------
+-- Author (owner) inserts a comment on the leaf; root_id must auto-fill to the
+-- project id even though the INSERT does not supply it.
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000001');
+
+INSERT INTO public.task_comments (id, task_id, author_id, body)
+VALUES
+  ('30000000-0000-0000-0000-000000000001',
+   '20000000-0000-0000-0000-000000000002',
+   '10000000-0000-0000-0000-000000000001',
+   'Comment on leaf task');
+
+DO $$
+BEGIN
+    ASSERT (SELECT root_id = '20000000-0000-0000-0000-000000000000'
+              FROM public.task_comments
+             WHERE id = '30000000-0000-0000-0000-000000000001'),
+           'Branch 1 (root_id auto-fill on leaf): expected root_id = project id';
+END $$;
+
+-- Branch 2: set_task_comments_root_id on a phase row (depth-1) ---------------
+-- Phase tasks have root_id set (by trg_set_root_id_from_parent on insert), so
+-- comments posted directly to a phase should fill root_id from that root.
+
+INSERT INTO public.task_comments (id, task_id, author_id, body)
+VALUES
+  ('30000000-0000-0000-0000-000000000002',
+   '20000000-0000-0000-0000-000000000001',
+   '10000000-0000-0000-0000-000000000001',
+   'Comment on phase row');
+
+DO $$
+BEGIN
+    ASSERT (SELECT root_id = '20000000-0000-0000-0000-000000000000'
+              FROM public.task_comments
+             WHERE id = '30000000-0000-0000-0000-000000000002'),
+           'Branch 2 (root_id auto-fill on phase): expected root_id = project id';
+END $$;
+
+-- Branch 3: SELECT — owner sees both comments ---------------------------------
+
+DO $$
+BEGIN
+    ASSERT (SELECT count(*) = 2
+              FROM public.task_comments
+             WHERE root_id = '20000000-0000-0000-0000-000000000000'),
+           'Branch 3 (SELECT owner): expected 2 rows visible';
+END $$;
+
+-- Branch 4: SELECT — editor sees both ----------------------------------------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000002');
+
+DO $$
+BEGIN
+    ASSERT (SELECT count(*) = 2
+              FROM public.task_comments
+             WHERE root_id = '20000000-0000-0000-0000-000000000000'),
+           'Branch 4 (SELECT editor): expected 2 rows visible';
+END $$;
+
+-- Branch 5: SELECT — viewer sees both ----------------------------------------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000003');
+
+DO $$
+BEGIN
+    ASSERT (SELECT count(*) = 2
+              FROM public.task_comments
+             WHERE root_id = '20000000-0000-0000-0000-000000000000'),
+           'Branch 5 (SELECT viewer): expected 2 rows visible';
+END $$;
+
+-- Branch 6: SELECT — non-member sees zero rows -------------------------------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000004');
+
+DO $$
+BEGIN
+    ASSERT (SELECT count(*) = 0
+              FROM public.task_comments
+             WHERE root_id = '20000000-0000-0000-0000-000000000000'),
+           'Branch 6 (SELECT non-member): expected 0 rows visible';
+END $$;
+
+-- Branch 7: SELECT — admin sees both -----------------------------------------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000005');
+
+DO $$
+BEGIN
+    ASSERT (SELECT count(*) = 2
+              FROM public.task_comments
+             WHERE root_id = '20000000-0000-0000-0000-000000000000'),
+           'Branch 7 (SELECT admin): expected 2 rows visible';
+END $$;
+
+-- Branch 8: INSERT — viewer can post a comment -------------------------------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000003');
+
+INSERT INTO public.task_comments (id, task_id, author_id, body)
+VALUES
+  ('30000000-0000-0000-0000-000000000003',
+   '20000000-0000-0000-0000-000000000002',
+   '10000000-0000-0000-0000-000000000003',
+   'Viewer comment');
+
+DO $$
+BEGIN
+    ASSERT EXISTS (SELECT 1 FROM public.task_comments
+                    WHERE id = '30000000-0000-0000-0000-000000000003'),
+           'Branch 8 (INSERT viewer): expected viewer can post';
+END $$;
+
+-- Branch 9: INSERT — non-member blocked by USING / WITH CHECK ---------------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000004');
+
+DO $$
+BEGIN
+    BEGIN
+        INSERT INTO public.task_comments (id, task_id, author_id, body)
+        VALUES
+          ('30000000-0000-0000-0000-000000000009',
+           '20000000-0000-0000-0000-000000000002',
+           '10000000-0000-0000-0000-000000000004',
+           'Non-member should be blocked');
+        RAISE EXCEPTION 'Branch 9 (INSERT non-member): expected RLS violation';
+    EXCEPTION WHEN insufficient_privilege OR check_violation THEN
+        -- Expected path.
+        NULL;
+    END;
+END $$;
+
+-- Branch 10: INSERT — author_id mismatch (viewer posting as someone else) ----
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000003');
+
+DO $$
+BEGIN
+    BEGIN
+        INSERT INTO public.task_comments (id, task_id, author_id, body)
+        VALUES
+          ('30000000-0000-0000-0000-00000000000a',
+           '20000000-0000-0000-0000-000000000002',
+           '10000000-0000-0000-0000-000000000002',  -- editor, not the caller
+           'Spoofed author should be blocked');
+        RAISE EXCEPTION 'Branch 10 (INSERT author spoof): expected RLS violation';
+    EXCEPTION WHEN insufficient_privilege OR check_violation THEN
+        NULL;
+    END;
+END $$;
+
+-- Branch 11: UPDATE — author edits own body ----------------------------------
+-- Viewer edits their own comment (Branch 8 row).
+
+UPDATE public.task_comments
+   SET body = 'Viewer comment (edited)'
+ WHERE id = '30000000-0000-0000-0000-000000000003';
+
+DO $$
+BEGIN
+    ASSERT (SELECT body = 'Viewer comment (edited)'
+              FROM public.task_comments
+             WHERE id = '30000000-0000-0000-0000-000000000003'),
+           'Branch 11 (UPDATE author): expected body update to succeed';
+END $$;
+
+-- Branch 12: UPDATE — non-author blocked -------------------------------------
+-- Editor tries to edit viewer's comment.
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000002');
+
+DO $$
+DECLARE v_row_count int;
+BEGIN
+    UPDATE public.task_comments
+       SET body = 'Editor should not be able to edit this'
+     WHERE id = '30000000-0000-0000-0000-000000000003';
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    ASSERT v_row_count = 0,
+           'Branch 12 (UPDATE non-author): expected 0 rows updated';
+END $$;
+
+-- Branch 13: UPDATE — immutable field (task_id) blocked via WITH CHECK -------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000003');
+
+DO $$
+BEGIN
+    BEGIN
+        UPDATE public.task_comments
+           SET task_id = '20000000-0000-0000-0000-000000000001' -- try to move to phase row
+         WHERE id = '30000000-0000-0000-0000-000000000003';
+        RAISE EXCEPTION 'Branch 13 (UPDATE immutable task_id): expected WITH CHECK violation';
+    EXCEPTION WHEN check_violation OR insufficient_privilege THEN
+        NULL;
+    END;
+END $$;
+
+-- Branch 14: Soft-delete — author writes deleted_at + blanks body ------------
+-- Semantically the "delete UX"; policy-wise it's an UPDATE by the author.
+
+UPDATE public.task_comments
+   SET deleted_at = now(), body = ''
+ WHERE id = '30000000-0000-0000-0000-000000000003';
+
+DO $$
+BEGIN
+    ASSERT (SELECT deleted_at IS NOT NULL AND body = ''
+              FROM public.task_comments
+             WHERE id = '30000000-0000-0000-0000-000000000003'),
+           'Branch 14 (soft-delete): expected deleted_at set and body cleared';
+END $$;
+
+-- Branch 15: UPDATE on a soft-deleted row is blocked (deleted_at IS NULL gate)
+
+DO $$
+DECLARE v_row_count int;
+BEGIN
+    UPDATE public.task_comments
+       SET body = 'resurrect me'
+     WHERE id = '30000000-0000-0000-0000-000000000003';
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    ASSERT v_row_count = 0,
+           'Branch 15 (UPDATE on soft-deleted): expected 0 rows updated';
+END $$;
+
+-- Branch 16: DELETE — non-author, non-owner blocked --------------------------
+-- Editor tries to hard-delete viewer's comment.
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000002');
+
+DO $$
+DECLARE v_row_count int;
+BEGIN
+    DELETE FROM public.task_comments
+     WHERE id = '30000000-0000-0000-0000-000000000003';
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    ASSERT v_row_count = 0,
+           'Branch 16 (DELETE editor of viewer comment): expected 0 rows deleted';
+END $$;
+
+-- Branch 17: DELETE — project owner can hard-delete anyone's comment ---------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000001');
+
+DELETE FROM public.task_comments
+ WHERE id = '30000000-0000-0000-0000-000000000003';
+
+DO $$
+BEGIN
+    ASSERT NOT EXISTS (SELECT 1 FROM public.task_comments
+                        WHERE id = '30000000-0000-0000-0000-000000000003'),
+           'Branch 17 (DELETE owner): expected row gone';
+END $$;
+
+-- Branch 18: DELETE — admin can hard-delete any comment ----------------------
+
+SELECT pg_temp.act_as('10000000-0000-0000-0000-000000000005');
+
+DELETE FROM public.task_comments
+ WHERE id = '30000000-0000-0000-0000-000000000001';
+
+DO $$
+BEGIN
+    ASSERT NOT EXISTS (SELECT 1 FROM public.task_comments
+                        WHERE id = '30000000-0000-0000-0000-000000000001'),
+           'Branch 18 (DELETE admin): expected row gone';
+END $$;
+
+SELECT pg_temp.reset_actor();
+
+ROLLBACK;

--- a/src/shared/db/app.types.ts
+++ b/src/shared/db/app.types.ts
@@ -57,6 +57,22 @@ export type ResourceWithTask = TaskResourceRow & {
     task: { id: string; title: string | null; root_id: string | null } | null;
 };
 
+// ----------------------------------------------------------------------------
+// Comments (Wave 26)
+// ----------------------------------------------------------------------------
+export type TaskCommentRow    = Database['public']['Tables']['task_comments']['Row'];
+export type TaskCommentInsert = Database['public']['Tables']['task_comments']['Insert'];
+export type TaskCommentUpdate = Database['public']['Tables']['task_comments']['Update'];
+
+/** Task comment row joined with author profile for UI rendering. */
+export type TaskCommentWithAuthor = TaskCommentRow & {
+    author: {
+        id: string;
+        email: string;
+        user_metadata?: UserMetadata;
+    } | null;
+};
+
 /** Standardized Person type for UI components */
 export interface Person extends PersonRow {
     notes: string | null;

--- a/src/shared/db/database.types.ts
+++ b/src/shared/db/database.types.ts
@@ -265,6 +265,48 @@ export type Database = {
  },
  ]
  }
+ task_comments: {
+ Row: {
+ id: string
+ task_id: string
+ root_id: string
+ parent_comment_id: string | null
+ author_id: string
+ body: string
+ mentions: string[]
+ created_at: string
+ updated_at: string
+ edited_at: string | null
+ deleted_at: string | null
+ }
+ Insert: {
+ id?: string
+ task_id: string
+ root_id?: string
+ parent_comment_id?: string | null
+ author_id: string
+ body: string
+ mentions?: string[]
+ created_at?: string
+ updated_at?: string
+ edited_at?: string | null
+ deleted_at?: string | null
+ }
+ Update: {
+ id?: string
+ task_id?: string
+ root_id?: string
+ parent_comment_id?: string | null
+ author_id?: string
+ body?: string
+ mentions?: string[]
+ created_at?: string
+ updated_at?: string
+ edited_at?: string | null
+ deleted_at?: string | null
+ }
+ Relationships: []
+ }
  task_relationships: {
  Row: {
  created_at: string | null

--- a/src/shared/db/database.types.ts
+++ b/src/shared/db/database.types.ts
@@ -305,7 +305,57 @@ export type Database = {
  edited_at?: string | null
  deleted_at?: string | null
  }
- Relationships: []
+ Relationships: [
+ {
+ foreignKeyName: "task_comments_task_id_fkey"
+ columns: ["task_id"]
+ isOneToOne: false
+ referencedRelation: "tasks"
+ referencedColumns: ["id"]
+ },
+ {
+ foreignKeyName: "task_comments_task_id_fkey"
+ columns: ["task_id"]
+ isOneToOne: false
+ referencedRelation: "tasks_with_primary_resource"
+ referencedColumns: ["id"]
+ },
+ {
+ foreignKeyName: "task_comments_task_id_fkey"
+ columns: ["task_id"]
+ isOneToOne: false
+ referencedRelation: "view_master_library"
+ referencedColumns: ["id"]
+ },
+ {
+ foreignKeyName: "task_comments_root_id_fkey"
+ columns: ["root_id"]
+ isOneToOne: false
+ referencedRelation: "tasks"
+ referencedColumns: ["id"]
+ },
+ {
+ foreignKeyName: "task_comments_root_id_fkey"
+ columns: ["root_id"]
+ isOneToOne: false
+ referencedRelation: "tasks_with_primary_resource"
+ referencedColumns: ["id"]
+ },
+ {
+ foreignKeyName: "task_comments_root_id_fkey"
+ columns: ["root_id"]
+ isOneToOne: false
+ referencedRelation: "view_master_library"
+ referencedColumns: ["id"]
+ },
+ {
+ foreignKeyName: "task_comments_parent_comment_id_fkey"
+ columns: ["parent_comment_id"]
+ isOneToOne: false
+ referencedRelation: "task_comments"
+ referencedColumns: ["id"]
+ },
+ ]
  }
  task_relationships: {
  Row: {


### PR DESCRIPTION
## Summary

Wave 26 Task 1 of 3 — the schema half of the §3.3 Collaboration Suite. Adds the `public.task_comments` table with threading, soft-delete, per-project-membership RLS, and a realtime publication add. No application code touches this data yet (Task 2 ships the `planterClient` entity + UI; Task 3 wires the realtime channel).

## Migration

`docs/db/migrations/2026_04_18_task_comments.sql` (additive, revert path in header):

- **Table** `public.task_comments`: `task_id` / `root_id` / `parent_comment_id` (self-FK), `author_id`, `body` (CHECK `length(trim(body)) BETWEEN 1 AND 10000`), `mentions text[]`, `created_at` / `updated_at` / `edited_at` / `deleted_at`. Threading is unbounded at the DB layer; the UI in Task 2 enforces a 1-level nest with chain-lift.
- **Indexes** (3): `(task_id, created_at DESC)`, `(root_id, created_at DESC)`, `(parent_comment_id) WHERE NOT NULL`.
- **Triggers** (2): `trg_task_comments_set_root_id` BEFORE INSERT mirrors `set_root_id_from_parent`; `trg_task_comments_handle_updated_at` reuses the shared helper.
- **Function** `set_task_comments_root_id()` (SECURITY DEFINER, `search_path = ''`): looks up `COALESCE(t.root_id, t.id)` from the parent task; raises if the parent task is missing.
- **RLS**:
  - SELECT — project member via `is_active_member(root_id, auth.uid())` or admin.
  - INSERT — project member; `author_id = auth.uid()` pinned via WITH CHECK.
  - UPDATE — author on undeleted rows; `task_id` / `root_id` / `parent_comment_id` / `author_id` immutable via WITH CHECK subqueries.
  - DELETE — author, project owner (`check_project_ownership_by_role`), or admin. Soft-delete preferred.
- **Publication**: `ALTER PUBLICATION supabase_realtime ADD TABLE public.task_comments;` (required by Task 3's per-task channel).

## Schema mirror

Every object mirrored into `docs/db/schema.sql`: table, owner, indexes, function + owner, triggers, FKs (4: `task_id`, `root_id`, `parent_comment_id`, `author_id`), RLS enable, 4 policies, publication ADD, REVOKE/GRANT on the function.

## Types

- `src/shared/db/database.types.ts` — hand-added `task_comments` block under `Database['public']['Tables']` (Wave 23/24/25 precedent — do not run `generate:types`, would overwrite).
- `src/shared/db/app.types.ts` — `TaskCommentRow` / `Insert` / `Update` + `TaskCommentWithAuthor` (nested `author: { id, email, user_metadata }`) appended after the `TaskResource` block.

## Architecture docs

- `docs/architecture/tasks-subtasks.md` — new `## Comments (Wave 26)` section (between Strategy Templates and Integration Points) covering table shape, soft-delete contract, RLS summary, realtime scoping.
- `docs/architecture/auth-rbac.md` — one-line cross-ref in the Resolved section.

## Manual RLS smoke

`docs/db/tests/task_comments_rls.sql` covers 18 branches via `DO $$ ASSERT` blocks:
1. `set_task_comments_root_id` on leaf task → root_id auto-fill.
2. Same on phase row.
3-7. SELECT visibility for owner / editor / viewer / non-member / admin.
8. INSERT by viewer (project member) succeeds.
9. INSERT by non-member blocked.
10. Author-id spoof blocked via WITH CHECK.
11. UPDATE by author on own row succeeds.
12. UPDATE by non-author silently no-ops (0 rows).
13. UPDATE mutating immutable `task_id` raises.
14. Soft-delete (UPDATE `deleted_at` + body='') succeeds.
15. UPDATE on soft-deleted row no-ops (policy requires `deleted_at IS NULL`).
16. DELETE by non-author non-owner no-ops.
17. DELETE by project owner succeeds.
18. DELETE by admin succeeds.

Invocation: `psql "$SUPABASE_DB_URL" -f docs/db/tests/task_comments_rls.sql`. Runs inside `BEGIN; ... ROLLBACK;` so there's no residue.

## Verification

```
npm test      → 577 passed (577)
npm run build → ✓ built in 539ms
npm run lint  → ✖ 4 problems (0 errors, 4 warnings)  # under wave baseline of 7
```

## Out of scope (other tasks)

- `planter.entities.TaskComment.*` + `<TaskComments>` UI + `useTaskComments` hook — **Task 2**.
- `useTaskCommentsRealtime` hook + `<TaskComments>` wiring — **Task 3**.
- Mention resolution to `auth.users` rows — **Wave 30**.
- Markdown rendering, reactions, attachments — **not planned**.

## Test plan

- [x] Migration applies cleanly on a fresh local Supabase (verify via `supabase db reset` or psql).
- [x] `\d public.task_comments` shows the table + 3 indexes; `\dp public.task_comments` shows 4 policies.
- [x] `SELECT 1 FROM pg_publication_tables WHERE pubname='supabase_realtime' AND tablename='task_comments'` returns one row.
- [x] `psql "$SUPABASE_DB_URL" -f docs/db/tests/task_comments_rls.sql` runs with every DO block succeeding.
- [ ] Reviewer: spot-check that `WITH CHECK` subqueries in the UPDATE policy actually work — the subquery references `task_comments_1` alias to dodge the implicit `task_comments` row-context name collision. Mirror commit uses the same alias.