### PR TITLE
feat(wave-29): checkpoint project kind + sequential phase unlock + donut visualization

### DIFF
--- a/Testing/unit/features/projects/components/EditProjectModal.kind.test.tsx
+++ b/Testing/unit/features/projects/components/EditProjectModal.kind.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { makeTask } from '@test';
+import type { TaskRow } from '@/shared/db/app.types';
+
+const mockUpdateMutateAsync = vi.fn();
+const mockDeleteMutateAsync = vi.fn();
+const mockUpdateStatusMutateAsync = vi.fn();
+
+vi.mock('@/features/projects/hooks/useProjectMutations', () => ({
+    useUpdateProject: () => ({ mutateAsync: mockUpdateMutateAsync }),
+    useDeleteProject: () => ({ mutateAsync: mockDeleteMutateAsync }),
+    useUpdateProjectStatus: () => ({ mutateAsync: mockUpdateStatusMutateAsync, isPending: false }),
+}));
+
+vi.mock('sonner', () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/shared/api/planterClient', () => ({
+    default: { functions: { invoke: vi.fn() } },
+}));
+
+import EditProjectModal from '@/features/projects/components/EditProjectModal';
+
+function renderModal(project: TaskRow) {
+    const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={qc}>
+            <MemoryRouter>
+                <EditProjectModal project={project} isOpen={true} onClose={vi.fn()} />
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateMutateAsync.mockResolvedValue({ shiftedCount: 0 });
+    mockUpdateStatusMutateAsync.mockResolvedValue(undefined);
+});
+
+describe('EditProjectModal — project kind picker (Wave 29)', () => {
+    it('renders the kind RadioGroup for an instance root task', () => {
+        renderModal(
+            makeTask({
+                id: 'p1',
+                title: 'Instance Root',
+                parent_task_id: null,
+                origin: 'instance',
+                start_date: '2026-01-01',
+                settings: null,
+            }),
+        );
+        expect(screen.getByTestId('project-kind-section')).toBeInTheDocument();
+        expect(screen.getByLabelText(/date-driven/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/checkpoint-based/i)).toBeInTheDocument();
+    });
+
+    it('hides the kind picker for templates', () => {
+        renderModal(
+            makeTask({
+                id: 't1',
+                title: 'Template',
+                parent_task_id: null,
+                origin: 'template',
+                start_date: '2026-01-01',
+                settings: null,
+            }),
+        );
+        expect(screen.queryByTestId('project-kind-section')).toBeNull();
+    });
+
+    it('submits with settings.project_kind = "checkpoint" after the user picks checkpoint', async () => {
+        renderModal(
+            makeTask({
+                id: 'p1',
+                title: 'Instance Root',
+                parent_task_id: null,
+                origin: 'instance',
+                start_date: '2026-01-01',
+                settings: null,
+            }),
+        );
+
+        fireEvent.click(screen.getByLabelText(/checkpoint-based/i));
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+        });
+
+        await waitFor(() => {
+            expect(mockUpdateMutateAsync).toHaveBeenCalled();
+        });
+        const payload = mockUpdateMutateAsync.mock.calls[0][0];
+        const settings = (payload.updates as { settings: Record<string, unknown> }).settings;
+        expect(settings.project_kind).toBe('checkpoint');
+    });
+
+    it('opens the confirmation dialog when switching from checkpoint back to date', () => {
+        renderModal(
+            makeTask({
+                id: 'p1',
+                title: 'Checkpoint Project',
+                parent_task_id: null,
+                origin: 'instance',
+                start_date: '2026-01-01',
+                settings: { project_kind: 'checkpoint' },
+            }),
+        );
+
+        fireEvent.click(screen.getByLabelText(/date-driven/i));
+        expect(screen.getByTestId('project-kind-revert-dialog')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /switch to date-driven/i })).toBeInTheDocument();
+    });
+
+    it('commits the revert to date after the user confirms', async () => {
+        renderModal(
+            makeTask({
+                id: 'p1',
+                title: 'Checkpoint Project',
+                parent_task_id: null,
+                origin: 'instance',
+                start_date: '2026-01-01',
+                settings: { project_kind: 'checkpoint' },
+            }),
+        );
+
+        fireEvent.click(screen.getByLabelText(/date-driven/i));
+        fireEvent.click(screen.getByRole('button', { name: /switch to date-driven/i }));
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+        });
+
+        await waitFor(() => expect(mockUpdateMutateAsync).toHaveBeenCalled());
+        const payload = mockUpdateMutateAsync.mock.calls[0][0];
+        const settings = (payload.updates as { settings: Record<string, unknown> }).settings;
+        expect(settings.project_kind).toBe('date');
+    });
+
+    it('keeps the kind as checkpoint when the user cancels the revert', () => {
+        renderModal(
+            makeTask({
+                id: 'p1',
+                title: 'Checkpoint Project',
+                parent_task_id: null,
+                origin: 'instance',
+                start_date: '2026-01-01',
+                settings: { project_kind: 'checkpoint' },
+            }),
+        );
+
+        fireEvent.click(screen.getByLabelText(/date-driven/i));
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+        // The checkpoint radio should still be checked
+        const checkpointRadio = screen.getByLabelText(/checkpoint-based/i);
+        expect(checkpointRadio).toBeChecked();
+    });
+});

