### PR TITLE
feat(wave-30): web push subscription + service worker + dispatch-push edge function

### DIFF
--- a/Testing/test-utils/factories.ts
+++ b/Testing/test-utils/factories.ts
@@ -6,6 +6,7 @@ import type {
   TaskCommentWithAuthor,
   NotificationPreferencesRow,
   NotificationLogRow,
+  PushSubscriptionRow,
 } from '@/shared/db/app.types';
 
 /**
@@ -211,5 +212,20 @@ export function makeNotificationLogRow(overrides: Partial<NotificationLogRow> = 
     sent_at: overrides.sent_at ?? new Date().toISOString(),
     provider_id: overrides.provider_id ?? null,
     error: overrides.error ?? null,
+  };
+}
+
+/** Wave 30: PushSubscriptionRow stub. Endpoint uses a realistic FCM-style URL. */
+export function makePushSubscription(overrides: Partial<PushSubscriptionRow> = {}): PushSubscriptionRow {
+  const id = overrides.id ?? faker.string.uuid();
+  return {
+    id,
+    user_id: overrides.user_id ?? faker.string.uuid(),
+    endpoint: overrides.endpoint ?? `https://fcm.googleapis.com/fcm/send/${id}`,
+    p256dh: overrides.p256dh ?? faker.string.alphanumeric(88),
+    auth: overrides.auth ?? faker.string.alphanumeric(24),
+    user_agent: overrides.user_agent ?? 'vitest',
+    created_at: overrides.created_at ?? new Date().toISOString(),
+    last_used_at: overrides.last_used_at ?? null,
   };
 }

--- a/Testing/test-utils/index.ts
+++ b/Testing/test-utils/index.ts
@@ -9,5 +9,6 @@ export {
   makePresenceState,
   makeNotificationPref,
   makeNotificationLogRow,
+  makePushSubscription,
 } from './factories';
 export type { PresenceState } from './factories';

--- a/Testing/test-utils/mocks/notification-api.ts
+++ b/Testing/test-utils/mocks/notification-api.ts
@@ -1,0 +1,38 @@
+import { vi } from 'vitest';
+
+export interface NotificationMockState {
+    requestPermission: ReturnType<typeof vi.fn>;
+    setPermission: (v: NotificationPermission) => void;
+}
+
+/**
+ * Install a jsdom-compatible `Notification` stub. The returned handle lets
+ * tests flip `Notification.permission` mid-test (e.g. simulating `granted`
+ * after `requestPermission()` resolves).
+ */
+export function installNotificationMock(initialPermission: NotificationPermission = 'default'): NotificationMockState {
+    let current: NotificationPermission = initialPermission;
+    const requestPermission = vi.fn(async () => current);
+
+    class NotificationStub {
+        static get permission(): NotificationPermission {
+            return current;
+        }
+        static requestPermission(): Promise<NotificationPermission> {
+            return requestPermission();
+        }
+    }
+
+    Object.defineProperty(globalThis, 'Notification', {
+        configurable: true,
+        writable: true,
+        value: NotificationStub,
+    });
+
+    return {
+        requestPermission,
+        setPermission: (v) => {
+            current = v;
+        },
+    };
+}

--- a/Testing/test-utils/mocks/service-worker.ts
+++ b/Testing/test-utils/mocks/service-worker.ts
@@ -1,0 +1,52 @@
+import { vi } from 'vitest';
+
+export interface MockServiceWorkerState {
+    register: ReturnType<typeof vi.fn>;
+    getRegistration: ReturnType<typeof vi.fn>;
+    pushManager: {
+        subscribe: ReturnType<typeof vi.fn>;
+        getSubscription: ReturnType<typeof vi.fn>;
+    };
+    activeSubscription: { endpoint: string; keys: { p256dh: string; auth: string }; unsubscribe: ReturnType<typeof vi.fn>; toJSON: () => unknown } | null;
+}
+
+/**
+ * Install a jsdom-compatible stub for `navigator.serviceWorker` + `window.PushManager`.
+ * Returns the mocks so tests can assert calls and flip `activeSubscription`.
+ *
+ * Must be called INSIDE `beforeEach` (or the suite's first render call) — we
+ * redefine the properties so re-install is safe.
+ */
+export function installServiceWorkerMock(): MockServiceWorkerState {
+    const subscribeMock = vi.fn();
+    const getSubscriptionMock = vi.fn();
+    const pushManager = { subscribe: subscribeMock, getSubscription: getSubscriptionMock };
+
+    const registration = { pushManager, scope: '/' };
+    const register = vi.fn().mockResolvedValue(registration);
+    const getRegistration = vi.fn().mockResolvedValue(registration);
+
+    const swStub = { register, getRegistration, ready: Promise.resolve(registration), controller: null };
+
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
+        configurable: true,
+        get: () => swStub,
+    });
+    // PushManager constructor stub — the hook checks with `'PushManager' in window`.
+    class PushManagerStub {}
+    Object.defineProperty(globalThis, 'PushManager', {
+        configurable: true,
+        writable: true,
+        value: PushManagerStub,
+    });
+    (globalThis as unknown as { PushManager?: typeof PushManagerStub }).PushManager ??= PushManagerStub;
+    const win = (globalThis as unknown as { window?: Record<string, unknown> }).window;
+    if (win) win.PushManager = PushManagerStub;
+
+    return {
+        register,
+        getRegistration,
+        pushManager,
+        activeSubscription: null,
+    };
+}

--- a/Testing/unit/features/settings/hooks/usePushSubscription.test.tsx
+++ b/Testing/unit/features/settings/hooks/usePushSubscription.test.tsx
@@ -62,11 +62,32 @@ describe('usePushSubscription (Wave 30)', () => {
         expect(result.current.isSupported).toBe(true);
     });
 
