### PR TITLE
chore(tests): restore LocaleSwitcher cache + drop stale eslint-disables

### DIFF
--- a/Testing/install-storage.ts
+++ b/Testing/install-storage.ts
@@ -1,0 +1,33 @@
+// Swap jsdom's persistence-backed localStorage/sessionStorage for plain
+// in-memory stores BEFORE any module imports them. jsdom 29 throws on
+// `setItem` when `--localstorage-file` is absent, which trips
+// `i18next-browser-languagedetector`'s one-shot `hasLocalStorageSupport`
+// probe during i18n init and silently disables caching for the whole run.
+// Importing this file first in `setupTests.ts` ensures the swap lands before
+// `@/shared/i18n` initializes its detector.
+
+class MemoryStorage implements Storage {
+ private store = new Map<string, string>();
+ get length(): number { return this.store.size; }
+ clear(): void { this.store.clear(); }
+ getItem(key: string): string | null {
+  return this.store.get(key) ?? null;
+ }
+ key(index: number): string | null {
+  const keys = Array.from(this.store.keys());
+  return (index >= 0 && index < keys.length) ? keys[index] : null;
+ }
+ removeItem(key: string): void { this.store.delete(key); }
+ setItem(key: string, value: string): void { this.store.set(key, String(value)); }
+}
+
+Object.defineProperty(window, 'localStorage', {
+ value: new MemoryStorage(),
+ writable: true,
+ configurable: true,
+});
+Object.defineProperty(window, 'sessionStorage', {
+ value: new MemoryStorage(),
+ writable: true,
+ configurable: true,
+});

--- a/Testing/setupTests.ts
+++ b/Testing/setupTests.ts
@@ -1,3 +1,7 @@
+// Storage swap runs before any other import so the in-memory polyfill is in
+// place before `@/shared/i18n` initializes `i18next-browser-languagedetector`
+// and probes `window.localStorage`. See `./install-storage` for the rationale.
+import './install-storage';
 import '@testing-library/jest-dom';
 import { vi, beforeEach } from 'vitest';
 // Eager i18n init so components calling `useTranslation` resolve against
@@ -25,35 +29,6 @@ Object.defineProperty(window, 'matchMedia', {
  removeEventListener: vi.fn(),
  dispatchEvent: vi.fn(),
  })),
-});
-
-// jsdom 29 ships a persistence-backed localStorage that fails without a
-// `--localstorage-file` path (vitest doesn't supply one). Install a plain
-// in-memory Storage so tests have the full API and are isolated per run.
-class MemoryStorage implements Storage {
- private store = new Map<string, string>();
- get length(): number { return this.store.size; }
- clear(): void { this.store.clear(); }
- getItem(key: string): string | null {
-  return this.store.get(key) ?? null;
- }
- key(index: number): string | null {
-  const keys = Array.from(this.store.keys());
-  return (index >= 0 && index < keys.length) ? keys[index] : null;
- }
- removeItem(key: string): void { this.store.delete(key); }
- setItem(key: string, value: string): void { this.store.set(key, String(value)); }
-}
-
-Object.defineProperty(window, 'localStorage', {
- value: new MemoryStorage(),
- writable: true,
- configurable: true,
-});
-Object.defineProperty(window, 'sessionStorage', {
- value: new MemoryStorage(),
- writable: true,
- configurable: true,
 });
 
 beforeEach(() => {

--- a/src/features/library/hooks/useTreeState.ts
+++ b/src/features/library/hooks/useTreeState.ts
@@ -29,11 +29,8 @@ export const useTreeState = (rootTasks: TreeNode[]): UseTreeStateReturn => {
 
     // Effect 1: Handle data updates from props. Hook owns mutable tree state
     // (reorders, status changes, lazily-loaded children) so we can't derive via useMemo.
-    // eslint-plugin-react-hooks@7 added `set-state-in-effect`; refactoring this
-    // hook is out of Wave 30 Task 3 scope — tracked for a future cleanup wave.
     useEffect(() => {
         if (rootTasks && rootTasks.length > 0) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
             setTreeData(mergeTaskUpdates(rootTasks));
         } else if (rootTasks) {
             setTreeData([]);
@@ -42,7 +39,6 @@ export const useTreeState = (rootTasks: TreeNode[]): UseTreeStateReturn => {
 
     // Effect 2: Sync persistent expansion state onto the tree. Same rationale as above.
     useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setTreeData((prevTree) => updateTreeExpansion(prevTree, expandedTaskIds));
     }, [expandedTaskIds]);
 


### PR DESCRIPTION
## Summary

Bridge PR cutting pre-existing drift on `main` that was blocking Wave 32 Task 1 pre-flight. Not part of any wave — cleanup only.

- **LocaleSwitcher test failure** (in place since Wave 31 shipped, [022d39a](https://github.com/JoelA510/PlanterPlan-Alpha/commit/022d39a)): `Testing/setupTests.ts` imported `@/shared/i18n` before installing the in-memory storage polyfill. `i18next-browser-languagedetector`'s one-shot `hasLocalStorageSupport` probe ran against jsdom's persistence-backed localStorage (which fails without `--localstorage-file`), cached `false`, and silently disabled `cacheUserLanguage` for the entire test run. Extracted the storage swap into a dedicated side-effect module (`Testing/install-storage.ts`) and imported it first in `setupTests.ts` so the polyfill is in place when the detector's probe fires.
- **Two stale `eslint-disable-next-line` directives** in `src/features/library/hooks/useTreeState.ts`: the `react-hooks/set-state-in-effect` rule no longer fires at those call sites, so the disables were flagged as unused. Removed the directives + the stale "Wave 30 Task 3" rationale comment; the `useEffect` bodies are otherwise unchanged.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `npm test` | 790 passed / 1 failed (791) | **791 passed (791)** |
| `npm run lint` | 0 errors / 8 warnings | 0 errors / **6 warnings** (≤7 baseline) |
| `npm run build` | clean | clean |

Remaining 6 warnings are all pre-existing (1× PeopleList, 1× useSettings, 4× AuthContext) — out of scope for this bridge.

## Test plan
- [x] `npx vitest run Testing/unit/features/settings/components/LocaleSwitcher.test.tsx` — 2/2 pass
- [x] `npx vitest run` — 791/791 pass
- [x] `npm run lint` — 0 errors, 6 warnings
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)