--- a/Testing/unit/features/projects/components/PhaseCard.donut.test.tsx
+++ b/Testing/unit/features/projects/components/PhaseCard.donut.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { makeTask } from '@test';
+import PhaseCard from '@/features/projects/components/PhaseCard';
+
+// Stub recharts' ResponsiveContainer so jsdom (zero-size) renders the children.
+vi.mock('recharts', async () => {
+    const actual = await vi.importActual<typeof import('recharts')>('recharts');
+    return {
+        ...actual,
+        ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+            <div style={{ width: 64, height: 64 }}>{children}</div>
+        ),
+    };
+});
+
+describe('PhaseCard — checkpoint donut (Wave 29)', () => {
+    it('renders the progress bar (not the donut) for date-kind projects', () => {
+        const phase = makeTask({ id: 'ph1', title: 'Discovery', task_type: 'phase', parent_task_id: 'p1', position: 1 });
+        const root = makeTask({ id: 'p1', title: 'Date Project', parent_task_id: null, settings: null });
+        render(<PhaseCard phase={phase} tasks={[]} milestones={[]} rootTask={root} />);
+
+        expect(screen.queryByTestId('phase-donut')).toBeNull();
+        expect(screen.getByText(/progress/i)).toBeInTheDocument();
+    });
+
+    it('renders the donut for checkpoint-kind projects', () => {
+        const phase = makeTask({ id: 'ph1', title: 'Discovery', task_type: 'phase', parent_task_id: 'p1', position: 1 });
+        const root = makeTask({ id: 'p1', title: 'CP Project', parent_task_id: null, settings: { project_kind: 'checkpoint' } });
+        render(<PhaseCard phase={phase} tasks={[]} milestones={[]} rootTask={root} />);
+
+        expect(screen.getByTestId('phase-donut')).toBeInTheDocument();
+    });
+
+    it('shows "Locked" as the center label when the phase is_locked on a checkpoint project', () => {
+        const phase = makeTask({
+            id: 'ph2',
+            title: 'Implementation',
+            task_type: 'phase',
+            parent_task_id: 'p1',
+            position: 2,
+            is_locked: true,
+        });
+        const root = makeTask({ id: 'p1', title: 'CP Project', parent_task_id: null, settings: { project_kind: 'checkpoint' } });
+        render(<PhaseCard phase={phase} tasks={[]} milestones={[]} rootTask={root} />);
+
+        const donut = screen.getByTestId('phase-donut');
+        expect(donut).toHaveTextContent('Locked');
+    });
+
+    it('shows {progress}% as the center label when unlocked on a checkpoint project', () => {
+        const phase = makeTask({ id: 'ph1', title: 'Discovery', task_type: 'phase', parent_task_id: 'p1', position: 1 });
+        const root = makeTask({ id: 'p1', title: 'CP Project', parent_task_id: null, settings: { project_kind: 'checkpoint' } });
+        render(<PhaseCard phase={phase} tasks={[]} milestones={[]} rootTask={root} />);
+
+        const donut = screen.getByTestId('phase-donut');
+        // 0/0 tasks → 0%
+        expect(donut).toHaveTextContent('0%');
+    });
+});

--- a/Testing/unit/features/projects/lib/project-kind.test.ts
+++ b/Testing/unit/features/projects/lib/project-kind.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+    applyProjectKind,
+    extractProjectKind,
+    formDataToProjectKind,
+} from '@/features/projects/lib/project-kind';
+
+describe('extractProjectKind (Wave 29)', () => {
+    it('defaults to date when settings is null', () => {
+        expect(extractProjectKind(null)).toBe('date');
+    });
+
+    it('defaults to date when settings is undefined', () => {
+        expect(extractProjectKind(undefined)).toBe('date');
+    });
+
+    it('defaults to date when settings is present but key is absent', () => {
+        expect(extractProjectKind({ settings: { published: true } })).toBe('date');
+    });
+
+    it('returns checkpoint when settings.project_kind = "checkpoint"', () => {
+        expect(extractProjectKind({ settings: { project_kind: 'checkpoint' } })).toBe('checkpoint');
+    });
+
+    it('returns date when settings.project_kind = "date"', () => {
+        expect(extractProjectKind({ settings: { project_kind: 'date' } })).toBe('date');
+    });
+
+    it('falls back to date for unrecognised values', () => {
+        expect(extractProjectKind({ settings: { project_kind: 'foo' } })).toBe('date');
+    });
+
+    it('safely handles array-shaped settings', () => {
+        expect(extractProjectKind({ settings: [] as unknown as Record<string, unknown> })).toBe('date');
+    });
+});
+
+describe('formDataToProjectKind (Wave 29)', () => {
+    it('returns null when the field is absent', () => {
+        expect(formDataToProjectKind({})).toBe(null);
+    });
+
+    it('returns checkpoint for checkpoint', () => {
+        expect(formDataToProjectKind({ project_kind: 'checkpoint' })).toBe('checkpoint');
+    });
+
+    it('returns date for date', () => {
+        expect(formDataToProjectKind({ project_kind: 'date' })).toBe('date');
+    });
+});
+
+describe('applyProjectKind (Wave 29)', () => {
+    it('merges the kind into existing settings, preserving other keys', () => {
+        const merged = applyProjectKind({ published: true, due_soon_threshold: 5 }, 'checkpoint');
+        expect(merged).toEqual({ published: true, due_soon_threshold: 5, project_kind: 'checkpoint' });
+    });
+
+    it('returns the existing settings untouched when kind is null', () => {
+        const merged = applyProjectKind({ published: true }, null);
+        expect(merged).toEqual({ published: true });
+    });
+
+    it('returns undefined when there is nothing to persist (no kind, no settings)', () => {
+        expect(applyProjectKind(null, null)).toBeUndefined();
+        expect(applyProjectKind(undefined, null)).toBeUndefined();
+        expect(applyProjectKind({}, null)).toBeUndefined();
+    });
+
+    it('writes project_kind onto empty settings', () => {
+        expect(applyProjectKind(null, 'date')).toEqual({ project_kind: 'date' });
+    });
+
+    it('safely handles array-shaped input by starting fresh', () => {
+        const merged = applyProjectKind([] as unknown as Record<string, unknown>, 'checkpoint');
+        expect(merged).toEqual({ project_kind: 'checkpoint' });
+    });
+});