-    it('hydrates subscription from planterClient.list on mount', async () => {
-        const row = makePushSubscription({ user_id: 'user-abc' });
+    it('hydrates THIS browser\'s subscription by matching endpoint against the DB row set', async () => {
+        const row = makePushSubscription({
+            user_id: 'user-abc',
+            endpoint: 'https://fcm.example/this-browser',
+        });
         mockList.mockResolvedValue([row]);
+        sw.pushManager.getSubscription.mockResolvedValue({
+            endpoint: 'https://fcm.example/this-browser',
+            unsubscribe: vi.fn(),
+        });
+
         const { result } = renderHook(() => usePushSubscription());
         await waitFor(() => expect(result.current.subscription).toEqual(row));
+    });
+
+    it('stays null when the DB has a row but the browser is not subscribed', async () => {
+        const row = makePushSubscription({
+            user_id: 'user-abc',
+            endpoint: 'https://fcm.example/other-device',
+        });
+        mockList.mockResolvedValue([row]);
+        sw.pushManager.getSubscription.mockResolvedValue(null);
+
+        const { result } = renderHook(() => usePushSubscription());
+        await waitFor(() => expect(mockList).toHaveBeenCalled());
+        expect(result.current.subscription).toBeNull();
     });
 
     it('subscribe: permission granted → registers SW + pushManager.subscribe + planterClient.create', async () => {
@@ -127,7 +148,13 @@ describe('usePushSubscription (Wave 30)', () => {
             endpoint: 'https://fcm.example/sub-existing',
         });
         mockList.mockResolvedValue([row]);
-        const fakeExisting = { unsubscribe: vi.fn().mockResolvedValue(true) };
+        // The hook hydrates by matching the browser endpoint to a DB row. Both
+        // the hydration call and the unsubscribe call hit `getSubscription`, so
+        // the stub must include the endpoint AND the unsubscribe method.
+        const fakeExisting = {
+            endpoint: 'https://fcm.example/sub-existing',
+            unsubscribe: vi.fn().mockResolvedValue(true),
+        };
         sw.pushManager.getSubscription.mockResolvedValue(fakeExisting);
 
         const { result } = renderHook(() => usePushSubscription());

--- a/Testing/unit/features/settings/hooks/usePushSubscription.test.tsx
+++ b/Testing/unit/features/settings/hooks/usePushSubscription.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { installServiceWorkerMock, type MockServiceWorkerState } from '@/../Testing/test-utils/mocks/service-worker';
+import { installNotificationMock, type NotificationMockState } from '@/../Testing/test-utils/mocks/notification-api';
+import { makePushSubscription } from '@test';
+import type { PushSubscriptionRow } from '@/shared/db/app.types';
+
+const mockCreate = vi.fn();
+const mockList = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock('@/shared/api/planterClient', () => ({
+    planter: {
+        entities: {
+            PushSubscription: {
+                create: (payload: unknown) => mockCreate(payload),
+                list: () => mockList(),
+                deleteByEndpoint: (endpoint: string) => mockDelete(endpoint),
+            },
+        },
+    },
+}));
+
+const stableUser = { id: 'user-abc', email: 'user@test.local' };
+const stableAuthContext = { user: stableUser };
+vi.mock('@/shared/contexts/AuthContext', () => ({
+    // Stable references so the hook's `[isSupported, user]` effect dep doesn't re-fire every render.
+    useAuth: () => stableAuthContext,
+}));
+
+// import.meta.env.VITE_VAPID_PUBLIC_KEY is stubbed via vitest's define config by
+// setting the env var at test time.
+vi.stubEnv('VITE_VAPID_PUBLIC_KEY', 'BOr1yE5OhkfjJ0PhT9O4jS4QbB0kfTw');
+
+import { usePushSubscription } from '@/features/settings/hooks/usePushSubscription';
+
+let sw: MockServiceWorkerState;
+let notif: NotificationMockState;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    sw = installServiceWorkerMock();
+    notif = installNotificationMock('default');
+    mockList.mockResolvedValue([]);
+});
+
+function wireSubscribeSuccess(endpoint = 'https://fcm.example/sub-1') {
+    const fakePush = {
+        endpoint,
+        toJSON: () => ({
+            endpoint,
+            keys: { p256dh: 'p256-key', auth: 'auth-key' },
+        }),
+    };
+    sw.pushManager.subscribe.mockResolvedValue(fakePush);
+    return fakePush;
+}
+
+describe('usePushSubscription (Wave 30)', () => {
+    it('reports isSupported=true when SW + PushManager are present', () => {
+        const { result } = renderHook(() => usePushSubscription());
+        expect(result.current.isSupported).toBe(true);
+    });
+
+    it('hydrates subscription from planterClient.list on mount', async () => {
+        const row = makePushSubscription({ user_id: 'user-abc' });
+        mockList.mockResolvedValue([row]);
+        const { result } = renderHook(() => usePushSubscription());
+        await waitFor(() => expect(result.current.subscription).toEqual(row));
+    });
+
+    it('subscribe: permission granted → registers SW + pushManager.subscribe + planterClient.create', async () => {
+        notif.setPermission('default');
+        notif.requestPermission.mockImplementation(async () => {
+            notif.setPermission('granted');
+            return 'granted' as NotificationPermission;
+        });
+        wireSubscribeSuccess();
+        const created: PushSubscriptionRow = makePushSubscription({
+            user_id: 'user-abc',
+            endpoint: 'https://fcm.example/sub-1',
+        });
+        mockCreate.mockResolvedValue(created);
+
+        const { result } = renderHook(() => usePushSubscription());
+        await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+        await act(async () => {
+            await result.current.subscribe();
+        });
+
+        expect(notif.requestPermission).toHaveBeenCalled();
+        expect(sw.register).toHaveBeenCalledWith('/sw.js');
+        expect(sw.pushManager.subscribe).toHaveBeenCalledWith(expect.objectContaining({ userVisibleOnly: true }));
+        expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+            user_id: 'user-abc',
+            endpoint: 'https://fcm.example/sub-1',
+            p256dh: 'p256-key',
+            auth: 'auth-key',
+        }));
+        await waitFor(() => expect(result.current.subscription).toEqual(created));
+        expect(result.current.permissionState).toBe('granted');
+    });
+
+    it('subscribe: permission denied → no SW register + no planterClient.create', async () => {
+        notif.requestPermission.mockImplementation(async () => {
+            notif.setPermission('denied');
+            return 'denied' as NotificationPermission;
+        });
+
+        const { result } = renderHook(() => usePushSubscription());
+        await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+        await act(async () => {
+            await result.current.subscribe();
+        });
+
+        expect(sw.register).not.toHaveBeenCalled();
+        expect(mockCreate).not.toHaveBeenCalled();
+        expect(result.current.permissionState).toBe('denied');
+        expect(result.current.subscription).toBeNull();
+    });
+
+    it('unsubscribe: calls DELETE + clears local state', async () => {
+        const row = makePushSubscription({
+            user_id: 'user-abc',
+            endpoint: 'https://fcm.example/sub-existing',
+        });
+        mockList.mockResolvedValue([row]);
+        const fakeExisting = { unsubscribe: vi.fn().mockResolvedValue(true) };
+        sw.pushManager.getSubscription.mockResolvedValue(fakeExisting);
+
+        const { result } = renderHook(() => usePushSubscription());
+        await waitFor(() => expect(result.current.subscription).toEqual(row));
+
+        await act(async () => {
+            await result.current.unsubscribe();
+        });
+
+        expect(fakeExisting.unsubscribe).toHaveBeenCalled();
+        expect(mockDelete).toHaveBeenCalledWith('https://fcm.example/sub-existing');
+        await waitFor(() => expect(result.current.subscription).toBeNull());
+    });
+});

--- a/Testing/unit/pages/Settings.notifications.test.tsx
+++ b/Testing/unit/pages/Settings.notifications.test.tsx
@@ -14,6 +14,19 @@ vi.mock('@/features/settings/hooks/useNotificationPreferences', () => ({
     useNotificationLog: () => ({ data: [], isLoading: false }),
 }));
 
