### PR TITLE
feat(wave-30): notification_preferences + notification_log + Settings UI

### DIFF
--- a/Testing/setupTests.ts
+++ b/Testing/setupTests.ts
@@ -2,6 +2,14 @@ import '@testing-library/jest-dom';
 import { vi, beforeEach } from 'vitest';
 
 // Mocks for JSDOM
+// Wave 30: Radix Select / Popover uses ResizeObserver; jsdom doesn't ship it.
+class ResizeObserverStub {
+ observe(): void {}
+ unobserve(): void {}
+ disconnect(): void {}
+}
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver ??= ResizeObserverStub;
+
 Object.defineProperty(window, 'matchMedia', {
  writable: true,
  value: vi.fn().mockImplementation(query => ({

--- a/Testing/test-utils/factories.ts
+++ b/Testing/test-utils/factories.ts
@@ -1,5 +1,12 @@
 import { faker } from '@faker-js/faker';
-import type { TaskRow, TeamMemberRow, TaskCommentRow, TaskCommentWithAuthor } from '@/shared/db/app.types';
+import type {
+  TaskRow,
+  TeamMemberRow,
+  TaskCommentRow,
+  TaskCommentWithAuthor,
+  NotificationPreferencesRow,
+  NotificationLogRow,
+} from '@/shared/db/app.types';
 
 /**
  * Creates a minimal TaskRow stub with sensible defaults.
@@ -173,5 +180,36 @@ export function makePresenceState(overrides: Partial<PresenceState> = {}): Prese
     email: overrides.email ?? faker.internet.email(),
     joinedAt: overrides.joinedAt ?? Date.now(),
     focusedTaskId: overrides.focusedTaskId ?? null,
+  };
+}
+
+/** Wave 30: NotificationPreferencesRow stub with documented canonical defaults. */
+export function makeNotificationPref(overrides: Partial<NotificationPreferencesRow> = {}): NotificationPreferencesRow {
+  return {
+    user_id: overrides.user_id ?? faker.string.uuid(),
+    email_mentions: overrides.email_mentions ?? true,
+    email_overdue_digest: overrides.email_overdue_digest ?? 'daily',
+    email_assignment: overrides.email_assignment ?? true,
+    push_mentions: overrides.push_mentions ?? true,
+    push_overdue: overrides.push_overdue ?? true,
+    push_assignment: overrides.push_assignment ?? false,
+    quiet_hours_start: overrides.quiet_hours_start ?? null,
+    quiet_hours_end: overrides.quiet_hours_end ?? null,
+    timezone: overrides.timezone ?? 'UTC',
+    updated_at: overrides.updated_at ?? new Date().toISOString(),
+  };
+}
+
+/** Wave 30: NotificationLogRow stub. Defaults to an email mention send. */
+export function makeNotificationLogRow(overrides: Partial<NotificationLogRow> = {}): NotificationLogRow {
+  return {
+    id: overrides.id ?? faker.string.uuid(),
+    user_id: overrides.user_id ?? faker.string.uuid(),
+    channel: overrides.channel ?? 'email',
+    event_type: overrides.event_type ?? 'mention_pending',
+    payload: overrides.payload ?? {},
+    sent_at: overrides.sent_at ?? new Date().toISOString(),
+    provider_id: overrides.provider_id ?? null,
+    error: overrides.error ?? null,
   };
 }

--- a/Testing/test-utils/index.ts
+++ b/Testing/test-utils/index.ts
@@ -7,5 +7,7 @@ export {
   makeComment,
   makeCommentWithAuthor,
   makePresenceState,
+  makeNotificationPref,
+  makeNotificationLogRow,
 } from './factories';
 export type { PresenceState } from './factories';

--- a/Testing/unit/features/settings/hooks/useNotificationPreferences.test.tsx
+++ b/Testing/unit/features/settings/hooks/useNotificationPreferences.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { makeNotificationPref } from '@test';
+import type { ReactNode } from 'react';
+
+const mockGetPreferences = vi.fn();
+const mockUpdatePreferences = vi.fn();
+const mockListLog = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock('@/shared/api/planterClient', () => ({
+    planter: {
+        notifications: {
+            getPreferences: () => mockGetPreferences(),
+            updatePreferences: (patch: unknown) => mockUpdatePreferences(patch),
+            listLog: (opts: unknown) => mockListLog(opts),
+        },
+    },
+}));
+
+vi.mock('sonner', () => ({
+    toast: { error: (...args: unknown[]) => mockToastError(...args) },
+}));
+
+import {
+    useNotificationPreferences,
+    useUpdateNotificationPreferences,
+    useNotificationLog,
+} from '@/features/settings/hooks/useNotificationPreferences';
+
+function wrapper({ children }: { children: ReactNode }) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('useNotificationPreferences (Wave 30)', () => {
+    beforeEach(() => {
+        mockGetPreferences.mockReset();
+        mockUpdatePreferences.mockReset();
+        mockListLog.mockReset();
+        mockToastError.mockReset();
+    });
+
+    it('useNotificationPreferences surfaces the query result', async () => {
+        const row = makeNotificationPref();
+        mockGetPreferences.mockResolvedValue(row);
+        const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+        await waitFor(() => expect(result.current.data).toEqual(row));
+    });
+
+    it('useNotificationLog honors opts and returns rows', async () => {
+        mockListLog.mockResolvedValue([]);
+        const { result } = renderHook(() => useNotificationLog({ limit: 5 }), { wrapper });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+        expect(mockListLog).toHaveBeenCalledWith({ limit: 5 });
+    });
+
+    it('optimistically updates cache + toasts on rollback', async () => {
+        const initial = makeNotificationPref({ email_overdue_digest: 'daily' });
+        mockGetPreferences.mockResolvedValue(initial);
+        mockUpdatePreferences.mockRejectedValueOnce(new Error('boom'));
+
+        const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+        function Wrap({ children }: { children: ReactNode }) {
+            return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+        }
+
+        // Seed the cache with a successful read first.
+        const prefs = renderHook(() => useNotificationPreferences(), { wrapper: Wrap });
+        await waitFor(() => expect(prefs.result.current.data).toEqual(initial));
+
+        const mut = renderHook(() => useUpdateNotificationPreferences(), { wrapper: Wrap });
+        await mut.result.current.mutateAsync({ email_overdue_digest: 'weekly' }).catch(() => {});
+
+        await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+        // Cache eventually rolls back to the pre-mutation row via onError + invalidate.
+        await waitFor(() => {
+            const cur = qc.getQueryData(['notificationPreferences']);
+            expect(cur).toEqual(initial);
+        });
+    });
+});

--- a/Testing/unit/pages/Settings.notifications.test.tsx
+++ b/Testing/unit/pages/Settings.notifications.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { makeNotificationPref } from '@test';
+
+const mockPrefs = makeNotificationPref({ email_mentions: true, email_overdue_digest: 'daily' });
+const mockUpdatePatch = vi.fn();
+
+vi.mock('@/features/settings/hooks/useNotificationPreferences', () => ({
+    useNotificationPreferences: () => ({ data: mockPrefs, isLoading: false, isError: false }),
+    useUpdateNotificationPreferences: () => ({ mutate: mockUpdatePatch }),
+    useNotificationLog: () => ({ data: [], isLoading: false }),
+}));
+
+// The existing Settings page reads `useSettings`; stub it so we're not testing
+// the Profile/Security tabs here.
+vi.mock('@/features/settings/hooks/useSettings', () => ({
+    useSettings: () => ({
+        state: {
+            profile: { avatar_url: '', full_name: '', role: '', organization: '', email_frequency: 'never' },
+            loading: false,
+            avatarError: null,
+            passwordForm: { newPassword: '', confirmPassword: '' },
+            passwordError: null,
+            passwordLoading: false,
+        },
+        actions: {
+            setProfile: vi.fn(),
+            setPasswordForm: vi.fn(),
+            setPasswordError: vi.fn(),
+            handlePasswordChange: vi.fn(),
+        },
+    }),
+}));
+
+import Settings from '@/pages/Settings';
+
+function renderSettings() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    function Wrap({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={qc}>
+                <MemoryRouter>{children}</MemoryRouter>
+            </QueryClientProvider>
+        );
+    }
+    return render(
+        <Wrap>
+            <Settings />
+        </Wrap>,
+    );
+}
+
+describe('Settings — Notifications tab (Wave 30)', () => {
+    beforeEach(() => {
+        mockUpdatePatch.mockReset();
+    });
+
+    it('clicking the Notifications nav shows the tab body', async () => {
+        renderSettings();
+        fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+        await waitFor(() => {
+            expect(screen.getByTestId('settings-notifications')).toBeInTheDocument();
+        });
+    });
+
+    it('mutates when the user flips the Email Mentions switch', async () => {
+        renderSettings();
+        fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+        // Email/Push both label a row 'Mentions'; target by element id.
+        await screen.findByTestId('settings-notifications');
+        const emailMentions = document.getElementById('email-mentions') as HTMLButtonElement;
+        expect(emailMentions).toBeInTheDocument();
+        fireEvent.click(emailMentions);
+        expect(mockUpdatePatch).toHaveBeenCalledWith(
+            expect.objectContaining({ email_mentions: false }),
+        );
+    });
+
+    it('push toggles are disabled until browser push is enabled', async () => {
+        renderSettings();
+        fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+        await screen.findByTestId('settings-notifications');
+        const pushSwitch = document.getElementById('push-mentions') as HTMLButtonElement;
+        const emailSwitch = document.getElementById('email-mentions') as HTMLButtonElement;
+        expect(pushSwitch).toBeInTheDocument();
+        expect(pushSwitch).toBeDisabled();
+        expect(emailSwitch).not.toBeDisabled();
+    });
+
+    it('renders the disabled Enable browser push button with a Wave 30 Task 2 tooltip', async () => {
+        renderSettings();
+        fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+        const btn = await screen.findByTestId('enable-browser-push');
+        expect(btn).toBeDisabled();
+        expect(btn).toHaveAttribute('title', expect.stringMatching(/wave 30 task 2/i));
+    });
+});

--- a/Testing/unit/shared/api/planterClient.notifications.test.ts
+++ b/Testing/unit/shared/api/planterClient.notifications.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeNotificationPref, makeNotificationLogRow } from '@test';
+
+function createChain(resolvedValue: { data: unknown; error: unknown } = { data: null, error: null }) {
+    const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+    const methods = [
+        'select', 'insert', 'update', 'delete', 'upsert',
+        'eq', 'neq', 'is', 'in', 'lt', 'or', 'order', 'range', 'limit',
+        'maybeSingle', 'single', 'abortSignal',
+    ];
+    for (const m of methods) {
+        chain[m] = vi.fn().mockReturnValue(chain);
+    }
+    (chain as unknown as { then: (resolve: (v: unknown) => void) => void }).then = (resolve: (v: unknown) => void) =>
+        resolve(resolvedValue);
+    return chain;
+}
+
+const mockFrom = vi.fn();
+vi.mock('@/shared/db/client', () => ({
+    supabase: { from: (...args: unknown[]) => mockFrom(...args) },
+}));
+vi.mock('@/shared/lib/retry', () => ({ retry: (fn: () => unknown) => fn() }));
+vi.mock('@/shared/lib/date-engine', () => ({
+    toIsoDate: (v: unknown) => (v ? String(v) : null),
+    nowUtcIso: () => '2026-04-18T12:00:00.000Z',
+    calculateMinMaxDates: vi.fn().mockReturnValue({ start_date: null, due_date: null }),
+}));
+
+import { planter } from '@/shared/api/planterClient';
+
+describe('planter.notifications (Wave 30)', () => {
+    beforeEach(() => {
+        mockFrom.mockReset();
+    });
+
+    describe('getPreferences', () => {
+        it('reads the authenticated user row via RLS (no explicit filter)', async () => {
+            const row = makeNotificationPref();
+            const chain = createChain({ data: row, error: null });
+            mockFrom.mockReturnValue(chain);
+
+            const result = await planter.notifications.getPreferences();
+
+            expect(mockFrom).toHaveBeenCalledWith('notification_preferences');
+            expect(chain.select).toHaveBeenCalledWith('*');
+            expect(chain.maybeSingle).toHaveBeenCalled();
+            expect(result).toEqual(row);
+        });
+
+        it('throws when the row is missing (no bootstrap yet)', async () => {
+            const chain = createChain({ data: null, error: null });
+            mockFrom.mockReturnValue(chain);
+            await expect(planter.notifications.getPreferences()).rejects.toThrow(/missing/);
+        });
+    });
+
+    describe('updatePreferences', () => {
+        it('sends a partial patch and returns the updated row', async () => {
+            const updated = makeNotificationPref({ email_overdue_digest: 'weekly' });
+            const chain = createChain({ data: updated, error: null });
+            mockFrom.mockReturnValue(chain);
+
+            const result = await planter.notifications.updatePreferences({ email_overdue_digest: 'weekly' });
+
+            expect(mockFrom).toHaveBeenCalledWith('notification_preferences');
+            expect(chain.update).toHaveBeenCalledWith({ email_overdue_digest: 'weekly' });
+            expect(chain.single).toHaveBeenCalled();
+            expect(result).toEqual(updated);
+        });
+    });
+
+    describe('listLog', () => {
+        it('returns newest-first up to default 50 rows', async () => {
+            const rows = [makeNotificationLogRow(), makeNotificationLogRow()];
+            const chain = createChain({ data: rows, error: null });
+            mockFrom.mockReturnValue(chain);
+
+            const result = await planter.notifications.listLog();
+
+            expect(mockFrom).toHaveBeenCalledWith('notification_log');
+            expect(chain.order).toHaveBeenCalledWith('sent_at', { ascending: false });
+            expect(chain.limit).toHaveBeenCalledWith(50);
+            expect(result).toEqual(rows);
+        });
+
+        it('honors before + eventType filters', async () => {
+            const chain = createChain({ data: [], error: null });
+            mockFrom.mockReturnValue(chain);
+
+            await planter.notifications.listLog({ limit: 10, before: '2026-04-01T00:00:00Z', eventType: 'mention_pending' });
+
+            expect(chain.limit).toHaveBeenCalledWith(10);
+            expect(chain.lt).toHaveBeenCalledWith('sent_at', '2026-04-01T00:00:00Z');
+            expect(chain.eq).toHaveBeenCalledWith('event_type', 'mention_pending');
+        });
+    });
+});

--- a/docs/architecture/auth-rbac.md
+++ b/docs/architecture/auth-rbac.md
@@ -93,3 +93,15 @@ A project Owner may designate any `viewer` or `limited`-role member as the **Lea
 **UI** (`src/features/tasks/components/TaskFormFields.tsx`): the `<PhaseLeadPicker>` sub-component (multi-select popover) renders only for `membershipRole === 'owner'` on phase/milestone rows. Options come from `useTeam(projectId).teamMembers.filter(m => m.role === 'viewer' || m.role === 'limited')` — owners/editors/coaches/admins are NOT in the picker because they already have UPDATE via existing policies. Badge in `TaskDetailsView.tsx` lists current leads.
 
 **Permission matrix update**: limited viewers may now edit tasks under any phase/milestone they are designated as Phase Lead for. See the matrix footnote above.
+
+### Notification Preferences (Wave 30)
+
+Per-user `public.notification_preferences` row, bootstrapped by `trg_bootstrap_notification_prefs` AFTER INSERT on `auth.users`. Append-only `public.notification_log` audit trail captures every dispatch attempt (sent or skipped) for debugging, idempotency, and the user-visible "Recent notifications" section in Settings.
+
+**RLS**:
+* `notification_preferences`: SELECT/INSERT/UPDATE for `user_id = auth.uid()`. DELETE not exposed — UPDATE is the off-switch.
+* `notification_log`: SELECT for `user_id = auth.uid() OR is_admin(auth.uid())`. INSERT/UPDATE/DELETE denied at policy level — only SECURITY DEFINER dispatch functions (Task 2 + Task 3) write rows.
+
+**Quiet hours**: stored as `TIME` in the user-supplied `timezone` column. Tasks 2 + 3 dispatch functions are responsible for skipping + logging when local-now is within the quiet window.
+
+Migration: `docs/db/migrations/2026_04_18_notification_preferences.sql`.

--- a/docs/db/migrations/2026_04_18_notification_preferences.sql
+++ b/docs/db/migrations/2026_04_18_notification_preferences.sql
@@ -1,0 +1,90 @@
+-- Migration: Wave 30 — notification preferences + log
+-- Date: 2026-04-18
+-- Description:
+--   Two tables that every notification feature reads from. Bootstrap trigger
+--   creates a default prefs row for every existing and future auth.users row.
+--   Append-only notification_log audit trail used for debugging, idempotency,
+--   and user-visible "recent notifications" tab.
+--
+-- Revert path:
+--   DROP TRIGGER IF EXISTS trg_bootstrap_notification_prefs ON auth.users;
+--   DROP FUNCTION IF EXISTS public.bootstrap_notification_prefs();
+--   DROP TABLE IF EXISTS public.notification_log CASCADE;
+--   DROP TABLE IF EXISTS public.notification_preferences CASCADE;
+
+CREATE TABLE public.notification_preferences (
+  user_id              uuid        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email_mentions       boolean     NOT NULL DEFAULT true,
+  email_overdue_digest text        NOT NULL DEFAULT 'daily' CHECK (email_overdue_digest IN ('off','daily','weekly')),
+  email_assignment     boolean     NOT NULL DEFAULT true,
+  push_mentions        boolean     NOT NULL DEFAULT true,
+  push_overdue         boolean     NOT NULL DEFAULT true,
+  push_assignment      boolean     NOT NULL DEFAULT false,
+  quiet_hours_start    time,
+  quiet_hours_end      time,
+  timezone             text        NOT NULL DEFAULT 'UTC',
+  updated_at           timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.notification_log (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  channel     text        NOT NULL CHECK (channel IN ('email','push')),
+  event_type  text        NOT NULL,
+  payload     jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  sent_at     timestamptz NOT NULL DEFAULT now(),
+  provider_id text,
+  error       text
+);
+
+CREATE INDEX idx_notification_log_user_id_sent_at ON public.notification_log (user_id, sent_at DESC);
+CREATE INDEX idx_notification_log_event_type      ON public.notification_log (event_type, sent_at DESC);
+
+CREATE TRIGGER trg_notification_preferences_handle_updated_at
+BEFORE UPDATE ON public.notification_preferences
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_updated_at();
+
+ALTER TABLE public.notification_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notification_log         ENABLE ROW LEVEL SECURITY;
+
+-- RLS: notification_preferences
+CREATE POLICY "Notif prefs: select own"  ON public.notification_preferences FOR SELECT  TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "Notif prefs: insert own"  ON public.notification_preferences FOR INSERT  TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Notif prefs: update own"  ON public.notification_preferences FOR UPDATE  TO authenticated USING (user_id = auth.uid());
+-- DELETE not exposed; UPDATE is the off-switch.
+
+-- RLS: notification_log (SELECT-only for users, plus admin)
+CREATE POLICY "Notif log: select own or admin"
+ON public.notification_log
+FOR SELECT
+TO authenticated
+USING (user_id = auth.uid() OR public.is_admin(auth.uid()));
+-- INSERT/UPDATE/DELETE denied at policy level — only SECURITY DEFINER dispatch functions write.
+
+-- Bootstrap: create a prefs row for every auth.users INSERT
+CREATE OR REPLACE FUNCTION public.bootstrap_notification_prefs()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  INSERT INTO public.notification_preferences (user_id) VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.bootstrap_notification_prefs() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bootstrap_notification_prefs() TO authenticated;
+
+CREATE TRIGGER trg_bootstrap_notification_prefs
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.bootstrap_notification_prefs();
+
+-- Backfill prefs for existing users
+INSERT INTO public.notification_preferences (user_id)
+SELECT id FROM auth.users
+ON CONFLICT (user_id) DO NOTHING;

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -1750,6 +1750,57 @@ CREATE TABLE IF NOT EXISTS "public"."activity_log" (
 ALTER TABLE "public"."activity_log" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "public"."notification_preferences" (
+    "user_id" "uuid" NOT NULL,
+    "email_mentions" boolean DEFAULT true NOT NULL,
+    "email_overdue_digest" "text" DEFAULT 'daily'::"text" NOT NULL,
+    "email_assignment" boolean DEFAULT true NOT NULL,
+    "push_mentions" boolean DEFAULT true NOT NULL,
+    "push_overdue" boolean DEFAULT true NOT NULL,
+    "push_assignment" boolean DEFAULT false NOT NULL,
+    "quiet_hours_start" time without time zone,
+    "quiet_hours_end" time without time zone,
+    "timezone" "text" DEFAULT 'UTC'::"text" NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "notification_preferences_email_overdue_digest_check" CHECK (("email_overdue_digest" = ANY (ARRAY['off'::"text", 'daily'::"text", 'weekly'::"text"])))
+);
+
+
+ALTER TABLE "public"."notification_preferences" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."notification_log" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "channel" "text" NOT NULL,
+    "event_type" "text" NOT NULL,
+    "payload" "jsonb" DEFAULT '{}'::"jsonb" NOT NULL,
+    "sent_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "provider_id" "text",
+    "error" "text",
+    CONSTRAINT "notification_log_channel_check" CHECK (("channel" = ANY (ARRAY['email'::"text", 'push'::"text"])))
+);
+
+
+ALTER TABLE "public"."notification_log" OWNER TO "postgres";
+
+
+-- Wave 30: Bootstrap a notification_preferences row for every auth.users INSERT.
+CREATE OR REPLACE FUNCTION "public"."bootstrap_notification_prefs"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+BEGIN
+  INSERT INTO public.notification_preferences (user_id) VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."bootstrap_notification_prefs"() OWNER TO "postgres";
+
+
 CREATE OR REPLACE VIEW "public"."tasks_with_primary_resource" AS
  SELECT "t"."id",
     "t"."parent_task_id",
@@ -1976,6 +2027,42 @@ CREATE INDEX "idx_activity_log_project_id" ON "public"."activity_log" USING "btr
 
 
 CREATE INDEX "idx_activity_log_entity" ON "public"."activity_log" USING "btree" ("entity_type", "entity_id", "created_at" DESC);
+
+
+
+ALTER TABLE ONLY "public"."notification_preferences"
+    ADD CONSTRAINT "notification_preferences_pkey" PRIMARY KEY ("user_id");
+
+
+
+ALTER TABLE ONLY "public"."notification_log"
+    ADD CONSTRAINT "notification_log_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."notification_preferences"
+    ADD CONSTRAINT "notification_preferences_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."notification_log"
+    ADD CONSTRAINT "notification_log_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+
+
+CREATE INDEX "idx_notification_log_user_id_sent_at" ON "public"."notification_log" USING "btree" ("user_id", "sent_at" DESC);
+
+
+
+CREATE INDEX "idx_notification_log_event_type" ON "public"."notification_log" USING "btree" ("event_type", "sent_at" DESC);
+
+
+
+CREATE OR REPLACE TRIGGER "trg_notification_preferences_handle_updated_at" BEFORE UPDATE ON "public"."notification_preferences" FOR EACH ROW EXECUTE FUNCTION "public"."handle_updated_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "trg_bootstrap_notification_prefs" AFTER INSERT ON "auth"."users" FOR EACH ROW EXECUTE FUNCTION "public"."bootstrap_notification_prefs"();
 
 
 
@@ -2337,6 +2424,24 @@ ALTER TABLE "public"."activity_log" ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Activity log select by project members" ON "public"."activity_log" FOR SELECT TO "authenticated" USING (("public"."is_active_member"("project_id", "auth"."uid"()) OR "public"."is_admin"("auth"."uid"())));
 
 
+ALTER TABLE "public"."notification_preferences" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."notification_log" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "Notif prefs: select own" ON "public"."notification_preferences" FOR SELECT TO "authenticated" USING (("user_id" = "auth"."uid"()));
+
+
+CREATE POLICY "Notif prefs: insert own" ON "public"."notification_preferences" FOR INSERT TO "authenticated" WITH CHECK (("user_id" = "auth"."uid"()));
+
+
+CREATE POLICY "Notif prefs: update own" ON "public"."notification_preferences" FOR UPDATE TO "authenticated" USING (("user_id" = "auth"."uid"()));
+
+
+CREATE POLICY "Notif log: select own or admin" ON "public"."notification_log" FOR SELECT TO "authenticated" USING ((("user_id" = "auth"."uid"()) OR "public"."is_admin"("auth"."uid"())));
+
+
 CREATE POLICY "Comments select by project members" ON "public"."task_comments" FOR SELECT TO "authenticated" USING (("public"."is_active_member"("root_id", "auth"."uid"()) OR "public"."is_admin"("auth"."uid"())));
 
 
@@ -2535,6 +2640,8 @@ REVOKE ALL ON FUNCTION "public"."derive_task_type"("p_parent_task_id" "uuid") FR
 GRANT ALL ON FUNCTION "public"."derive_task_type"("p_parent_task_id" "uuid") TO "authenticated";
 REVOKE ALL ON FUNCTION "public"."user_is_phase_lead"("target_task_id" "uuid", "uid" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."user_is_phase_lead"("target_task_id" "uuid", "uid" "uuid") TO "authenticated";
+REVOKE ALL ON FUNCTION "public"."bootstrap_notification_prefs"() FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."bootstrap_notification_prefs"() TO "authenticated";
 
 
 

--- a/docs/db/tests/notification_prefs_bootstrap.sql
+++ b/docs/db/tests/notification_prefs_bootstrap.sql
@@ -1,0 +1,39 @@
+-- EXPECT: inserting a new auth.users row materializes a notification_preferences row via trg_bootstrap_notification_prefs
+--
+-- Wave 30 Task 1: verify the bootstrap trigger fires and the new prefs row
+-- carries the documented defaults. Run with the service-role key or as
+-- superuser so the auth.users INSERT isn't blocked by RLS.
+--
+-- Wrap in BEGIN/ROLLBACK so repeated execution is idempotent.
+
+BEGIN;
+
+-- SETUP: insert a synthetic auth.users row with a deterministic uuid.
+DO $$
+DECLARE
+    v_uid uuid := '00000000-0000-0000-0000-00000000bbbb';
+    v_prefs public.notification_preferences%ROWTYPE;
+BEGIN
+    INSERT INTO auth.users (id, email) VALUES (v_uid, 'notif-bootstrap-smoke@test.local');
+
+    SELECT * INTO v_prefs FROM public.notification_preferences WHERE user_id = v_uid;
+    IF v_prefs IS NULL THEN
+        RAISE EXCEPTION '[FAIL] notification_preferences row was not bootstrapped for new user';
+    END IF;
+
+    -- Canonical defaults per the migration header.
+    IF v_prefs.email_mentions        IS DISTINCT FROM true   THEN RAISE EXCEPTION '[FAIL] email_mentions default drifted'; END IF;
+    IF v_prefs.email_overdue_digest  IS DISTINCT FROM 'daily' THEN RAISE EXCEPTION '[FAIL] email_overdue_digest default drifted'; END IF;
+    IF v_prefs.email_assignment      IS DISTINCT FROM true   THEN RAISE EXCEPTION '[FAIL] email_assignment default drifted'; END IF;
+    IF v_prefs.push_mentions         IS DISTINCT FROM true   THEN RAISE EXCEPTION '[FAIL] push_mentions default drifted'; END IF;
+    IF v_prefs.push_overdue          IS DISTINCT FROM true   THEN RAISE EXCEPTION '[FAIL] push_overdue default drifted'; END IF;
+    IF v_prefs.push_assignment       IS DISTINCT FROM false  THEN RAISE EXCEPTION '[FAIL] push_assignment default drifted'; END IF;
+    IF v_prefs.timezone              IS DISTINCT FROM 'UTC'  THEN RAISE EXCEPTION '[FAIL] timezone default drifted'; END IF;
+
+    RAISE NOTICE '[OK] bootstrap trigger materialized prefs row with canonical defaults';
+END $$;
+
+-- Cleanup (rollback handles it too, but be explicit).
+DELETE FROM auth.users WHERE email = 'notif-bootstrap-smoke@test.local';
+
+ROLLBACK;

--- a/src/features/settings/hooks/useNotificationPreferences.ts
+++ b/src/features/settings/hooks/useNotificationPreferences.ts
@@ -1,0 +1,51 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { planter } from '@/shared/api/planterClient';
+import type {
+    NotificationPreferencesRow,
+    NotificationPreferencesUpdate,
+    NotificationLogRow,
+} from '@/shared/db/app.types';
+
+const PREFS_KEY = ['notificationPreferences'] as const;
+
+export function useNotificationPreferences() {
+    return useQuery<NotificationPreferencesRow>({
+        queryKey: PREFS_KEY,
+        queryFn: () => planter.notifications.getPreferences(),
+    });
+}
+
+interface OptimisticContext {
+    previous?: NotificationPreferencesRow;
+}
+
+export function useUpdateNotificationPreferences() {
+    const qc = useQueryClient();
+    return useMutation<NotificationPreferencesRow, Error, NotificationPreferencesUpdate, OptimisticContext>({
+        mutationFn: (patch) => planter.notifications.updatePreferences(patch),
+        onMutate: async (patch) => {
+            await qc.cancelQueries({ queryKey: PREFS_KEY });
+            const previous = qc.getQueryData<NotificationPreferencesRow>(PREFS_KEY);
+            if (previous) {
+                qc.setQueryData<NotificationPreferencesRow>(PREFS_KEY, { ...previous, ...patch } as NotificationPreferencesRow);
+            }
+            return { previous };
+        },
+        onError: (_err, _patch, ctx) => {
+            if (ctx?.previous) qc.setQueryData(PREFS_KEY, ctx.previous);
+            qc.invalidateQueries({ queryKey: PREFS_KEY });
+            toast.error('Could not save preferences');
+        },
+        onSettled: () => {
+            qc.invalidateQueries({ queryKey: PREFS_KEY });
+        },
+    });
+}
+
+export function useNotificationLog(opts?: { limit?: number; before?: string; eventType?: string }) {
+    return useQuery<NotificationLogRow[]>({
+        queryKey: ['notificationLog', opts],
+        queryFn: () => planter.notifications.listLog(opts),
+    });
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,8 +11,9 @@ import {
 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useSettings } from '@/features/settings/hooks/useSettings';
+import SettingsNotificationsTab from '@/pages/components/SettingsNotificationsTab';
 
-type SettingsTab = 'profile' | 'security';
+type SettingsTab = 'profile' | 'security' | 'notifications';
 
 export default function Settings() {
  const { state, actions } = useSettings();
@@ -33,7 +34,7 @@ export default function Settings() {
  <div className="md:col-span-1 space-y-1">
  {([
  { label: 'Profile', icon: User, tab: 'profile' as SettingsTab },
- { label: 'Notifications', icon: Bell, comingSoon: true },
+ { label: 'Notifications', icon: Bell, tab: 'notifications' as SettingsTab },
  { label: 'Security', icon: Lock, tab: 'security' as SettingsTab },
  ] as Array<{ label: string; icon: React.ElementType; tab?: SettingsTab; comingSoon?: boolean }>).map((item) => (
  <Button
@@ -169,6 +170,11 @@ export default function Settings() {
  </div>
  </form>
  </div>
+ )}
+
+ {/* Notifications Tab (Wave 30) */}
+ {activeTab === 'notifications' && (
+ <SettingsNotificationsTab />
  )}
 
  {/* Security Tab */}

--- a/src/pages/components/SettingsNotificationsTab.tsx
+++ b/src/pages/components/SettingsNotificationsTab.tsx
@@ -3,6 +3,7 @@ import { Label } from '@/shared/ui/label';
 import { Switch } from '@/shared/ui/switch';
 import { Input } from '@/shared/ui/input';
 import { Button } from '@/shared/ui/button';
+import { formatDate } from '@/shared/lib/date-engine';
 import {
     Select,
     SelectContent,
@@ -16,6 +17,11 @@ import {
     useNotificationLog,
 } from '@/features/settings/hooks/useNotificationPreferences';
 import type { NotificationPreferencesRow } from '@/shared/db/app.types';
+
+/** Turns `mention_pending` into `Mention Pending` for user-facing display. */
+function humanizeEventType(eventType: string): string {
+    return eventType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 const COMMON_TIMEZONES = [
     'UTC',
@@ -70,12 +76,12 @@ export default function SettingsNotificationsTab() {
         <div className="space-y-6" data-testid="settings-notifications">
             <div className="bg-card rounded-xl border border-border shadow-sm p-6">
                 <h2 className="text-xl font-bold text-slate-900">Email</h2>
-                <p className="text-sm text-slate-500 mt-1">Control which events produce an email.</p>
+                <p className="text-sm text-slate-600 mt-1">Control which events produce an email.</p>
 
                 <div className="mt-6 flex items-center justify-between gap-4">
                     <div>
                         <Label htmlFor="email-mentions" className="text-sm font-medium">Mentions</Label>
-                        <p className="text-xs text-slate-500">Email me when someone `@`-mentions me in a task comment.</p>
+                        <p className="text-xs text-slate-600">Email me when someone `@`-mentions me in a task comment.</p>
                     </div>
                     <Switch
                         id="email-mentions"
@@ -87,7 +93,7 @@ export default function SettingsNotificationsTab() {
                 <div className="mt-4 flex items-center justify-between gap-4">
                     <div>
                         <Label htmlFor="email-overdue-digest" className="text-sm font-medium">Overdue digest</Label>
-                        <p className="text-xs text-slate-500">Scheduled summary of tasks past due.</p>
+                        <p className="text-xs text-slate-600">Scheduled summary of tasks past due.</p>
                     </div>
                     <Select
                         value={prefs.email_overdue_digest}
@@ -107,7 +113,7 @@ export default function SettingsNotificationsTab() {
                 <div className="mt-4 flex items-center justify-between gap-4">
                     <div>
                         <Label htmlFor="email-assignment" className="text-sm font-medium">Task assignment</Label>
-                        <p className="text-xs text-slate-500">Email me when a task is assigned to me.</p>
+                        <p className="text-xs text-slate-600">Email me when a task is assigned to me.</p>
                     </div>
                     <Switch
                         id="email-assignment"
@@ -121,7 +127,7 @@ export default function SettingsNotificationsTab() {
                 <div className="flex items-center justify-between gap-4">
                     <div>
                         <h2 className="text-xl font-bold text-slate-900">Push</h2>
-                        <p className="text-sm text-slate-500 mt-1">Browser push notifications via the service worker.</p>
+                        <p className="text-sm text-slate-600 mt-1">Browser push notifications via the service worker.</p>
                     </div>
                     <Button
                         type="button"
@@ -167,7 +173,7 @@ export default function SettingsNotificationsTab() {
 
             <div className="bg-card rounded-xl border border-border shadow-sm p-6">
                 <h2 className="text-xl font-bold text-slate-900">Quiet hours</h2>
-                <p className="text-sm text-slate-500 mt-1">Dispatchers skip sends when local-now is within this window.</p>
+                <p className="text-sm text-slate-600 mt-1">Dispatchers skip sends when local-now is within this window.</p>
 
                 <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
                     <div className="space-y-2">
@@ -213,15 +219,15 @@ export default function SettingsNotificationsTab() {
                 </summary>
                 <div className="mt-4 space-y-2" data-testid="notif-log">
                     {logQuery.isLoading ? (
-                        <p className="text-xs text-slate-500">Loading recent sends…</p>
+                        <p className="text-xs text-slate-600">Loading recent sends…</p>
                     ) : (logQuery.data?.length ?? 0) === 0 ? (
-                        <p className="text-xs text-slate-500">No notifications have been sent yet.</p>
+                        <p className="text-xs text-slate-600">No notifications have been sent yet.</p>
                     ) : (
                         (logQuery.data ?? []).map((row) => (
                             <div key={row.id} className="flex items-start justify-between gap-3 border-b border-slate-100 py-2 text-xs last:border-0">
                                 <div>
-                                    <p className="font-medium text-slate-700">{row.event_type}</p>
-                                    <p className="text-slate-500">{row.channel} · {row.sent_at}</p>
+                                    <p className="font-medium text-slate-700">{humanizeEventType(row.event_type)}</p>
+                                    <p className="text-slate-600">{row.channel} · {formatDate(row.sent_at, 'PPp')}</p>
                                 </div>
                                 {row.error ? (
                                     <span className="text-red-600">error</span>
@@ -255,7 +261,7 @@ function ToggleRow({ id, label, description, checked, disabled, disabledTooltip,
         >
             <div>
                 <Label htmlFor={id} className="text-sm font-medium">{label}</Label>
-                <p className="text-xs text-slate-500">{description}</p>
+                <p className="text-xs text-slate-600">{description}</p>
             </div>
             <Switch
                 id={id}

--- a/src/pages/components/SettingsNotificationsTab.tsx
+++ b/src/pages/components/SettingsNotificationsTab.tsx
@@ -1,0 +1,268 @@
+import { useMemo } from 'react';
+import { Label } from '@/shared/ui/label';
+import { Switch } from '@/shared/ui/switch';
+import { Input } from '@/shared/ui/input';
+import { Button } from '@/shared/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/shared/ui/select';
+import {
+    useNotificationPreferences,
+    useUpdateNotificationPreferences,
+    useNotificationLog,
+} from '@/features/settings/hooks/useNotificationPreferences';
+import type { NotificationPreferencesRow } from '@/shared/db/app.types';
+
+const COMMON_TIMEZONES = [
+    'UTC',
+    'America/Los_Angeles',
+    'America/Denver',
+    'America/Chicago',
+    'America/New_York',
+    'Europe/London',
+    'Europe/Paris',
+    'Asia/Tokyo',
+    'Australia/Sydney',
+];
+
+/** Prefer the browser's full tz list when available (Chrome/Firefox); fall back to our curated list. */
+function useTimezoneOptions(): string[] {
+    return useMemo(() => {
+        type IntlWithTz = typeof Intl & { supportedValuesOf?: (key: 'timeZone') => string[] };
+        const intl = Intl as IntlWithTz;
+        const runtime = typeof intl.supportedValuesOf === 'function' ? intl.supportedValuesOf('timeZone') : null;
+        return runtime && runtime.length > 0 ? runtime : COMMON_TIMEZONES;
+    }, []);
+}
+
+export default function SettingsNotificationsTab() {
+    const { data: prefs, isLoading, isError } = useNotificationPreferences();
+    const updateMutation = useUpdateNotificationPreferences();
+    const logQuery = useNotificationLog({ limit: 20 });
+    const timezoneOptions = useTimezoneOptions();
+
+    // Placeholder for Task 2: browser push isn't wired yet, so the three push
+    // toggles below are disabled with a tooltip until the subscription hook lands.
+    const pushSubscribed = false;
+
+    if (isLoading || !prefs) {
+        return (
+            <div className="rounded-xl border border-border bg-card p-6 text-sm text-muted-foreground shadow-sm" data-testid="notif-loading">
+                Loading preferences…
+            </div>
+        );
+    }
+    if (isError) {
+        return (
+            <div className="rounded-xl border border-border bg-card p-6 text-sm text-red-600 shadow-sm">
+                Could not load notification preferences.
+            </div>
+        );
+    }
+
+    const patch = (p: Partial<NotificationPreferencesRow>) => updateMutation.mutate(p);
+
+    return (
+        <div className="space-y-6" data-testid="settings-notifications">
+            <div className="bg-card rounded-xl border border-border shadow-sm p-6">
+                <h2 className="text-xl font-bold text-slate-900">Email</h2>
+                <p className="text-sm text-slate-500 mt-1">Control which events produce an email.</p>
+
+                <div className="mt-6 flex items-center justify-between gap-4">
+                    <div>
+                        <Label htmlFor="email-mentions" className="text-sm font-medium">Mentions</Label>
+                        <p className="text-xs text-slate-500">Email me when someone `@`-mentions me in a task comment.</p>
+                    </div>
+                    <Switch
+                        id="email-mentions"
+                        checked={prefs.email_mentions}
+                        onCheckedChange={(v) => patch({ email_mentions: v })}
+                    />
+                </div>
+
+                <div className="mt-4 flex items-center justify-between gap-4">
+                    <div>
+                        <Label htmlFor="email-overdue-digest" className="text-sm font-medium">Overdue digest</Label>
+                        <p className="text-xs text-slate-500">Scheduled summary of tasks past due.</p>
+                    </div>
+                    <Select
+                        value={prefs.email_overdue_digest}
+                        onValueChange={(v) => patch({ email_overdue_digest: v as 'off' | 'daily' | 'weekly' })}
+                    >
+                        <SelectTrigger id="email-overdue-digest" className="w-32">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="off">Off</SelectItem>
+                            <SelectItem value="daily">Daily</SelectItem>
+                            <SelectItem value="weekly">Weekly</SelectItem>
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                <div className="mt-4 flex items-center justify-between gap-4">
+                    <div>
+                        <Label htmlFor="email-assignment" className="text-sm font-medium">Task assignment</Label>
+                        <p className="text-xs text-slate-500">Email me when a task is assigned to me.</p>
+                    </div>
+                    <Switch
+                        id="email-assignment"
+                        checked={prefs.email_assignment}
+                        onCheckedChange={(v) => patch({ email_assignment: v })}
+                    />
+                </div>
+            </div>
+
+            <div className="bg-card rounded-xl border border-border shadow-sm p-6">
+                <div className="flex items-center justify-between gap-4">
+                    <div>
+                        <h2 className="text-xl font-bold text-slate-900">Push</h2>
+                        <p className="text-sm text-slate-500 mt-1">Browser push notifications via the service worker.</p>
+                    </div>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        disabled
+                        title="Browser push subscription wiring ships in Wave 30 Task 2"
+                        data-testid="enable-browser-push"
+                    >
+                        Enable browser push
+                    </Button>
+                </div>
+
+                <div className="mt-6 space-y-4">
+                    <ToggleRow
+                        id="push-mentions"
+                        label="Mentions"
+                        description="Push me when someone `@`-mentions me."
+                        checked={prefs.push_mentions}
+                        disabled={!pushSubscribed}
+                        disabledTooltip="Enable browser push first."
+                        onChange={(v) => patch({ push_mentions: v })}
+                    />
+                    <ToggleRow
+                        id="push-overdue"
+                        label="Overdue digest"
+                        description="Push me the daily overdue summary."
+                        checked={prefs.push_overdue}
+                        disabled={!pushSubscribed}
+                        disabledTooltip="Enable browser push first."
+                        onChange={(v) => patch({ push_overdue: v })}
+                    />
+                    <ToggleRow
+                        id="push-assignment"
+                        label="Task assignment"
+                        description="Push me when a task is assigned to me."
+                        checked={prefs.push_assignment}
+                        disabled={!pushSubscribed}
+                        disabledTooltip="Enable browser push first."
+                        onChange={(v) => patch({ push_assignment: v })}
+                    />
+                </div>
+            </div>
+
+            <div className="bg-card rounded-xl border border-border shadow-sm p-6">
+                <h2 className="text-xl font-bold text-slate-900">Quiet hours</h2>
+                <p className="text-sm text-slate-500 mt-1">Dispatchers skip sends when local-now is within this window.</p>
+
+                <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-3">
+                    <div className="space-y-2">
+                        <Label htmlFor="quiet-start" className="text-sm font-medium">Start</Label>
+                        <Input
+                            id="quiet-start"
+                            type="time"
+                            value={prefs.quiet_hours_start ?? ''}
+                            onChange={(e) => patch({ quiet_hours_start: e.target.value || null })}
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="quiet-end" className="text-sm font-medium">End</Label>
+                        <Input
+                            id="quiet-end"
+                            type="time"
+                            value={prefs.quiet_hours_end ?? ''}
+                            onChange={(e) => patch({ quiet_hours_end: e.target.value || null })}
+                        />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="timezone" className="text-sm font-medium">Timezone</Label>
+                        <Select
+                            value={prefs.timezone}
+                            onValueChange={(v) => patch({ timezone: v })}
+                        >
+                            <SelectTrigger id="timezone">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent className="max-h-72">
+                                {timezoneOptions.map((tz) => (
+                                    <SelectItem key={tz} value={tz}>{tz}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+            </div>
+
+            <details className="bg-card rounded-xl border border-border shadow-sm p-6">
+                <summary className="cursor-pointer text-sm font-medium text-slate-700">
+                    Recent notifications ({logQuery.data?.length ?? 0})
+                </summary>
+                <div className="mt-4 space-y-2" data-testid="notif-log">
+                    {logQuery.isLoading ? (
+                        <p className="text-xs text-slate-500">Loading recent sends…</p>
+                    ) : (logQuery.data?.length ?? 0) === 0 ? (
+                        <p className="text-xs text-slate-500">No notifications have been sent yet.</p>
+                    ) : (
+                        (logQuery.data ?? []).map((row) => (
+                            <div key={row.id} className="flex items-start justify-between gap-3 border-b border-slate-100 py-2 text-xs last:border-0">
+                                <div>
+                                    <p className="font-medium text-slate-700">{row.event_type}</p>
+                                    <p className="text-slate-500">{row.channel} · {row.sent_at}</p>
+                                </div>
+                                {row.error ? (
+                                    <span className="text-red-600">error</span>
+                                ) : (
+                                    <span className="text-emerald-700">sent</span>
+                                )}
+                            </div>
+                        ))
+                    )}
+                </div>
+            </details>
+        </div>
+    );
+}
+
+interface ToggleRowProps {
+    id: string;
+    label: string;
+    description: string;
+    checked: boolean;
+    disabled?: boolean;
+    disabledTooltip?: string;
+    onChange: (value: boolean) => void;
+}
+
+function ToggleRow({ id, label, description, checked, disabled, disabledTooltip, onChange }: ToggleRowProps) {
+    return (
+        <div
+            className="flex items-center justify-between gap-4"
+            title={disabled ? disabledTooltip : undefined}
+        >
+            <div>
+                <Label htmlFor={id} className="text-sm font-medium">{label}</Label>
+                <p className="text-xs text-slate-500">{description}</p>
+            </div>
+            <Switch
+                id={id}
+                checked={checked}
+                disabled={disabled}
+                onCheckedChange={onChange}
+            />
+        </div>
+    );
+}

--- a/src/shared/api/planterClient.ts
+++ b/src/shared/api/planterClient.ts
@@ -15,7 +15,10 @@ import type {
     UserMetadata,
     TaskCommentRow,
     TaskCommentWithAuthor,
-    ActivityLogWithActor
+    ActivityLogWithActor,
+    NotificationPreferencesRow,
+    NotificationPreferencesUpdate,
+    NotificationLogRow
 } from '@/shared/db/app.types';
 import type { User as AuthUser } from '@supabase/supabase-js';
 
@@ -73,6 +76,15 @@ export interface PlanterClient {
          *   `Error` (never an upstream body).
          */
         invoke: <T = unknown>(functionName: string, opts?: { body?: Record<string, unknown> }) => Promise<{ data: T | null, error: Error | null }>;
+    };
+    /** Wave 30 — per-user notification preferences + audit log. */
+    notifications: {
+        /** Returns the authenticated user's preferences row (RLS auto-filters to own). */
+        getPreferences: () => Promise<NotificationPreferencesRow>;
+        /** Partial update of the caller's preferences row; returns the updated row. */
+        updatePreferences: (patch: NotificationPreferencesUpdate) => Promise<NotificationPreferencesRow>;
+        /** Returns recent notification-log rows for the caller (newest first). */
+        listLog: (opts?: { limit?: number; before?: string; eventType?: string }) => Promise<NotificationLogRow[]>;
     };
 }
 
@@ -1039,6 +1051,55 @@ export const planter: PlanterClient = {
             } catch (error: unknown) {
                 return { data: null, error: error instanceof Error ? error : new Error(String(error)) };
             }
+        },
+    },
+
+    // ---------------------------------------------------------------------------
+    // Notifications (Wave 30)
+    // ---------------------------------------------------------------------------
+    // RLS auto-filters SELECTs + UPDATEs to `user_id = auth.uid()`, so these
+    // helpers never need to thread the caller id explicitly. See
+    // docs/architecture/auth-rbac.md → "Notification Preferences (Wave 30)".
+
+    notifications: {
+        getPreferences: async (): Promise<NotificationPreferencesRow> => {
+            return retry(async () => {
+                const { data, error } = await supabase
+                    .from('notification_preferences')
+                    .select('*')
+                    .limit(1)
+                    .maybeSingle();
+                if (error) throw new PlanterError(error.message, parseInt(error.code ?? '500'));
+                if (!data) {
+                    throw new PlanterError('notification_preferences row missing for caller', 404);
+                }
+                return data as NotificationPreferencesRow;
+            });
+        },
+        updatePreferences: async (patch: NotificationPreferencesUpdate): Promise<NotificationPreferencesRow> => {
+            return retry(async () => {
+                const { data, error } = await supabase
+                    .from('notification_preferences')
+                    .update(patch)
+                    .select('*')
+                    .single();
+                if (error) throw new PlanterError(error.message, parseInt(error.code ?? '500'));
+                return data as NotificationPreferencesRow;
+            });
+        },
+        listLog: async (opts?: { limit?: number; before?: string; eventType?: string }): Promise<NotificationLogRow[]> => {
+            return retry(async () => {
+                let query = supabase
+                    .from('notification_log')
+                    .select('*')
+                    .order('sent_at', { ascending: false })
+                    .limit(opts?.limit ?? 50);
+                if (opts?.before) query = query.lt('sent_at', opts.before);
+                if (opts?.eventType) query = query.eq('event_type', opts.eventType);
+                const { data, error } = await query;
+                if (error) throw new PlanterError(error.message, parseInt(error.code ?? '500'));
+                return (data as NotificationLogRow[]) || [];
+            });
         },
     },
 };

--- a/src/shared/db/app.types.ts
+++ b/src/shared/db/app.types.ts
@@ -74,6 +74,13 @@ export type TaskCommentWithAuthor = TaskCommentRow & {
 };
 
 // ----------------------------------------------------------------------------
+// Notifications (Wave 30)
+// ----------------------------------------------------------------------------
+export type NotificationPreferencesRow    = Database['public']['Tables']['notification_preferences']['Row'];
+export type NotificationPreferencesUpdate = Database['public']['Tables']['notification_preferences']['Update'];
+export type NotificationLogRow            = Database['public']['Tables']['notification_log']['Row'];
+
+// ----------------------------------------------------------------------------
 // Activity Log (Wave 27)
 // ----------------------------------------------------------------------------
 export type ActivityLogRow = Database['public']['Tables']['activity_log']['Row'];

--- a/src/shared/db/database.types.ts
+++ b/src/shared/db/database.types.ts
@@ -93,6 +93,81 @@ export type Database = {
  }
  Relationships: []
  }
+ notification_preferences: {
+ Row: {
+ user_id: string
+ email_mentions: boolean
+ email_overdue_digest: 'off' | 'daily' | 'weekly'
+ email_assignment: boolean
+ push_mentions: boolean
+ push_overdue: boolean
+ push_assignment: boolean
+ quiet_hours_start: string | null
+ quiet_hours_end: string | null
+ timezone: string
+ updated_at: string
+ }
+ Insert: {
+ user_id: string
+ email_mentions?: boolean
+ email_overdue_digest?: 'off' | 'daily' | 'weekly'
+ email_assignment?: boolean
+ push_mentions?: boolean
+ push_overdue?: boolean
+ push_assignment?: boolean
+ quiet_hours_start?: string | null
+ quiet_hours_end?: string | null
+ timezone?: string
+ updated_at?: string
+ }
+ Update: {
+ user_id?: string
+ email_mentions?: boolean
+ email_overdue_digest?: 'off' | 'daily' | 'weekly'
+ email_assignment?: boolean
+ push_mentions?: boolean
+ push_overdue?: boolean
+ push_assignment?: boolean
+ quiet_hours_start?: string | null
+ quiet_hours_end?: string | null
+ timezone?: string
+ updated_at?: string
+ }
+ Relationships: []
+ }
+ notification_log: {
+ Row: {
+ id: string
+ user_id: string
+ channel: 'email' | 'push'
+ event_type: string
+ payload: Json
+ sent_at: string
+ provider_id: string | null
+ error: string | null
+ }
+ Insert: {
+ id?: string
+ user_id: string
+ channel: 'email' | 'push'
+ event_type: string
+ payload?: Json
+ sent_at?: string
+ provider_id?: string | null
+ error?: string | null
+ }
+ Update: {
+ id?: string
+ user_id?: string
+ channel?: 'email' | 'push'
+ event_type?: string
+ payload?: Json
+ sent_at?: string
+ provider_id?: string | null
+ error?: string | null
+ }
+ Relationships: []
+ }
  people: {
  Row: {
  created_at: string | null


### PR DESCRIPTION
## Summary
- **Data foundation for the Wave 30 notification stack.**
  - `public.notification_preferences` — per-user singleton keyed on `auth.users(id)`. Covers email/push toggles per event class (mentions, overdue digest, assignment), quiet-hours window, timezone. CHECK gates `email_overdue_digest ∈ {'off','daily','weekly'}`.
  - `public.notification_log` — append-only audit trail of every dispatch attempt. Indexes on `(user_id, sent_at DESC)` and `(event_type, sent_at DESC)`.
  - `trg_bootstrap_notification_prefs` AFTER INSERT on `auth.users` materializes a default prefs row for new signups; migration backfills for existing users.
  - RLS: prefs self-only SELECT/INSERT/UPDATE (no DELETE — UPDATE is the off-switch); log SELECT gated to `user_id = auth.uid() OR is_admin(auth.uid())`; no INSERT/UPDATE/DELETE policies so only SECURITY DEFINER dispatchers (Tasks 2 + 3) can write.
- **Domain wire-up.** `NotificationPreferencesRow/Update` + `NotificationLogRow` types hand-added to `database.types.ts` and re-exported through `app.types.ts`. `planter.notifications.{getPreferences, updatePreferences, listLog}` namespace — RLS auto-filters so helpers never need to thread uids. `listLog` honors `limit` (default 50), `before`, and `eventType` filters.
- **Hooks.** `useNotificationPreferences` / `useUpdateNotificationPreferences` / `useNotificationLog`. Update is optimistic with rollback-to-previous + `toast.error` on failure, plus `invalidateQueries` in `onSettled`.
- **Settings UI.** Promote the Notifications nav item from `comingSoon` to a real `'notifications'` tab. The tab body lives in `src/pages/components/SettingsNotificationsTab.tsx` — sections for Email, Push (three toggles disabled with a Wave-30-Task-2 tooltip until browser subscription wiring lands), Quiet hours (start/end `<Input type="time">` + timezone `<Select>` backed by `Intl.supportedValuesOf('timeZone')` when available), and a collapsed Recent-notifications `<details>` surfacing `useNotificationLog({ limit: 20 })`.
- **Test infra.** `makeNotificationPref` / `makeNotificationLogRow` factories; minimal `ResizeObserver` stub in `Testing/setupTests.ts` (Radix Select/Popover dependency; first Wave where the suite mounts a page-level `<Select>`).

## Test-count delta
74 test files (+3) / 730 tests (+12).

Verification gate (all green locally):
- `npm run lint` — 0 errors, 4 warnings (pre-existing baseline).
- `npm run build` — clean.
- `npm test` — 730 passed.

psql smoke at `docs/db/tests/notification_prefs_bootstrap.sql` — inserts a synthetic `auth.users` row and asserts the trigger materializes a prefs row with the canonical defaults (rollback-wrapped).

## Out of scope (per wave plan)
- Quiet-hours enforcement in the dispatcher (Task 3 reads the column).
- Browser push subscription wiring + service worker (Task 2).
- Mention resolution, digest cron functions (Task 3).
- Per-project preference overrides (deferred).

## Test plan
- [x] `npm run lint`, `npm run build`, `npm test` — green.
- [x] psql smoke for the bootstrap trigger + default-values contract.
- [ ] Manual: sign up a new user → verify the prefs row materializes via the trigger (Supabase Studio table view).
- [ ] Manual: navigate to Settings → Notifications → flip a toggle → verify the mutation hits `notification_preferences` and the optimistic UI reflects instantly.
- [ ] Manual: unplug the network → verify the rollback toast fires and the switch reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)