--- a/Testing/unit/shared/lib/date-engine/checkpoint.test.ts
+++ b/Testing/unit/shared/lib/date-engine/checkpoint.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isCheckpointProject,
+    deriveUrgencyForProject,
+    recalculateProjectDates,
+    type DateEngineTask,
+} from '@/shared/lib/date-engine';
+
+describe('isCheckpointProject (Wave 29)', () => {
+    it('returns false for null / undefined', () => {
+        expect(isCheckpointProject(null)).toBe(false);
+        expect(isCheckpointProject(undefined)).toBe(false);
+    });
+
+    it('returns false for a non-root task even when kind is checkpoint', () => {
+        expect(isCheckpointProject({ parent_task_id: 'p1', settings: { project_kind: 'checkpoint' } })).toBe(false);
+    });
+
+    it('returns true for a root task with settings.project_kind = checkpoint', () => {
+        expect(isCheckpointProject({ parent_task_id: null, settings: { project_kind: 'checkpoint' } })).toBe(true);
+    });
+
+    it('returns false for a root task without the settings key', () => {
+        expect(isCheckpointProject({ parent_task_id: null, settings: {} })).toBe(false);
+        expect(isCheckpointProject({ parent_task_id: null, settings: null })).toBe(false);
+    });
+
+    it('returns false for a root task with explicit date kind', () => {
+        expect(isCheckpointProject({ parent_task_id: null, settings: { project_kind: 'date' } })).toBe(false);
+    });
+});
+
+describe('recalculateProjectDates — checkpoint carve-out (Wave 29)', () => {
+    it('returns [] when the project root is a checkpoint project', () => {
+        const tasks: DateEngineTask[] = [
+            { id: 'root', parent_task_id: null, start_date: '2026-01-01', settings: { project_kind: 'checkpoint' } } as DateEngineTask,
+            { id: 't1', parent_task_id: 'root', start_date: '2026-01-10', due_date: '2026-01-15' },
+        ];
+        const updates = recalculateProjectDates(tasks, '2026-02-01', '2026-01-01');
+        expect(updates).toEqual([]);
+    });
+
+    it('still shifts tasks for date-kind projects (regression guard)', () => {
+        const tasks: DateEngineTask[] = [
+            { id: 'root', parent_task_id: null, start_date: '2026-01-01' },
+            { id: 't1', parent_task_id: 'root', start_date: '2026-01-10', due_date: '2026-01-15' },
+        ];
+        const updates = recalculateProjectDates(tasks, '2026-02-01', '2026-01-01');
+        expect(updates.length).toBeGreaterThan(0);
+        expect(updates.map((u) => u.id)).toContain('t1');
+    });
+});
+
+describe('deriveUrgencyForProject (Wave 29)', () => {
+    const now = new Date('2026-04-19T12:00:00Z');
+
+    it('suppresses urgency to not_yet_due for checkpoint projects', () => {
+        const result = deriveUrgencyForProject(
+            { start_date: '2026-01-01', due_date: '2026-01-10', is_complete: false, status: 'todo' },
+            { parent_task_id: null, settings: { project_kind: 'checkpoint' } },
+            3,
+            now,
+        );
+        expect(result).toBe('not_yet_due');
+    });
+
+    it('returns null for completed tasks even in checkpoint projects', () => {
+        const result = deriveUrgencyForProject(
+            { start_date: '2026-01-01', due_date: '2026-01-10', is_complete: true, status: 'completed' },
+            { parent_task_id: null, settings: { project_kind: 'checkpoint' } },
+            3,
+            now,
+        );
+        expect(result).toBe(null);
+    });
+
+    it('falls through to deriveUrgency for date-kind projects', () => {
+        const result = deriveUrgencyForProject(
+            { start_date: '2026-01-01', due_date: '2026-01-10', is_complete: false, status: 'todo' },
+            { parent_task_id: null, settings: { project_kind: 'date' } },
+            3,
+            now,
+        );
+        expect(result).toBe('overdue');
+    });
+
+    it('falls through when rootTask is null/undefined (backward compat)', () => {
+        const result = deriveUrgencyForProject(
+            { start_date: '2026-01-01', due_date: '2026-01-10', is_complete: false, status: 'todo' },
+            null,
+            3,
+            now,
+        );
+        expect(result).toBe('overdue');
+    });
+});