+// Wave 30 Task 2: SettingsNotificationsTab now imports usePushSubscription.
+// Stub the whole hook so the Supabase client import chain doesn't execute.
+vi.mock('@/features/settings/hooks/usePushSubscription', () => ({
+    usePushSubscription: () => ({
+        subscription: null,
+        isSubscribing: false,
+        subscribe: vi.fn(),
+        unsubscribe: vi.fn(),
+        isSupported: false,
+        permissionState: 'default' as NotificationPermission,
+    }),
+}));
+
 // The existing Settings page reads `useSettings`; stub it so we're not testing
 // the Profile/Security tabs here.
 vi.mock('@/features/settings/hooks/useSettings', () => ({
@@ -90,11 +103,11 @@ describe('Settings — Notifications tab (Wave 30)', () => {
         expect(emailSwitch).not.toBeDisabled();
     });
 
-    it('renders the disabled Enable browser push button with a Wave 30 Task 2 tooltip', async () => {
+    it('disables the Enable browser push button when the browser lacks support', async () => {
         renderSettings();
         fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
         const btn = await screen.findByTestId('enable-browser-push');
         expect(btn).toBeDisabled();
-        expect(btn).toHaveAttribute('title', expect.stringMatching(/wave 30 task 2/i));
+        expect(btn).toHaveAttribute('title', expect.stringMatching(/not supported/i));
     });
 });

--- a/Testing/unit/supabase/functions/dispatch-push.test.ts
+++ b/Testing/unit/supabase/functions/dispatch-push.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dispatchToUsers, type DispatchBody, type SendFn, type SupabaseLike, type PushSubRow } from '../../../../supabase/functions/dispatch-push/dispatch';
+
+interface LoggedRow {
+    user_id: string;
+    channel: string;
+    event_type: string;
+    payload: Record<string, unknown>;
+    error: string | null;
+    provider_id: string | null;
+}
+
+/** Builds a fake Supabase client that routes `.from(table).select(...).in(...)` calls to the supplied table data. */
+function makeFakeSupabase(tables: {
+    notification_preferences?: unknown[];
+    push_subscriptions?: unknown[];
+}) {
+    const insertedLogs: LoggedRow[] = [];
+    const deletedSubIds: string[] = [];
+
+    const from: SupabaseLike['from'] = (table: string) => ({
+        select: () => ({
+            in: async () => {
+                if (table === 'notification_preferences') {
+                    return { data: tables.notification_preferences ?? [], error: null };
+                }
+                if (table === 'push_subscriptions') {
+                    return { data: tables.push_subscriptions ?? [], error: null };
+                }
+                return { data: [], error: null };
+            },
+        }),
+        insert: async (row: Record<string, unknown>) => {
+            if (table === 'notification_log') insertedLogs.push(row as unknown as LoggedRow);
+            return { error: null };
+        },
+        delete: () => ({
+            eq: async (_col: string, value: string) => {
+                if (table === 'push_subscriptions') deletedSubIds.push(value);
+                return { error: null };
+            },
+        }),
+    });
+
+    return { supabase: { from } satisfies SupabaseLike, insertedLogs, deletedSubIds };
+}
+
+const body: DispatchBody = {
+    user_ids: ['u-1'],
+    title: 'Test',
+    body: 'Hello',
+    event_type: 'mentions',
+};
+
+const baseNow = new Date('2026-04-18T12:00:00Z');
+
+beforeEach(() => {
+    vi.useRealTimers();
+});
+
+describe('dispatchToUsers (Wave 30 Task 2)', () => {
+    it('skips + logs pref_disabled when push_mentions=false', async () => {
+        const { supabase, insertedLogs } = makeFakeSupabase({
+            notification_preferences: [{
+                user_id: 'u-1',
+                push_mentions: false,
+                push_overdue: true,
+                push_assignment: true,
+                quiet_hours_start: null,
+                quiet_hours_end: null,
+                timezone: 'UTC',
+            }],
+            push_subscriptions: [],
+        });
+        const send = vi.fn<SendFn>();
+
+        const result = await dispatchToUsers(supabase, body, baseNow, send);
+
+        expect(send).not.toHaveBeenCalled();
+        expect(result).toEqual({ sent: 0, skipped: 1, failed: 0 });
+        expect(insertedLogs[0]).toMatchObject({ error: 'pref_disabled', user_id: 'u-1' });
+    });
+
+    it('skips + logs quiet_hours when local-now is in the quiet window', async () => {
+        // quiet 08:00–20:00 UTC; baseNow is 12:00 UTC → in window.
+        const { supabase, insertedLogs } = makeFakeSupabase({
+            notification_preferences: [{
+                user_id: 'u-1',
+                push_mentions: true,
+                push_overdue: true,
+                push_assignment: true,
+                quiet_hours_start: '08:00:00',
+                quiet_hours_end: '20:00:00',
+                timezone: 'UTC',
+            }],
+            push_subscriptions: [
+                { id: 's-1', user_id: 'u-1', endpoint: 'https://fcm.example/1', p256dh: 'p', auth: 'a' },
+            ],
+        });
+        const send = vi.fn<SendFn>();
+
+        const result = await dispatchToUsers(supabase, body, baseNow, send);
+
+        expect(send).not.toHaveBeenCalled();
+        expect(result).toEqual({ sent: 0, skipped: 1, failed: 0 });
+        expect(insertedLogs[0]).toMatchObject({ error: 'quiet_hours' });
+    });
+
+    it('logs success + provider_id on 200', async () => {
+        const { supabase, insertedLogs } = makeFakeSupabase({
+            notification_preferences: [{
+                user_id: 'u-1',
+                push_mentions: true,
+                push_overdue: true,
+                push_assignment: true,
+                quiet_hours_start: null,
+                quiet_hours_end: null,
+                timezone: 'UTC',
+            }],
+            push_subscriptions: [
+                { id: 's-1', user_id: 'u-1', endpoint: 'https://fcm.example/1', p256dh: 'p', auth: 'a' },
+            ],
+        });
+        const send = vi.fn<SendFn>().mockResolvedValue({ statusCode: 200, headers: { 'x-message-id': 'msg-123' } });
+
+        const result = await dispatchToUsers(supabase, body, baseNow, send);
+
+        expect(send).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({ sent: 1, skipped: 0, failed: 0 });
+        expect(insertedLogs[0]).toMatchObject({ error: null, provider_id: 'msg-123' });
+    });
+
+    it('410 → DELETE the subscription row + logs 410_gone', async () => {
+        const { supabase, insertedLogs, deletedSubIds } = makeFakeSupabase({
+            notification_preferences: [{
+                user_id: 'u-1',
+                push_mentions: true,
+                push_overdue: true,
+                push_assignment: true,
+                quiet_hours_start: null,
+                quiet_hours_end: null,
+                timezone: 'UTC',
+            }],
+            push_subscriptions: [
+                { id: 's-stale', user_id: 'u-1', endpoint: 'https://fcm.example/stale', p256dh: 'p', auth: 'a' },
+            ],
+        });
+        const send = vi.fn<SendFn>().mockRejectedValue({ statusCode: 410 });
+
+        const result = await dispatchToUsers(supabase, body, baseNow, send);
+
+        expect(result).toEqual({ sent: 0, skipped: 0, failed: 1 });
+        expect(deletedSubIds).toEqual(['s-stale']);
+        expect(insertedLogs[0]).toMatchObject({ error: '410_gone' });
+    });
+
+    it('iterates multiple subscriptions per user', async () => {
+        const subs: PushSubRow[] = [
+            { id: 's-1', user_id: 'u-1', endpoint: 'https://fcm.example/1', p256dh: 'p', auth: 'a' },
+            { id: 's-2', user_id: 'u-1', endpoint: 'https://fcm.example/2', p256dh: 'p', auth: 'a' },
+        ];
+        const { supabase, insertedLogs } = makeFakeSupabase({
+            notification_preferences: [{
+                user_id: 'u-1',
+                push_mentions: true,
+                push_overdue: true,
+                push_assignment: true,
+                quiet_hours_start: null,
+                quiet_hours_end: null,
+                timezone: 'UTC',
+            }],
+            push_subscriptions: subs,
+        });
+        const send = vi.fn<SendFn>().mockResolvedValue({ statusCode: 200, headers: {} });
+
+        const result = await dispatchToUsers(supabase, body, baseNow, send);
+
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(result).toEqual({ sent: 2, skipped: 0, failed: 0 });
+        expect(insertedLogs).toHaveLength(2);
+    });
+});

--- a/docs/db/migrations/2026_04_18_push_subscriptions.sql
+++ b/docs/db/migrations/2026_04_18_push_subscriptions.sql
@@ -1,0 +1,30 @@
+-- Migration: Wave 30 — push subscriptions
+-- Date: 2026-04-18
+-- Description:
+--   One row per (user, browser-endpoint). RLS scopes to own; the dispatch
+--   function (SECURITY DEFINER) reads across users and DELETEs stale rows
+--   on 410 Gone responses.
+--
+-- Revert path:
+--   DROP TABLE IF EXISTS public.push_subscriptions CASCADE;
+
+CREATE TABLE public.push_subscriptions (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint      text        NOT NULL,
+  p256dh        text        NOT NULL,
+  auth          text        NOT NULL,
+  user_agent    text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  last_used_at  timestamptz,
+  UNIQUE (user_id, endpoint)
+);
+
+CREATE INDEX idx_push_subscriptions_user_id ON public.push_subscriptions (user_id);
+
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Push subs: select own"  ON public.push_subscriptions FOR SELECT TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "Push subs: insert own"  ON public.push_subscriptions FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Push subs: delete own"  ON public.push_subscriptions FOR DELETE TO authenticated USING (user_id = auth.uid());
+-- UPDATE not exposed to clients; dispatch function uses SECURITY DEFINER.

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -1785,6 +1785,21 @@ CREATE TABLE IF NOT EXISTS "public"."notification_log" (
 ALTER TABLE "public"."notification_log" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "public"."push_subscriptions" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "endpoint" "text" NOT NULL,
+    "p256dh" "text" NOT NULL,
+    "auth" "text" NOT NULL,
+    "user_agent" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "last_used_at" timestamp with time zone
+);
+
+
+ALTER TABLE "public"."push_subscriptions" OWNER TO "postgres";
+
+
 -- Wave 30: Bootstrap a notification_preferences row for every auth.users INSERT.
 CREATE OR REPLACE FUNCTION "public"."bootstrap_notification_prefs"() RETURNS "trigger"
     LANGUAGE "plpgsql" SECURITY DEFINER
@@ -2050,11 +2065,30 @@ ALTER TABLE ONLY "public"."notification_log"
 
 
 
+ALTER TABLE ONLY "public"."push_subscriptions"
+    ADD CONSTRAINT "push_subscriptions_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."push_subscriptions"
+    ADD CONSTRAINT "push_subscriptions_user_id_endpoint_key" UNIQUE ("user_id", "endpoint");
+
+
+
+ALTER TABLE ONLY "public"."push_subscriptions"
+    ADD CONSTRAINT "push_subscriptions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+
+
 CREATE INDEX "idx_notification_log_user_id_sent_at" ON "public"."notification_log" USING "btree" ("user_id", "sent_at" DESC);
 
 
 
 CREATE INDEX "idx_notification_log_event_type" ON "public"."notification_log" USING "btree" ("event_type", "sent_at" DESC);
+
+
+
+CREATE INDEX "idx_push_subscriptions_user_id" ON "public"."push_subscriptions" USING "btree" ("user_id");
 
 
 
@@ -2440,6 +2474,18 @@ CREATE POLICY "Notif prefs: update own" ON "public"."notification_preferences" F
 
 
 CREATE POLICY "Notif log: select own or admin" ON "public"."notification_log" FOR SELECT TO "authenticated" USING ((("user_id" = "auth"."uid"()) OR "public"."is_admin"("auth"."uid"())));
+
+
+ALTER TABLE "public"."push_subscriptions" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "Push subs: select own" ON "public"."push_subscriptions" FOR SELECT TO "authenticated" USING (("user_id" = "auth"."uid"()));
+
+
+CREATE POLICY "Push subs: insert own" ON "public"."push_subscriptions" FOR INSERT TO "authenticated" WITH CHECK (("user_id" = "auth"."uid"()));
+
+
+CREATE POLICY "Push subs: delete own" ON "public"."push_subscriptions" FOR DELETE TO "authenticated" USING (("user_id" = "auth"."uid"()));
 
 
 CREATE POLICY "Comments select by project members" ON "public"."task_comments" FOR SELECT TO "authenticated" USING (("public"."is_active_member"("root_id", "auth"."uid"()) OR "public"."is_admin"("auth"."uid"())));

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,29 @@
+/**
+ * PlanterPlan service worker — push notification handler.
+ *
+ * EXCEPTION: this is the only non-TypeScript file in src/. Wave 32 will
+ * subsume it with a workbox-built TS worker (`src/sw.ts`) and DELETE this file.
+ * Tracked in docs/dev-notes.md.
+ */
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: 'PlanterPlan', body: event.data.text() };
+  }
+  const { title = 'PlanterPlan', body = '', url = '/', icon = '/icon-192.png', tag } = payload;
+  event.waitUntil(
+    self.registration.showNotification(title, { body, icon, tag, data: { url } }),
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url || '/';
+  event.waitUntil(self.clients.openWindow(url));
+});

--- a/src/features/settings/hooks/usePushSubscription.ts
+++ b/src/features/settings/hooks/usePushSubscription.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/shared/contexts/AuthContext';
+import { planter } from '@/shared/api/planterClient';
+import type { PushSubscriptionRow } from '@/shared/db/app.types';
+
+/** Base64-URL → Uint8Array for `applicationServerKey`. Standard MDN snippet. */
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+    const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+    const normalised = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const raw = atob(normalised);
+    const out = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i += 1) out[i] = raw.charCodeAt(i);
+    return out;
+}
+
+function readPermission(): NotificationPermission | 'unsupported' {
+    if (typeof Notification === 'undefined') return 'unsupported';
+    return Notification.permission;
+}
+
+/**
+ * Wave 30 Web Push subscription hook.
+ *
+ * Returns a small state machine: after mount, `subscribe()` triggers permission
+ * prompts + service-worker registration + a push subscription + the
+ * planterClient insert; `unsubscribe()` reverses it and DELETEs the row.
+ *
+ * `isSupported` is true only when the browser exposes both `navigator.serviceWorker`
+ * and `window.PushManager`. Falsy on the server (SSR / test) and on Safari
+ * without an installed PWA (Wave 32 gates the PWA shell).
+ */
+export function usePushSubscription() {
+    const { user } = useAuth();
+    const [subscription, setSubscription] = useState<PushSubscriptionRow | null>(null);
+    const [isSubscribing, setIsSubscribing] = useState(false);
+    const [permissionState, setPermissionState] = useState<NotificationPermission | 'unsupported'>(() => readPermission());
+
+    const isSupported = typeof navigator !== 'undefined'
+        && 'serviceWorker' in navigator
+        && typeof window !== 'undefined'
+        && 'PushManager' in window
+        && typeof Notification !== 'undefined';
+
+    // On mount (when supported and logged in) fetch the caller's row — RLS filters automatically.
+    useEffect(() => {
+        if (!isSupported || !user) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const rows = await planter.entities.PushSubscription.list();
+                if (!cancelled) setSubscription(rows[0] ?? null);
+            } catch (err) {
+                console.warn('[usePushSubscription] list() failed', err);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [isSupported, user]);
+
+    const subscribe = useCallback(async (): Promise<void> => {
+        if (!isSupported || !user) return;
+        setIsSubscribing(true);
+        try {
+            const permission = await Notification.requestPermission();
+            setPermissionState(permission);
+            if (permission !== 'granted') return;
+
+            const registration = await navigator.serviceWorker.register('/sw.js');
+            const publicKey = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+            if (!publicKey) {
+                console.error('[usePushSubscription] missing VITE_VAPID_PUBLIC_KEY');
+                return;
+            }
+            const sub = await registration.pushManager.subscribe({
+                userVisibleOnly: true,
+                // Cast avoids TS strict `ArrayBuffer` vs `ArrayBufferLike` mismatch on
+                // DOM lib typings; Uint8Array is the runtime-correct shape for VAPID keys.
+                applicationServerKey: urlBase64ToUint8Array(publicKey) as unknown as BufferSource,
+            });
+
+            const raw = sub.toJSON() as { endpoint?: string; keys?: { p256dh?: string; auth?: string } };
+            if (!raw.endpoint || !raw.keys?.p256dh || !raw.keys?.auth) {
+                console.error('[usePushSubscription] PushSubscription.toJSON returned incomplete payload');
+                return;
+            }
+            const inserted = await planter.entities.PushSubscription.create({
+                user_id: user.id,
+                endpoint: raw.endpoint,
+                p256dh: raw.keys.p256dh,
+                auth: raw.keys.auth,
+                user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+            });
+            setSubscription(inserted);
+        } catch (err) {
+            console.error('[usePushSubscription] subscribe failed', err);
+        } finally {
+            setIsSubscribing(false);
+        }
+    }, [isSupported, user]);
+
+    const unsubscribe = useCallback(async (): Promise<void> => {
+        if (!subscription) return;
+        try {
+            if (isSupported) {
+                const registration = await navigator.serviceWorker.getRegistration('/sw.js');
+                const existing = await registration?.pushManager.getSubscription();
+                if (existing) await existing.unsubscribe();
+            }
+            await planter.entities.PushSubscription.deleteByEndpoint(subscription.endpoint);
+            setSubscription(null);
+        } catch (err) {
+            console.error('[usePushSubscription] unsubscribe failed', err);
+        }
+    }, [subscription, isSupported]);
+
+    return {
+        subscription,
+        isSubscribing,
+        subscribe,
+        unsubscribe,
+        isSupported,
+        permissionState,
+    };
+}

--- a/src/features/settings/hooks/usePushSubscription.ts
+++ b/src/features/settings/hooks/usePushSubscription.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '@/shared/contexts/AuthContext';
 import { planter } from '@/shared/api/planterClient';
 import type { PushSubscriptionRow } from '@/shared/db/app.types';
@@ -25,6 +25,11 @@ function readPermission(): NotificationPermission | 'unsupported' {
  * prompts + service-worker registration + a push subscription + the
  * planterClient insert; `unsubscribe()` reverses it and DELETEs the row.
  *
+ * Multi-device aware: `subscription` always reflects THIS browser's row
+ * (matched by endpoint against the DB's full list for the user), so Device A
+ * never shows "Disable" because Device B happens to be subscribed, and
+ * unsubscribe never deletes a sibling device's row.
+ *
  * `isSupported` is true only when the browser exposes both `navigator.serviceWorker`
  * and `window.PushManager`. Falsy on the server (SSR / test) and on Safari
  * without an installed PWA (Wave 32 gates the PWA shell).
@@ -35,22 +40,39 @@ export function usePushSubscription() {
     const [isSubscribing, setIsSubscribing] = useState(false);
     const [permissionState, setPermissionState] = useState<NotificationPermission | 'unsupported'>(() => readPermission());
 
-    const isSupported = typeof navigator !== 'undefined'
-        && 'serviceWorker' in navigator
-        && typeof window !== 'undefined'
-        && 'PushManager' in window
-        && typeof Notification !== 'undefined';
+    // Computed once per mount — browser API availability doesn't change during a session.
+    const isSupported = useMemo(
+        () =>
+            typeof navigator !== 'undefined'
+            && 'serviceWorker' in navigator
+            && typeof window !== 'undefined'
+            && 'PushManager' in window
+            && typeof Notification !== 'undefined',
+        [],
+    );
 
-    // On mount (when supported and logged in) fetch the caller's row — RLS filters automatically.
+    // On mount (when supported and logged in) match the DB row to the CURRENT
+    // browser's endpoint. RLS filters to the caller's rows; `pushManager.getSubscription()`
+    // returns THIS browser's push handle (or null). Picking `rows[0]` blindly breaks
+    // multi-device — flagged in the Gemini PR review.
     useEffect(() => {
         if (!isSupported || !user) return;
         let cancelled = false;
         (async () => {
             try {
-                const rows = await planter.entities.PushSubscription.list();
-                if (!cancelled) setSubscription(rows[0] ?? null);
+                const [rows, registration] = await Promise.all([
+                    planter.entities.PushSubscription.list(),
+                    navigator.serviceWorker.getRegistration('/'),
+                ]);
+                if (cancelled) return;
+                const browserSub = await registration?.pushManager.getSubscription();
+                if (cancelled) return;
+                const currentSub = browserSub
+                    ? rows.find((r) => r.endpoint === browserSub.endpoint) ?? null
+                    : null;
+                setSubscription(currentSub);
             } catch (err) {
-                console.warn('[usePushSubscription] list() failed', err);
+                console.warn('[usePushSubscription] hydrate failed', err);
             }
         })();
         return () => { cancelled = true; };
@@ -101,7 +123,9 @@ export function usePushSubscription() {
         if (!subscription) return;
         try {
             if (isSupported) {
-                const registration = await navigator.serviceWorker.getRegistration('/sw.js');
+                // Scope URL (`/`), not script URL. The service worker registers from
+                // `/sw.js` but its scope is the origin root.
+                const registration = await navigator.serviceWorker.getRegistration('/');
                 const existing = await registration?.pushManager.getSubscription();
                 if (existing) await existing.unsubscribe();
             }

--- a/src/pages/components/SettingsNotificationsTab.tsx
+++ b/src/pages/components/SettingsNotificationsTab.tsx
@@ -16,6 +16,7 @@ import {
     useUpdateNotificationPreferences,
     useNotificationLog,
 } from '@/features/settings/hooks/useNotificationPreferences';
+import { usePushSubscription } from '@/features/settings/hooks/usePushSubscription';
 import type { NotificationPreferencesRow } from '@/shared/db/app.types';
 
 /** Turns `mention_pending` into `Mention Pending` for user-facing display. */
@@ -51,9 +52,11 @@ export default function SettingsNotificationsTab() {
     const logQuery = useNotificationLog({ limit: 20 });
     const timezoneOptions = useTimezoneOptions();
 
-    // Placeholder for Task 2: browser push isn't wired yet, so the three push
-    // toggles below are disabled with a tooltip until the subscription hook lands.
-    const pushSubscribed = false;
+    // Wave 30 Task 2: real browser push subscription state. When the browser
+    // lacks the APIs (Safari without PWA install, server render), `isSupported`
+    // is false and the Enable button is disabled with an explanatory tooltip.
+    const push = usePushSubscription();
+    const pushSubscribed = Boolean(push.subscription);
 
     if (isLoading || !prefs) {
         return (
@@ -132,11 +135,23 @@ export default function SettingsNotificationsTab() {
                     <Button
                         type="button"
                         variant="outline"
-                        disabled
-                        title="Browser push subscription wiring ships in Wave 30 Task 2"
+                        onClick={() => {
+                            if (pushSubscribed) void push.unsubscribe();
+                            else void push.subscribe();
+                        }}
+                        disabled={!push.isSupported || push.isSubscribing}
+                        title={push.isSupported
+                            ? (push.permissionState === 'denied'
+                                ? 'Browser notifications blocked — re-enable in site settings.'
+                                : undefined)
+                            : 'Browser push is not supported here (install the PWA on Safari, or use a desktop browser).'}
                         data-testid="enable-browser-push"
                     >
-                        Enable browser push
+                        {push.isSubscribing
+                            ? 'Working…'
+                            : pushSubscribed
+                                ? 'Disable browser push'
+                                : 'Enable browser push'}
                     </Button>
                 </div>
 

--- a/src/shared/api/planterClient.ts
+++ b/src/shared/api/planterClient.ts
@@ -18,7 +18,9 @@ import type {
     ActivityLogWithActor,
     NotificationPreferencesRow,
     NotificationPreferencesUpdate,
-    NotificationLogRow
+    NotificationLogRow,
+    PushSubscriptionRow,
+    PushSubscriptionInsert
 } from '@/shared/db/app.types';
 import type { User as AuthUser } from '@supabase/supabase-js';
 
@@ -62,6 +64,7 @@ export interface PlanterClient {
         Person: EntityClient<PersonRow, Database['public']['Tables']['people']['Insert'], Database['public']['Tables']['people']['Update']>;
         TaskComment: TaskCommentEntityClient;
         ActivityLog: ActivityLogEntityClient;
+        PushSubscription: PushSubscriptionEntityClient;
     };
     rpc: <T = unknown, P extends object = object>(functionName: string, params: P) => Promise<{ data: T | null, error: Error | null }>;
     functions: {
@@ -202,6 +205,16 @@ interface ActivityLogEntityClient {
         entityId: string,
         opts?: { limit?: number },
     ) => Promise<ActivityLogWithActor[]>;
+}
+
+/** Wave 30 push subscriptions — one row per (user, browser-endpoint). */
+interface PushSubscriptionEntityClient {
+    /** Inserts a subscription row; RLS enforces `user_id = auth.uid()`. */
+    create: (payload: Omit<PushSubscriptionInsert, 'user_id'> & { user_id: string }) => Promise<PushSubscriptionRow>;
+    /** Lists the caller's subscriptions newest-first. */
+    list: () => Promise<PushSubscriptionRow[]>;
+    /** DELETEs the caller's subscription with the given endpoint. RLS-scoped. */
+    deleteByEndpoint: (endpoint: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1004,6 +1017,42 @@ export const planter: PlanterClient = {
                 });
             },
         } satisfies ActivityLogEntityClient,
+
+        // -----------------------------------------------------------------
+        // PushSubscription (Wave 30)
+        // -----------------------------------------------------------------
+        PushSubscription: {
+            create: async (payload) => {
+                return retry(async () => {
+                    const { data, error } = await supabase
+                        .from('push_subscriptions')
+                        .insert(payload)
+                        .select('*')
+                        .single();
+                    if (error) throw new PlanterError(error.message, parseInt(error.code ?? '500'));
+                    return data as PushSubscriptionRow;
+                });
+            },
+            list: async () => {
+                return retry(async () => {
+                    const { data, error } = await supabase
+                        .from('push_subscriptions')
+                        .select('*')
+                        .order('created_at', { ascending: false });
+                    if (error) throw new PlanterError(error.message, parseInt(error.code ?? '500'));
+                    return (data as PushSubscriptionRow[]) || [];
+                });
+            },
+            deleteByEndpoint: async (endpoint) => {
+                return retry(async () => {
+                    const { error } = await supabase
+                        .from('push_subscriptions')
+                        .delete()
+                        .eq('endpoint', endpoint);
+                    if (error) throw new PlanterError(error.message, parseInt(error.code ?? '500'));
+                });
+            },
+        } satisfies PushSubscriptionEntityClient,
     },
 
     // ---------------------------------------------------------------------------

--- a/src/shared/db/app.types.ts
+++ b/src/shared/db/app.types.ts
@@ -79,6 +79,8 @@ export type TaskCommentWithAuthor = TaskCommentRow & {
 export type NotificationPreferencesRow    = Database['public']['Tables']['notification_preferences']['Row'];
 export type NotificationPreferencesUpdate = Database['public']['Tables']['notification_preferences']['Update'];
 export type NotificationLogRow            = Database['public']['Tables']['notification_log']['Row'];
+export type PushSubscriptionRow           = Database['public']['Tables']['push_subscriptions']['Row'];
+export type PushSubscriptionInsert        = Database['public']['Tables']['push_subscriptions']['Insert'];
 
 // ----------------------------------------------------------------------------
 // Activity Log (Wave 27)

--- a/src/shared/db/database.types.ts
+++ b/src/shared/db/database.types.ts
@@ -168,6 +168,39 @@ export type Database = {
  }
  Relationships: []
  }
+ push_subscriptions: {
+ Row: {
+ id: string
+ user_id: string
+ endpoint: string
+ p256dh: string
+ auth: string
+ user_agent: string | null
+ created_at: string
+ last_used_at: string | null
+ }
+ Insert: {
+ id?: string
+ user_id: string
+ endpoint: string
+ p256dh: string
+ auth: string
+ user_agent?: string | null
+ created_at?: string
+ last_used_at?: string | null
+ }
+ Update: {
+ id?: string
+ user_id?: string
+ endpoint?: string
+ p256dh?: string
+ auth?: string
+ user_agent?: string | null
+ created_at?: string
+ last_used_at?: string | null
+ }
+ Relationships: []
+ }
  people: {
  Row: {
  created_at: string | null

--- a/supabase/functions/_shared/notification-prefs.ts
+++ b/supabase/functions/_shared/notification-prefs.ts
@@ -15,6 +15,25 @@ export interface NotificationPrefsLite {
     timezone: string
 }
 
+// `Intl.DateTimeFormat` is expensive to instantiate. Memoize one formatter per
+// timezone so a batch dispatch to 1000 users sharing UTC pays the cost once,
+// not 1000×. The map persists across calls within a single Deno function
+// invocation; Gemini's PR review flagged the per-call construction.
+const formatterByTz = new Map<string, Intl.DateTimeFormat>()
+function formatterFor(timezone: string): Intl.DateTimeFormat {
+    let fmt = formatterByTz.get(timezone)
+    if (!fmt) {
+        fmt = new Intl.DateTimeFormat('en-US', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+            timeZone: timezone,
+        })
+        formatterByTz.set(timezone, fmt)
+    }
+    return fmt
+}
+
 /**
  * Returns `true` when `now` — when rendered in the user's tz — falls inside the
  * closed [start, end] window on the 24-hour clock. Handles wrap-across-midnight
@@ -30,13 +49,7 @@ export function inQuietHours(
     end: string | null,
 ): boolean {
     if (!start || !end) return false
-    const fmt = new Intl.DateTimeFormat('en-US', {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false,
-        timeZone: timezone,
-    })
-    const parts = fmt.formatToParts(now)
+    const parts = formatterFor(timezone).formatToParts(now)
     const hh = Number(parts.find((p) => p.type === 'hour')?.value ?? '0')
     const mm = Number(parts.find((p) => p.type === 'minute')?.value ?? '0')
     const nowMin = hh * 60 + mm

--- a/supabase/functions/_shared/notification-prefs.ts
+++ b/supabase/functions/_shared/notification-prefs.ts
@@ -1,0 +1,66 @@
+// Pure helpers shared by the Wave 30 dispatch edge functions. Kept here (not
+// in-line with a specific function's index.ts) so both `dispatch-push` and the
+// Task 3 `dispatch-notifications` / `overdue-digest` can import without the
+// Deno-only Supabase + esm.sh transitive deps. Node-friendly = vitest-testable.
+
+export type NotificationEventType = 'mentions' | 'overdue' | 'assignment'
+
+export interface NotificationPrefsLite {
+    user_id: string
+    push_mentions: boolean
+    push_overdue: boolean
+    push_assignment: boolean
+    quiet_hours_start: string | null
+    quiet_hours_end: string | null
+    timezone: string
+}
+
+/**
+ * Returns `true` when `now` — when rendered in the user's tz — falls inside the
+ * closed [start, end] window on the 24-hour clock. Handles wrap-across-midnight
+ * windows (e.g., 22:00–07:00).
+ *
+ * Uses `Intl.DateTimeFormat` for tz-aware formatting, not raw date math — so
+ * this helper stays styleguide-compliant and runs identically in Node and Deno.
+ */
+export function inQuietHours(
+    now: Date,
+    timezone: string,
+    start: string | null,
+    end: string | null,
+): boolean {
+    if (!start || !end) return false
+    const fmt = new Intl.DateTimeFormat('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+        timeZone: timezone,
+    })
+    const parts = fmt.formatToParts(now)
+    const hh = Number(parts.find((p) => p.type === 'hour')?.value ?? '0')
+    const mm = Number(parts.find((p) => p.type === 'minute')?.value ?? '0')
+    const nowMin = hh * 60 + mm
+
+    const startMin = toMinutes(start)
+    const endMin = toMinutes(end)
+
+    if (startMin <= endMin) {
+        return nowMin >= startMin && nowMin <= endMin
+    }
+    // Wraps across midnight.
+    return nowMin >= startMin || nowMin <= endMin
+}
+
+function toMinutes(hhmm: string): number {
+    const [h, m] = hhmm.split(':').map(Number)
+    return (h || 0) * 60 + (m || 0)
+}
+
+/** Maps an event type to the matching `push_*` column on notification_preferences. */
+export function pushPrefColumnFor(event: NotificationEventType): keyof Pick<NotificationPrefsLite, 'push_mentions' | 'push_overdue' | 'push_assignment'> {
+    switch (event) {
+        case 'mentions': return 'push_mentions'
+        case 'overdue': return 'push_overdue'
+        case 'assignment': return 'push_assignment'
+    }
+}

--- a/supabase/functions/dispatch-push/README.md
+++ b/supabase/functions/dispatch-push/README.md
@@ -1,0 +1,71 @@
+# dispatch-push (Wave 30)
+
+Web Push fan-out edge function. Called from other edge functions (Task 3's
+`dispatch-notifications` + `overdue-digest`) — **not** from the browser.
+
+## Contract
+
+```ts
+POST { user_ids: string[], title: string, body: string, url?: string, tag?: string, event_type: 'mentions' | 'overdue' | 'assignment' }
+→ { success: true, sent: number, skipped: number, failed: number }
+```
+
+## Pre-flight per dispatch
+
+For every user in `user_ids`:
+1. Load `notification_preferences.push_<event_type>` — skip with
+   `error = 'pref_disabled'` when false.
+2. Check the user's `quiet_hours_start` / `quiet_hours_end` in their
+   `timezone` via `Intl.DateTimeFormat` — skip with `error = 'quiet_hours'`.
+3. Load every `push_subscriptions` row and send one push per subscription
+   via `web-push@3.6.7` (ESM from esm.sh).
+4. On `statusCode === 410 | 404`: DELETE the stale subscription row and log
+   `error = '410_gone'`. On other failures: log `error = <status | message>`.
+5. On success: log the `x-message-id` response header as `provider_id`.
+
+All log rows go into `public.notification_log` (SECURITY DEFINER —
+the function uses `SUPABASE_SERVICE_ROLE_KEY`).
+
+## Required environment
+
+| Variable | Scope | Description |
+| --- | --- | --- |
+| `SUPABASE_URL` | function | Project URL. |
+| `SUPABASE_SERVICE_ROLE_KEY` | function (secret) | Service-role key; bypasses RLS for cross-user reads + log inserts. |
+| `VITE_VAPID_PUBLIC_KEY` | function | VAPID public key (same value the browser bundles). |
+| `VAPID_PRIVATE_KEY` | function (secret) | VAPID private key — **never committed**. |
+| `VAPID_SUBJECT` | function | `mailto:ops@planterplan.example` (contact for push-service operators). |
+
+Generate VAPID keys once: `npx web-push generate-vapid-keys`. Put the public
+key in `.env.example` (shipped to the bundle as `VITE_VAPID_PUBLIC_KEY`);
+the private key is a Supabase secret only.
+
+When any VAPID env is missing the function short-circuits to log-only (writes
+`error = 'vapid_unconfigured'` to `notification_log` so the operator can spot
+the misconfiguration at a glance).
+
+## Scheduling
+
+Not scheduled. Invoked by other edge functions only. Schedule the callers
+(Task 3) — `dispatch-notifications` on a 1-minute interval,
+`overdue-digest` daily/weekly.
+
+**`pg_cron` is intentionally NOT enabled in this codebase.** Use:
+- Supabase Dashboard → Scheduled Triggers (preferred), OR
+- GitHub Actions cron POSTing the function URL, OR
+- An external pinger (`cron-job.org`, etc.).
+
+## Local smoke
+
+```bash
+supabase functions serve dispatch-push --env-file ./supabase/.env.local
+
+curl -X POST http://127.0.0.1:54321/functions/v1/dispatch-push \
+  -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "user_ids": ["<uid>"], "title": "Hello", "body": "World", "event_type": "mentions" }'
+```
+
+Expect `{ success: true, sent: 1, skipped: 0, failed: 0 }` when the target
+user has a valid subscription, `push_mentions = true`, and isn't in quiet
+hours.

--- a/supabase/functions/dispatch-push/dispatch.ts
+++ b/supabase/functions/dispatch-push/dispatch.ts
@@ -1,0 +1,177 @@
+// Pure dispatch loop, factored out of `index.ts` so vitest can import + test it
+// without spinning up Deno.serve or esm.sh. The Deno entry point injects the
+// real Supabase client and a web-push-backed `sender`; tests inject mocks.
+
+import {
+    inQuietHours,
+    pushPrefColumnFor,
+    type NotificationEventType,
+    type NotificationPrefsLite,
+} from '../_shared/notification-prefs.ts'
+
+export interface DispatchBody {
+    user_ids: string[]
+    title: string
+    body: string
+    url?: string
+    tag?: string
+    event_type: NotificationEventType
+}
+
+export interface PushSubRow {
+    id: string
+    user_id: string
+    endpoint: string
+    p256dh: string
+    auth: string
+}
+
+export interface SupabaseLike {
+    from: (table: string) => {
+        select: (cols: string) => {
+            in: (col: string, values: string[]) => Promise<{ data: unknown[] | null; error: { message: string } | null }>
+        }
+        insert: (row: Record<string, unknown>) => Promise<{ error: { message: string } | null }>
+        delete: () => {
+            eq: (col: string, value: string) => Promise<{ error: { message: string } | null }>
+        }
+    }
+}
+
+export interface SendResult {
+    statusCode: number
+    headers?: Record<string, string>
+}
+
+export type SendFn = (sub: PushSubRow, payload: string) => Promise<SendResult>
+
+export interface DispatchResult {
+    sent: number
+    skipped: number
+    failed: number
+}
+
+async function logDispatch(
+    supabase: SupabaseLike,
+    row: {
+        user_id: string
+        event_type: string
+        payload: Record<string, unknown>
+        error?: string | null
+        provider_id?: string | null
+    },
+): Promise<void> {
+    await supabase.from('notification_log').insert({
+        user_id: row.user_id,
+        channel: 'push',
+        event_type: row.event_type,
+        payload: row.payload,
+        error: row.error ?? null,
+        provider_id: row.provider_id ?? null,
+    })
+}
+
+/**
+ * Core dispatch loop. For each user: check prefs → check quiet hours → fetch
+ * subscriptions → call `send` for each. Records every outcome in notification_log.
+ * On 410/404 from the sender: DELETEs the stale subscription row.
+ */
+export async function dispatchToUsers(
+    supabase: SupabaseLike,
+    body: DispatchBody,
+    now: Date,
+    send: SendFn,
+): Promise<DispatchResult> {
+    const prefColumn = pushPrefColumnFor(body.event_type)
+
+    const prefsRes = await supabase
+        .from('notification_preferences')
+        .select('user_id, push_mentions, push_overdue, push_assignment, quiet_hours_start, quiet_hours_end, timezone')
+        .in('user_id', body.user_ids)
+    if (prefsRes.error) throw new Error(prefsRes.error.message)
+    const prefsByUser = new Map<string, NotificationPrefsLite>()
+    for (const p of (prefsRes.data ?? []) as NotificationPrefsLite[]) prefsByUser.set(p.user_id, p)
+
+    const subsRes = await supabase
+        .from('push_subscriptions')
+        .select('id, user_id, endpoint, p256dh, auth')
+        .in('user_id', body.user_ids)
+    if (subsRes.error) throw new Error(subsRes.error.message)
+    const subsByUser = new Map<string, PushSubRow[]>()
+    for (const s of (subsRes.data ?? []) as PushSubRow[]) {
+        const bucket = subsByUser.get(s.user_id) ?? []
+        bucket.push(s)
+        subsByUser.set(s.user_id, bucket)
+    }
+
+    let sent = 0
+    let skipped = 0
+    let failed = 0
+
+    for (const uid of body.user_ids) {
+        const prefs = prefsByUser.get(uid)
+        if (!prefs) {
+            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'prefs_missing' })
+            skipped += 1
+            continue
+        }
+        if (prefs[prefColumn] !== true) {
+            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'pref_disabled' })
+            skipped += 1
+            continue
+        }
+        if (inQuietHours(now, prefs.timezone, prefs.quiet_hours_start, prefs.quiet_hours_end)) {
+            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'quiet_hours' })
+            skipped += 1
+            continue
+        }
+
+        const subs = subsByUser.get(uid) ?? []
+        if (subs.length === 0) {
+            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'no_subscription' })
+            skipped += 1
+            continue
+        }
+
+        for (const s of subs) {
+            const payload = JSON.stringify({
+                title: body.title,
+                body: body.body,
+                url: body.url ?? '/',
+                tag: body.tag,
+            })
+            try {
+                const result = await send(s, payload)
+                const providerId = result.headers?.['x-message-id'] ?? null
+                await logDispatch(supabase, {
+                    user_id: uid,
+                    event_type: body.event_type,
+                    payload: { title: body.title, endpoint_id: s.id },
+                    provider_id: providerId,
+                })
+                sent += 1
+            } catch (err) {
+                const status = (err as { statusCode?: number }).statusCode
+                if (status === 410 || status === 404) {
+                    await supabase.from('push_subscriptions').delete().eq('id', s.id)
+                    await logDispatch(supabase, {
+                        user_id: uid,
+                        event_type: body.event_type,
+                        payload: { title: body.title, endpoint_id: s.id },
+                        error: '410_gone',
+                    })
+                } else {
+                    await logDispatch(supabase, {
+                        user_id: uid,
+                        event_type: body.event_type,
+                        payload: { title: body.title, endpoint_id: s.id },
+                        error: String(status ?? (err as Error).message),
+                    })
+                }
+                failed += 1
+            }
+        }
+    }
+
+    return { sent, skipped, failed }
+}

--- a/supabase/functions/dispatch-push/dispatch.ts
+++ b/supabase/functions/dispatch-push/dispatch.ts
@@ -104,74 +104,103 @@ export async function dispatchToUsers(
         subsByUser.set(s.user_id, bucket)
     }
 
+    // Payload is identical across every subscription for a single dispatch call,
+    // so build it ONCE up front. Previously it was stringified inside the
+    // per-subscription loop (Gemini PR review).
+    const payload = JSON.stringify({
+        title: body.title,
+        body: body.body,
+        url: body.url ?? '/',
+        tag: body.tag,
+    })
+
+    // Process users in parallel; within each user, process subscriptions in
+    // parallel. `Promise.allSettled` guarantees a single failure can't poison
+    // the batch. Sequential awaits would be fine for 1–10 users but risked
+    // edge-function timeouts for large fan-outs (Gemini PR review).
+    const perUser = await Promise.allSettled(
+        body.user_ids.map(async (uid): Promise<DispatchResult> => {
+            const prefs = prefsByUser.get(uid)
+            if (!prefs) {
+                await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'prefs_missing' })
+                return { sent: 0, skipped: 1, failed: 0 }
+            }
+            if (prefs[prefColumn] !== true) {
+                await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'pref_disabled' })
+                return { sent: 0, skipped: 1, failed: 0 }
+            }
+            if (inQuietHours(now, prefs.timezone, prefs.quiet_hours_start, prefs.quiet_hours_end)) {
+                await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'quiet_hours' })
+                return { sent: 0, skipped: 1, failed: 0 }
+            }
+
+            const subs = subsByUser.get(uid) ?? []
+            if (subs.length === 0) {
+                await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'no_subscription' })
+                return { sent: 0, skipped: 1, failed: 0 }
+            }
+
+            const subResults = await Promise.allSettled(subs.map(async (s) => {
+                try {
+                    const result = await send(s, payload)
+                    const providerId = result.headers?.['x-message-id'] ?? null
+                    await logDispatch(supabase, {
+                        user_id: uid,
+                        event_type: body.event_type,
+                        payload: { title: body.title, endpoint_id: s.id },
+                        provider_id: providerId,
+                    })
+                    return 'sent' as const
+                } catch (err) {
+                    const status = (err as { statusCode?: number }).statusCode
+                    if (status === 410 || status === 404) {
+                        await supabase.from('push_subscriptions').delete().eq('id', s.id)
+                        await logDispatch(supabase, {
+                            user_id: uid,
+                            event_type: body.event_type,
+                            payload: { title: body.title, endpoint_id: s.id },
+                            error: '410_gone',
+                        })
+                    } else {
+                        await logDispatch(supabase, {
+                            user_id: uid,
+                            event_type: body.event_type,
+                            payload: { title: body.title, endpoint_id: s.id },
+                            error: String(status ?? (err as Error).message),
+                        })
+                    }
+                    return 'failed' as const
+                }
+            }))
+
+            let uSent = 0
+            let uFailed = 0
+            for (const r of subResults) {
+                // `fn` never throws; `.catch` inside returns 'failed'. If something DOES
+                // throw unexpectedly, count it as a failure (defensive).
+                if (r.status === 'fulfilled') {
+                    if (r.value === 'sent') uSent += 1
+                    else uFailed += 1
+                } else {
+                    uFailed += 1
+                }
+            }
+            return { sent: uSent, skipped: 0, failed: uFailed }
+        }),
+    )
+
     let sent = 0
     let skipped = 0
     let failed = 0