--- a/docs/db/migrations/2026_04_18_project_kind.sql
+++ b/docs/db/migrations/2026_04_18_project_kind.sql
@@ -1,0 +1,21 @@
+-- Migration: Wave 29 — project_kind (checkpoint vs date) discriminator on root tasks
+-- Date: 2026-04-18
+-- Description:
+--   Adds an additive CHECK constraint that gates settings->>'project_kind' to the
+--   two-value vocabulary on root tasks (parent_task_id IS NULL). Non-root tasks
+--   are unaffected. Absence of the key (the default for every existing project)
+--   means 'date' — backfill is a no-op, no UPDATE statement.
+--
+--   The kind toggle lives in EditProjectModal; the date-engine and nightly-sync
+--   short-circuit checkpoint projects (see src/shared/lib/date-engine/index.ts
+--   and supabase/functions/nightly-sync/index.ts).
+--
+-- Revert path:
+--   ALTER TABLE public.tasks DROP CONSTRAINT IF EXISTS tasks_project_kind_check;
+
+ALTER TABLE public.tasks
+ADD CONSTRAINT tasks_project_kind_check CHECK (
+  parent_task_id IS NOT NULL
+  OR settings ->> 'project_kind' IS NULL
+  OR settings ->> 'project_kind' IN ('date','checkpoint')
+);

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -1662,6 +1662,7 @@ CREATE TABLE IF NOT EXISTS "public"."tasks" (
     "settings" "jsonb" DEFAULT '{}'::"jsonb",
     "supervisor_email" "text",
     "task_type" "text",
+    CONSTRAINT "tasks_project_kind_check" CHECK ((("parent_task_id" IS NOT NULL) OR (("settings" ->> 'project_kind'::"text") IS NULL) OR (("settings" ->> 'project_kind'::"text") = ANY (ARRAY['date'::"text", 'checkpoint'::"text"])))),
     CONSTRAINT "tasks_project_type_check" CHECK (("project_type" = ANY (ARRAY['primary'::"text", 'secondary'::"text"]))),
     CONSTRAINT "tasks_root_id_required_for_children" CHECK ((("parent_task_id" IS NULL) OR ("root_id" IS NOT NULL))),
     CONSTRAINT "tasks_task_type_check" CHECK ((("task_type" IS NULL) OR ("task_type" = ANY (ARRAY['project'::"text", 'phase'::"text", 'milestone'::"text", 'task'::"text", 'subtask'::"text"]))))

--- a/docs/db/tests/checkpoint_kind.sql
+++ b/docs/db/tests/checkpoint_kind.sql
@@ -1,0 +1,38 @@
+-- EXPECT: 3 inserts succeed, 1 insert raises constraint violation
+--
+-- Wave 29: manual psql smoke for the tasks_project_kind_check constraint.
+-- Requires the migration 2026_04_18_project_kind.sql to have been applied.
+-- Run in a transaction so repeated execution is a no-op.
+
+BEGIN;
+
+-- 1. Root task with NO project_kind key — should succeed (defaults to date).
+INSERT INTO public.tasks (id, title, parent_task_id, origin, settings)
+VALUES (gen_random_uuid(), '[checkpoint_kind smoke] default-kind', NULL, 'instance', '{}'::jsonb);
+
+-- 2. Root task with explicit 'date' — should succeed.
+INSERT INTO public.tasks (id, title, parent_task_id, origin, settings)
+VALUES (gen_random_uuid(), '[checkpoint_kind smoke] explicit date', NULL, 'instance', '{"project_kind":"date"}'::jsonb);
+
+-- 3. Root task with explicit 'checkpoint' — should succeed.
+INSERT INTO public.tasks (id, title, parent_task_id, origin, settings)
+VALUES (gen_random_uuid(), '[checkpoint_kind smoke] explicit checkpoint', NULL, 'instance', '{"project_kind":"checkpoint"}'::jsonb);
+
+-- 4. Root task with invalid 'foo' — should FAIL with constraint violation.
+--    Wrap in a savepoint so the rollback doesn't abort the outer transaction.
+SAVEPOINT before_bad;
+DO $$
+BEGIN
+    INSERT INTO public.tasks (id, title, parent_task_id, origin, settings)
+    VALUES (gen_random_uuid(), '[checkpoint_kind smoke] invalid kind', NULL, 'instance', '{"project_kind":"foo"}'::jsonb);
+    RAISE EXCEPTION 'Expected constraint violation did NOT raise for project_kind=foo';
+EXCEPTION
+    WHEN check_violation THEN
+        RAISE NOTICE '[OK] constraint rejected project_kind=foo as expected';
+END $$;
+ROLLBACK TO SAVEPOINT before_bad;
+
+-- Clean up the three successful inserts.
+DELETE FROM public.tasks WHERE title LIKE '[checkpoint_kind smoke]%';
+
+COMMIT;

--- a/src/features/projects/components/EditProjectModal.tsx
+++ b/src/features/projects/components/EditProjectModal.tsx
@@ -398,7 +398,7 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
      <DialogTitle>Switch back to date-driven scheduling?</DialogTitle>
     </DialogHeader>
     <p className="text-sm text-slate-600">
-     Existing due dates will become active again. Tasks that are past due will appear as overdue. Locked phases stay locked until you toggle <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">is_locked</code> directly.
+     Existing due dates will become active again. Tasks that are past due will appear as overdue. Locked phases will remain locked until you manually unlock them.
     </p>
     <DialogFooter className="gap-2 sm:justify-end">
      <Button variant="outline" onClick={() => setPendingKindRevert(false)}>

--- a/src/features/projects/components/EditProjectModal.tsx
+++ b/src/features/projects/components/EditProjectModal.tsx
@@ -3,13 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/button';
 import { Label } from '@/shared/ui/label';
 import { Input } from '@/shared/ui/input';
 import { Textarea } from '@/shared/ui/textarea';
 import { Switch } from '@/shared/ui/switch';
+import { RadioGroup, RadioGroupItem } from '@/shared/ui/radio-group';
 import { useUpdateProject, useDeleteProject, useUpdateProjectStatus } from '@/features/projects/hooks/useProjectMutations';
+import { applyProjectKind, extractProjectKind, type ProjectKind } from '@/features/projects/lib/project-kind';
 import { toIsoDate } from '@/shared/lib/date-engine';
 import { PROJECT_STATUS } from '@/shared/constants/domain';
 import type { TaskRow } from '@/shared/db/app.types';
@@ -65,6 +67,10 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
  // The raw typed database row `settings` might be loose JSON, so explicitly cast what we expect internally
  const currentSettings = (project.settings as Record<string, unknown>) || {};
  const [isPublished, setIsPublished] = useState(currentSettings.published === true);
+ const [projectKind, setProjectKind] = useState<ProjectKind>(() => extractProjectKind(project));
+ const [pendingKindRevert, setPendingKindRevert] = useState(false);
+ const isRoot = project.parent_task_id === null || project.parent_task_id === undefined;
+ const isInstance = project.origin === 'instance';
 
  const [isSendingTest, setIsSendingTest] = useState(false);
 
@@ -121,15 +127,20 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
    const oldStartDate = toIsoDate(project.start_date || project.created_at);
    const { due_soon_threshold, due_date, supervisor_email, ...rest } = data;
 
+   const mergedSettings = {
+    ...currentSettings,
+    due_soon_threshold,
+    ...(isTemplate ? { published: isPublished } : {}),
+   };
+   const settingsWithKind = isRoot && isInstance
+    ? applyProjectKind(mergedSettings, projectKind) ?? mergedSettings
+    : mergedSettings;
+
    const updateData = {
     ...rest,
     due_date: due_date ? due_date : null,
     supervisor_email: supervisor_email ? supervisor_email : null,
-    settings: {
-     ...currentSettings,
-     due_soon_threshold,
-     ...(isTemplate ? { published: isPublished } : {}),
-    },
+    settings: settingsWithKind,
    };
 
    const result = await updateProjectMutation.mutateAsync({
@@ -150,6 +161,7 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
  };
 
  return (
+  <>
   <Dialog open={isOpen} onOpenChange={onClose}>
    <DialogContent data-testid="edit-project-modal" className="sm:max-w-[500px]">
     <DialogHeader>
@@ -234,6 +246,36 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
          checked={isPublished}
          onCheckedChange={setIsPublished}
         />
+       </div>
+      )}
+
+      {isRoot && isInstance && (
+       <div className="grid gap-2 py-2" data-testid="project-kind-section">
+        <Label className="font-medium">Project Type</Label>
+        <p className="text-xs text-slate-500">
+         Date-driven projects shift incomplete task dates when you change the launch date. Checkpoint projects unlock phases one at a time without date math.
+        </p>
+        <RadioGroup
+         value={projectKind}
+         onValueChange={(v) => {
+          const next = v as ProjectKind;
+          if (projectKind === 'checkpoint' && next === 'date') {
+           setPendingKindRevert(true);
+           return;
+          }
+          setProjectKind(next);
+         }}
+         className="flex flex-col gap-2"
+        >
+         <div className="flex items-center gap-2">
+          <RadioGroupItem value="date" id="kind-date" />
+          <Label htmlFor="kind-date" className="font-normal">Date-driven (default)</Label>
+         </div>
+         <div className="flex items-center gap-2">
+          <RadioGroupItem value="checkpoint" id="kind-checkpoint" />
+          <Label htmlFor="kind-checkpoint" className="font-normal">Checkpoint-based</Label>
+         </div>
+        </RadioGroup>
        </div>
       )}
      </div>
@@ -349,5 +391,31 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
     </div>
    </DialogContent>
   </Dialog>
+
+  <Dialog open={pendingKindRevert} onOpenChange={setPendingKindRevert}>
+   <DialogContent data-testid="project-kind-revert-dialog" className="sm:max-w-[440px]">
+    <DialogHeader>
+     <DialogTitle>Switch back to date-driven scheduling?</DialogTitle>
+    </DialogHeader>
+    <p className="text-sm text-slate-600">
+     Existing due dates will become active again. Tasks that are past due will appear as overdue. Locked phases stay locked until you toggle <code className="rounded bg-slate-100 px-1 py-0.5 text-xs">is_locked</code> directly.
+    </p>
+    <DialogFooter className="gap-2 sm:justify-end">
+     <Button variant="outline" onClick={() => setPendingKindRevert(false)}>
+      Cancel
+     </Button>
+     <Button
+      variant="destructive"
+      onClick={() => {
+       setProjectKind('date');
+       setPendingKindRevert(false);
+      }}
+     >
+      Switch to date-driven
+     </Button>
+    </DialogFooter>
+   </DialogContent>
+  </Dialog>
+  </>
  );
 }