-
-    for (const uid of body.user_ids) {
-        const prefs = prefsByUser.get(uid)
-        if (!prefs) {
-            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'prefs_missing' })
-            skipped += 1
-            continue
-        }
-        if (prefs[prefColumn] !== true) {
-            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'pref_disabled' })
-            skipped += 1
-            continue
-        }
-        if (inQuietHours(now, prefs.timezone, prefs.quiet_hours_start, prefs.quiet_hours_end)) {
-            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'quiet_hours' })
-            skipped += 1
-            continue
-        }
-
-        const subs = subsByUser.get(uid) ?? []
-        if (subs.length === 0) {
-            await logDispatch(supabase, { user_id: uid, event_type: body.event_type, payload: { title: body.title }, error: 'no_subscription' })
-            skipped += 1
-            continue
-        }
-
-        for (const s of subs) {
-            const payload = JSON.stringify({
-                title: body.title,
-                body: body.body,
-                url: body.url ?? '/',
-                tag: body.tag,
-            })
-            try {
-                const result = await send(s, payload)
-                const providerId = result.headers?.['x-message-id'] ?? null
-                await logDispatch(supabase, {
-                    user_id: uid,
-                    event_type: body.event_type,
-                    payload: { title: body.title, endpoint_id: s.id },
-                    provider_id: providerId,
-                })
-                sent += 1
-            } catch (err) {
-                const status = (err as { statusCode?: number }).statusCode
-                if (status === 410 || status === 404) {
-                    await supabase.from('push_subscriptions').delete().eq('id', s.id)
-                    await logDispatch(supabase, {
-                        user_id: uid,
-                        event_type: body.event_type,
-                        payload: { title: body.title, endpoint_id: s.id },
-                        error: '410_gone',
-                    })
-                } else {
-                    await logDispatch(supabase, {
-                        user_id: uid,
-                        event_type: body.event_type,
-                        payload: { title: body.title, endpoint_id: s.id },
-                        error: String(status ?? (err as Error).message),
-                    })
-                }
-                failed += 1
-            }
+    for (const r of perUser) {
+        if (r.status === 'fulfilled') {
+            sent += r.value.sent
+            skipped += r.value.skipped
+            failed += r.value.failed
+        } else {
+            // Entire per-user task threw (e.g., logDispatch I/O failure).
+            failed += 1
         }
     }
-
     return { sent, skipped, failed }
 }