--- a/src/features/projects/components/PhaseCard.tsx
+++ b/src/features/projects/components/PhaseCard.tsx
@@ -126,8 +126,8 @@ export default function PhaseCard({ phase, tasks = [], milestones = [], isActive
  dataKey="value"
  strokeWidth={0}
  >
- <Cell fill={totalTasks === 0 || isLocked ? '#e2e8f0' : 'hsl(19, 96%, 41%)'} />
- <Cell fill="#e2e8f0" />
+ <Cell fill={totalTasks === 0 || isLocked ? 'var(--color-slate-200)' : 'var(--color-brand-600)'} />
+ <Cell fill="var(--color-slate-200)" />
  </Pie>
  </PieChart>
  </ResponsiveContainer>

--- a/src/features/projects/components/PhaseCard.tsx
+++ b/src/features/projects/components/PhaseCard.tsx
@@ -1,11 +1,13 @@
 import { Card } from '@/shared/ui/card';
 import { Progress } from '@/shared/ui/progress';
+import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 
 import { ChevronRight, CheckCircle2, Lock } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { cn } from '@/shared/lib/utils';
 import { TASK_STATUS } from '@/shared/constants';
 import { PHASE_STATUS_COLORS } from '@/shared/constants/colors';
+import { extractProjectKind } from '@/features/projects/lib/project-kind';
 import type { TaskRow } from '@/shared/db/app.types';
 
 function getPhaseStatus(progress: number, totalTasks: number, phaseTasks: TaskRow[]): string {
@@ -26,9 +28,11 @@ interface PhaseCardProps {
  milestones?: TaskRow[];
  isActive?: boolean;
  onClick?: () => void;
+ /** Wave 29: the project root; when `settings.project_kind === 'checkpoint'` the progress bar swaps to a donut. */
+ rootTask?: TaskRow | null;
 }
 
-export default function PhaseCard({ phase, tasks = [], milestones = [], isActive, onClick }: PhaseCardProps) {
+export default function PhaseCard({ phase, tasks = [], milestones = [], isActive, onClick, rootTask }: PhaseCardProps) {
  const order = phase.position || 1;
  const isLocked = phase.is_locked;
 
@@ -43,6 +47,11 @@ export default function PhaseCard({ phase, tasks = [], milestones = [], isActive
  const isComplete = progress === 100 && totalTasks > 0;
  const phaseStatus = getPhaseStatus(progress, totalTasks, phaseTasks);
  const colors = PHASE_STATUS_COLORS[phaseStatus] || PHASE_STATUS_COLORS.not_started;
+ const isCheckpoint = extractProjectKind(rootTask) === 'checkpoint';
+ const donutData = [
+  { name: 'Completed', value: completedTasks },
+  { name: 'Remaining', value: Math.max(0, totalTasks - completedTasks) },
+ ];
 
  return (
  <motion.div whileHover={{ scale: isLocked ? 1 : 1.02 }} whileTap={{ scale: isLocked ? 1 : 0.98 }} className="h-full">
@@ -101,7 +110,38 @@ export default function PhaseCard({ phase, tasks = [], milestones = [], isActive
  </div>
 
  <div className="space-y-2">
- {isLocked ? (
+ {isCheckpoint ? (
+ <div className="flex items-center justify-between gap-3" data-testid="phase-donut">
+ <div className="relative h-16 w-16">
+ <ResponsiveContainer width="100%" height="100%">
+ <PieChart>
+ <Pie
+ data={donutData}
+ cx="50%"
+ cy="50%"
+ innerRadius={18}
+ outerRadius={30}
+ startAngle={90}
+ endAngle={-270}
+ dataKey="value"
+ strokeWidth={0}
+ >
+ <Cell fill={totalTasks === 0 || isLocked ? '#e2e8f0' : 'hsl(19, 96%, 41%)'} />
+ <Cell fill="#e2e8f0" />
+ </Pie>
+ </PieChart>
+ </ResponsiveContainer>
+ <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs font-medium text-slate-900">
+ {isLocked ? 'Locked' : `${progress}%`}
+ </div>
+ </div>
+ <p className="text-xs text-slate-600">
+ {isLocked
+  ? `Complete Phase ${order - 1} to unlock`
+  : `${completedTasks} of ${totalTasks} tasks`}
+ </p>
+ </div>
+ ) : isLocked ? (
  <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted p-2 rounded justify-center">
  <Lock className="w-3 h-3" />
  <span>Complete Phase {order - 1} to unlock</span>

--- a/src/features/projects/lib/project-kind.ts
+++ b/src/features/projects/lib/project-kind.ts
@@ -1,0 +1,54 @@
+import type { TaskRow } from '@/shared/db/app.types';
+
+export type ProjectKind = 'date' | 'checkpoint';
+
+/**
+ * Reads the project kind from a root task's `settings` JSONB. Defaults to
+ * `'date'` when the key is absent, null, or any non-recognised value, so
+ * every pre-Wave-29 project keeps its original behaviour.
+ *
+ * @param rootTask - Root task (or undefined/null) whose settings carry the kind.
+ * @returns The project kind — either 'date' (default) or 'checkpoint'.
+ */
+export function extractProjectKind(
+    rootTask: Pick<TaskRow, 'settings'> | null | undefined,
+): ProjectKind {
+    const settings = rootTask?.settings;
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return 'date';
+    const raw = (settings as Record<string, unknown>).project_kind;
+    return raw === 'checkpoint' ? 'checkpoint' : 'date';
+}
+
+/**
+ * Normalises a form's `project_kind` field into the settings shape.
+ * Returns `null` when the form did not include the field (no change).
+ *
+ * @param data - Form data (arbitrary shape) that may contain a `project_kind`.
+ * @returns The normalised kind, or `null` to leave settings untouched.
+ */
+export function formDataToProjectKind(data: { project_kind?: ProjectKind }): ProjectKind | null {
+    if (data.project_kind === 'checkpoint' || data.project_kind === 'date') return data.project_kind;
+    return null;
+}
+
+/**
+ * Merges a project kind into the existing settings JSONB, preserving all other
+ * keys. Pass `null` to leave settings untouched.
+ *
+ * @param currentSettings - Existing settings JSONB on the root task.
+ * @param kind - Normalised project kind (see `formDataToProjectKind`), or null.
+ * @returns The merged settings patch, or the original settings when `kind === null`.
+ */
+export function applyProjectKind(
+    currentSettings: Record<string, unknown> | null | undefined,
+    kind: ProjectKind | null,
+): Record<string, unknown> | undefined {
+    const base =
+        currentSettings && typeof currentSettings === 'object' && !Array.isArray(currentSettings)
+            ? { ...currentSettings }
+            : {};
+    if (kind === null) {
+        return Object.keys(base).length > 0 ? base : undefined;
+    }
+    return { ...base, project_kind: kind };
+}

--- a/src/shared/db/app.types.ts
+++ b/src/shared/db/app.types.ts
@@ -168,6 +168,10 @@ export interface TaskSettings {
     is_coaching_task?: boolean;
     /** Wave 24: when true, completing this instance task opens a dialog offering Master Library follow-ups (cloned as siblings). */
     is_strategy_template?: boolean;
+    /** Wave 29: on root tasks only — selects the project type ('date' = date-driven scheduling, default; 'checkpoint' = sequential phase-unlock). */
+    project_kind?: 'date' | 'checkpoint';
+    /** Wave 29: on phase/milestone rows — user ids designated as Phase Leads; consumed by the `user_is_phase_lead` RLS helper. */
+    phase_lead_user_ids?: string[];
 }
 
 // ----------------------------------------------------------------------------

--- a/src/shared/lib/date-engine/index.ts
+++ b/src/shared/lib/date-engine/index.ts
@@ -326,6 +326,10 @@ export const recalculateProjectDates = (
 ): DateUpdateRecord[] => {
  if (!projectTasks || !newStartDateStr || !oldStartDateStr) return [];
 
+ // Wave 29: checkpoint projects don't bulk-shift on start-date changes.
+ const root = projectTasks.find((t) => !t.parent_task_id);
+ if (isCheckpointProject(root)) return [];
+
  const oldIso = toIsoDate(oldStartDateStr);
  const newIso = toIsoDate(newStartDateStr);
  if (!oldIso || !newIso) return [];
@@ -434,4 +438,63 @@ export const deriveUrgency = (
  }
 
  return 'current';
+};
+
+// ---------------------------------------------------------------------------
+// Wave 29 — Checkpoint project kind (project-type discriminator)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal shape used by `isCheckpointProject`. Accepts any task-like object
+ * with an optional settings JSONB; the only keys read are `parent_task_id`
+ * and `settings.project_kind`.
+ */
+export interface CheckpointRootLike {
+ parent_task_id?: string | null;
+ settings?: Record<string, unknown> | null;
+}
+
+/**
+ * True when a task's settings indicate a checkpoint-kind project. Safe on
+ * non-root tasks (always false because only the root carries the kind) and
+ * on null / undefined. Defaults to date-driven when the settings key is absent,
+ * so every pre-Wave-29 project is unaffected.
+ *
+ * MUST stay byte-equivalent with the Deno mirror at
+ * `supabase/functions/_shared/date.ts`. Lock-step convention per Wave 21
+ * recurrence helpers.
+ *
+ * @param rootTask - A task-like object (or null) to inspect. Only `parent_task_id` and `settings.project_kind` are read.
+ * @returns `true` iff the input is a root task with `settings.project_kind === 'checkpoint'`.
+ */
+export function isCheckpointProject(rootTask: CheckpointRootLike | null | undefined): boolean {
+ if (!rootTask) return false;
+ if (rootTask.parent_task_id) return false;
+ const settings = rootTask.settings;
+ if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false;
+ return (settings as Record<string, unknown>).project_kind === 'checkpoint';
+}
+
+/**
+ * Wrapper around `deriveUrgency` that accepts the task's project root and
+ * short-circuits to `'not_yet_due'` for any non-completed task in a
+ * checkpoint project. Date-kind projects (the default) fall through to the
+ * existing branch logic unchanged — so this wrapper is signature-compatible
+ * with `deriveUrgency` plus one extra optional positional argument.
+ *
+ * @param task - Task whose urgency is being derived (same shape as `deriveUrgency`).
+ * @param rootTask - The project root (or null). When checkpoint, urgency is suppressed.
+ * @param dueSoonThresholdDays - Threshold for the `due_soon` branch.
+ * @param now - Injected `now` for testability.
+ * @returns Urgency label, or `null` when suppressed by completion / missing dates.
+ */
+export const deriveUrgencyForProject = (
+ task: Pick<DateEngineTask, 'start_date' | 'due_date' | 'is_complete' | 'status'>,
+ rootTask: CheckpointRootLike | null | undefined,
+ dueSoonThresholdDays: number,
+ now: Date = new Date(),
+): TaskUrgency | null => {
+ if (task.is_complete || task.status === 'completed') return null;
+ if (isCheckpointProject(rootTask)) return 'not_yet_due';
+ return deriveUrgency(task, dueSoonThresholdDays, now);
 };

--- a/supabase/functions/_shared/date.ts
+++ b/supabase/functions/_shared/date.ts
@@ -32,3 +32,22 @@ export const dateStringToUtcMonthKey = (raw: string | null): string | null => {
     if (Number.isNaN(d.getTime())) return null
     return toUtcMonthKey(d)
 }
+
+// ---------------------------------------------------------------------------
+// Wave 29 — Checkpoint project kind (project-type discriminator)
+// Lock-step with src/shared/lib/date-engine/index.ts → isCheckpointProject.
+// Update both together.
+// ---------------------------------------------------------------------------
+
+export interface CheckpointRootLike {
+    parent_task_id?: string | null
+    settings?: Record<string, unknown> | null
+}
+
+export function isCheckpointProject(rootTask: CheckpointRootLike | null | undefined): boolean {
+    if (!rootTask) return false
+    if (rootTask.parent_task_id) return false
+    const settings = rootTask.settings
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return false
+    return (settings as Record<string, unknown>).project_kind === 'checkpoint'
+}

--- a/supabase/functions/nightly-sync/index.ts
+++ b/supabase/functions/nightly-sync/index.ts
@@ -1,6 +1,6 @@
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { isRecurrenceRule, shouldFireRecurrenceOn, RecurrenceRule } from '../_shared/recurrence.ts'
-import { toUtcIsoDate } from '../_shared/date.ts'
+import { isCheckpointProject, toUtcIsoDate } from '../_shared/date.ts'
 
 const corsHeaders = {
     'Access-Control-Allow-Origin': '*',
@@ -35,25 +35,28 @@ interface SyncResult {
 }
 
 /**
- * Build a map of rootId → due_soon_threshold days by loading the project root
- * tasks referenced by `rootIds`. Falls back to DEFAULT_DUE_SOON_THRESHOLD_DAYS
- * for any root whose settings don't explicitly set a threshold.
+ * Build a map of rootId → due_soon_threshold days plus a set of rootIds whose
+ * settings identify them as checkpoint projects (Wave 29). Loads the root
+ * tasks referenced by `rootIds` in one query. Falls back to
+ * DEFAULT_DUE_SOON_THRESHOLD_DAYS for any root whose settings don't set a
+ * threshold.
  */
-async function loadThresholds(
+async function loadRootInfo(
     supabase: SupabaseClient,
     rootIds: string[],
-): Promise<Map<string, number>> {
+): Promise<{ thresholds: Map<string, number>; checkpointRoots: Set<string> }> {
     const unique = Array.from(new Set(rootIds.filter(Boolean)))
-    const map = new Map<string, number>()
-    if (unique.length === 0) return map
+    const thresholds = new Map<string, number>()
+    const checkpointRoots = new Set<string>()
+    if (unique.length === 0) return { thresholds, checkpointRoots }
 
     const { data, error } = await supabase
         .from('tasks')
-        .select('id, settings')
+        .select('id, parent_task_id, settings')
         .in('id', unique)
     if (error) throw error
 
-    for (const row of (data ?? []) as Array<{ id: string; settings: Record<string, unknown> | null }>) {
+    for (const row of (data ?? []) as Array<{ id: string; parent_task_id: string | null; settings: Record<string, unknown> | null }>) {
         let threshold = DEFAULT_DUE_SOON_THRESHOLD_DAYS
         const s = row.settings
         if (s && typeof s === 'object' && !Array.isArray(s)) {
@@ -61,9 +64,10 @@ async function loadThresholds(
             const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN
             if (Number.isFinite(n) && n >= 0) threshold = Math.floor(n)
         }
-        map.set(row.id, threshold)
+        thresholds.set(row.id, threshold)
+        if (isCheckpointProject(row)) checkpointRoots.add(row.id)
     }
-    return map
+    return { thresholds, checkpointRoots }
 }
 
 /**
@@ -181,38 +185,52 @@ Deno.serve(async (req) => {
         const nowIso = new Date().toISOString()
 
         // 1. Transition past-due, incomplete tasks to 'overdue'.
-        const { data: overdueRows, error: overdueErr } = await supabase
+        //    Select candidates first so we can filter out tasks in checkpoint projects
+        //    (Wave 29: those project kinds treat due_dates as informational only).
+        const { data: overdueCandidates, error: overdueCandErr } = await supabase
             .from('tasks')
-            .update({ status: 'overdue', updated_at: nowIso })
+            .select('id, root_id')
             .lt('due_date', nowIso)
             .neq('status', 'completed')
             .neq('status', 'overdue')
             .eq('is_complete', false)
-            .select('id')
-        if (overdueErr) throw overdueErr
+        if (overdueCandErr) throw overdueCandErr
 
-        const overdueIds = (overdueRows ?? []).map((r: { id: string }) => r.id)
-
-        // 2. Transition tasks due within their project's due_soon threshold to 'due_soon'.
-        //    Candidate set: not complete, due_date >= now, status not already terminal/overdue/due_soon.
-        const { data: candidates, error: candErr } = await supabase
+        // 2. Pre-fetch candidates for the due_soon pass so we can load root info once
+        //    covering BOTH passes.
+        const { data: dueSoonCandidates, error: dueSoonCandErr } = await supabase
             .from('tasks')
             .select('id, root_id, due_date, status, is_complete, settings')
             .gte('due_date', nowIso)
             .eq('is_complete', false)
             .not('status', 'in', '("completed","overdue","due_soon")')
-        if (candErr) throw candErr
+        if (dueSoonCandErr) throw dueSoonCandErr
 
-        const candidateRows = (candidates ?? []) as TaskRow[]
-        const rootIds = candidateRows
-            .map((r) => r.root_id)
-            .filter((v): v is string => typeof v === 'string' && v.length > 0)
-        const thresholds = await loadThresholds(supabase, rootIds)
+        const overdueCandRows = (overdueCandidates ?? []) as Array<{ id: string; root_id: string | null }>
+        const dueSoonCandRows = (dueSoonCandidates ?? []) as TaskRow[]
+        const rootIds = [
+            ...overdueCandRows.map((r) => r.root_id),
+            ...dueSoonCandRows.map((r) => r.root_id),
+        ].filter((v): v is string => typeof v === 'string' && v.length > 0)
+        const { thresholds, checkpointRoots } = await loadRootInfo(supabase, rootIds)
+
+        const overdueIds = overdueCandRows
+            .filter((r) => !(r.root_id && checkpointRoots.has(r.root_id)))
+            .map((r) => r.id)
+
+        if (overdueIds.length > 0) {
+            const { error: overdueUpdateErr } = await supabase
+                .from('tasks')
+                .update({ status: 'overdue', updated_at: nowIso })
+                .in('id', overdueIds)
+            if (overdueUpdateErr) throw overdueUpdateErr
+        }
 
         const nowMs = new Date(nowIso).getTime()
         const dueSoonIds: string[] = []
-        for (const row of candidateRows) {
+        for (const row of dueSoonCandRows) {
             if (!row.due_date) continue
+            if (row.root_id && checkpointRoots.has(row.root_id)) continue
             const threshold = row.root_id
                 ? thresholds.get(row.root_id) ?? DEFAULT_DUE_SOON_THRESHOLD_DAYS
                 : DEFAULT_DUE_SOON_THRESHOLD_DAYS

--- a/supabase/functions/nightly-sync/index.ts
+++ b/supabase/functions/nightly-sync/index.ts
@@ -197,17 +197,19 @@ Deno.serve(async (req) => {
         if (overdueCandErr) throw overdueCandErr
 
         // 2. Pre-fetch candidates for the due_soon pass so we can load root info once
-        //    covering BOTH passes.
+        //    covering BOTH passes. Checkpoint filtering is applied AFTER loadRootInfo
+        //    using each root's settings; the per-task `settings` column isn't needed.
         const { data: dueSoonCandidates, error: dueSoonCandErr } = await supabase
             .from('tasks')
-            .select('id, root_id, due_date, status, is_complete, settings')
+            .select('id, root_id, due_date, status, is_complete')
             .gte('due_date', nowIso)
             .eq('is_complete', false)
             .not('status', 'in', '("completed","overdue","due_soon")')
         if (dueSoonCandErr) throw dueSoonCandErr
 
+        type DueSoonCandidate = Omit<TaskRow, 'settings'>
         const overdueCandRows = (overdueCandidates ?? []) as Array<{ id: string; root_id: string | null }>
-        const dueSoonCandRows = (dueSoonCandidates ?? []) as TaskRow[]
+        const dueSoonCandRows = (dueSoonCandidates ?? []) as DueSoonCandidate[]
         const rootIds = [
             ...overdueCandRows.map((r) => r.root_id),
             ...dueSoonCandRows.map((r) => r.root_id),


### PR DESCRIPTION
## Summary
- **Project-kind discriminator.** `settings.project_kind: 'date' | 'checkpoint'` on root tasks, gated by an additive CHECK constraint `tasks_project_kind_check`. Absence defaults to `'date'` — every existing project is unaffected. Migration: `docs/db/migrations/2026_04_18_project_kind.sql`.
- **Date-engine carve-outs.** `isCheckpointProject(rootTask)` helper (lock-step with `supabase/functions/_shared/date.ts`). `recalculateProjectDates` early-returns on checkpoint root. NEW `deriveUrgencyForProject` wrapper (existing `deriveUrgency` signature untouched — backward-compatible).
- **Nightly-sync.** The overdue + due_soon urgency passes skip checkpoint roots via a single combined root-settings query (`loadRootInfo`). Recurrence pass is unaffected.
- **UI.** `EditProjectModal` renders a `<RadioGroup>` kind picker for instance root tasks; switching checkpoint → date opens a confirmation Dialog (reason: re-engaging dates may surface overdue tasks). `PhaseCard` swaps its progress bar for a recharts `<PieChart>` donut on checkpoint projects, with center label `Locked` when `phase.is_locked === true`.
- **Phase-unlock semantics unchanged.** The existing `check_phase_unlock` + `handle_phase_completion` triggers do the unlocking. This wave only gates the UX around the lock-state — it does not touch the triggers.
- **Helper trio.** `src/features/projects/lib/project-kind.ts` (`extractProjectKind`, `formDataToProjectKind`, `applyProjectKind`), mirrors the Wave 22 coaching/strategy helper-trio precedent.

## Test-count delta
69 test files (+4) / 703 tests (+36) — above plan target.

Verification gate (all green locally):
- `npm run lint` — 0 errors, 4 warnings (pre-existing baseline).
- `npm run build` — clean, no new chunks (gantt chunk unchanged at 42 kB).
- `npm test` — 703 passed.

## Out of scope (per wave plan)
- Auto-classifying existing projects as checkpoint.
- Cross-phase prerequisite chain editor UI.
- Fancy unlock animations.
- Phase Lead (Wave 29 Task 2 — next PR).

## Test plan
- [x] `npm run lint`, `npm run build`, `npm test` — all green.
- [x] `docs/db/tests/checkpoint_kind.sql` — psql smoke with savepoint-wrapped negative case.
- [ ] Manual: flip project to checkpoint → lock icons + donut appear on phases 2+.
- [ ] Manual: complete phase 1's tasks → existing `check_phase_unlock` trigger unlocks phase 2 → realtime refetch updates UI.
- [ ] Manual: flip back to date → confirmation dialog → submit → bars return.
- [ ] Manual: `supabase functions serve nightly-sync` against a checkpoint project → log shows 0 urgency transitions for its tasks.
- [ ] Eyeball-diff: `isCheckpointProject` bodies in `src/shared/lib/date-engine/index.ts` and `supabase/functions/_shared/date.ts` are byte-equivalent (both implemented fresh this wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)