--- a/supabase/functions/dispatch-push/index.ts
+++ b/supabase/functions/dispatch-push/index.ts
@@ -1,0 +1,72 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import webPush from 'https://esm.sh/web-push@3.6.7'
+import { dispatchToUsers, type DispatchBody, type PushSubRow, type SendResult } from './dispatch.ts'
+
+const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+Deno.serve(async (req) => {
+    if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+    try {
+        const body = (await req.json()) as DispatchBody
+        if (!body?.user_ids?.length || !body.title || !body.event_type) {
+            return new Response(JSON.stringify({ success: false, error: 'missing user_ids/title/event_type' }), {
+                headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+                status: 400,
+            })
+        }
+
+        const supabase = createClient(
+            Deno.env.get('SUPABASE_URL') ?? '',
+            Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+        )
+
+        const privateKey = Deno.env.get('VAPID_PRIVATE_KEY')
+        const publicKey = Deno.env.get('VITE_VAPID_PUBLIC_KEY')
+        const subject = Deno.env.get('VAPID_SUBJECT')
+        if (!privateKey || !publicKey || !subject) {
+            console.warn('[dispatch-push] VAPID env missing; short-circuiting to log-only')
+            for (const uid of body.user_ids) {
+                await supabase.from('notification_log').insert({
+                    user_id: uid,
+                    channel: 'push',
+                    event_type: body.event_type,
+                    payload: { title: body.title },
+                    error: 'vapid_unconfigured',
+                })
+            }
+            return new Response(JSON.stringify({ success: false, error: 'vapid_unconfigured' }), {
+                headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+                status: 200,
+            })
+        }
+        webPush.setVapidDetails(subject, publicKey, privateKey)
+
+        const sender = async (sub: PushSubRow, payload: string): Promise<SendResult> => {
+            const result = await webPush.sendNotification(
+                { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+                payload,
+            )
+            return {
+                statusCode: result?.statusCode ?? 200,
+                headers: (result?.headers ?? {}) as Record<string, string>,
+            }
+        }
+
+        // @ts-expect-error the Deno Supabase client has a slightly wider type than the pure helper expects; the runtime contract is identical.
+        const result = await dispatchToUsers(supabase, body, new Date(), sender)
+
+        return new Response(JSON.stringify({ success: true, ...result }), {
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        })
+    } catch (error) {
+        console.error('[dispatch-push] unhandled error', error)
+        return new Response(JSON.stringify({ success: false, error: 'Internal server error' }), {
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            status: 500,
+        })
+    }
+})


### PR DESCRIPTION
## Summary
- **Data layer.** `public.push_subscriptions` table with `UNIQUE(user_id, endpoint)`, self-scoped RLS for SELECT/INSERT/DELETE (no client UPDATE; the SECURITY DEFINER dispatcher is the sole mutator), and an index on `user_id`. Migration: `docs/db/migrations/2026_04_18_push_subscriptions.sql`. Types hand-added to `database.types.ts` + re-exported from `app.types.ts`.
- **Client layer.** `planter.entities.PushSubscription.{create, list, deleteByEndpoint}` namespace. `usePushSubscription` hook returns `{ subscription, isSubscribing, subscribe, unsubscribe, isSupported, permissionState }` and handles the standard `Notification.requestPermission` → `navigator.serviceWorker.register('/sw.js')` → `pushManager.subscribe` → `planter.entities.PushSubscription.create` flow. `public/sw.js` is the only non-TS file under `src/`; header comment + a dev-notes entry will land in the Wave 30 finalize to flag the Wave 32 workbox-replacement.
- **Edge function.** `supabase/functions/dispatch-push/` is split into a thin Deno.serve wrapper (`index.ts`, env + web-push binding) and a pure dispatch loop (`dispatch.ts`) so vitest can exercise the whole state machine without spinning up Deno. Pure helpers live in `_shared/notification-prefs.ts` (`inQuietHours` handles wrap-across-midnight windows via `Intl.DateTimeFormat`; `pushPrefColumnFor` maps event types to `push_*` columns). When VAPID env is missing the function short-circuits to log-only.
- **Settings UI.** The Enable/Disable push button wires to `usePushSubscription`; disabled-tooltip surfaces permission-denied or not-supported states (Safari without PWA install).
- **Env + tooling.** `.env.example` seeded with the three VAPID keys (public committed as var name only — values belong in Supabase secrets / local `.env`).

## Test-count delta
76 test files (+2) / 740 tests (+10).

Verification gate (all green locally):
- `npm run lint` — 0 errors, 4 warnings (pre-existing baseline).
- `npm run build` — clean.
- `npm test` — 740 passed.

`dispatch-push` tests cover the 5 mandated scenarios: `pref_disabled` skip+log, `quiet_hours` skip+log, `200` with `provider_id`, `410` → DELETE the subscription + log `410_gone`, and multi-subscription fan-out. `usePushSubscription` tests cover `isSupported` detection, `list()` hydration, permission-granted subscribe, permission-denied early return, and unsubscribe's browser-side + DB-side cleanup.

## Out of scope (per wave plan)
- iOS Safari push without PWA install (Wave 32 ships the PWA shell).
- Rich notifications with action buttons, badge counters.
- Native mobile push.

## Test plan
- [x] Lint / build / tests — green.
- [ ] **Manual: generate VAPID keys locally** (`npx web-push generate-vapid-keys`), put `VITE_VAPID_PUBLIC_KEY` in `.env.local` and the matching `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT` in Supabase secrets.
- [ ] Manual: visit Settings → Notifications → click Enable browser push → grant the browser prompt → verify a row lands in `push_subscriptions`.
- [ ] Manual: invoke `dispatch-push` via `supabase functions serve dispatch-push` against your own user id → see a system notification + a `notification_log` row with `provider_id`.
- [ ] Manual: flip `push_mentions = false` → re-invoke → verify `error = 'pref_disabled'` in `notification_log` and no notification.
- [ ] Manual: set quiet hours covering "now" → re-invoke → verify `error = 'quiet_hours'`.
- [ ] Manual: clear the local subscription (DevTools → Application → Service Workers → Unregister) + re-invoke → expect `error = '410_gone'` and the `push_subscriptions` row gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)