### PR TITLE
fix(wave-32): correct milestone/status filtering in useTaskFilters

### DIFF
--- a/Testing/unit/features/projects/hooks/useProjectPresence.test.tsx
+++ b/Testing/unit/features/projects/hooks/useProjectPresence.test.tsx
@@ -13,10 +13,15 @@ vi.mock('@/shared/db/client', () => ({
     },
 }));
 
+// Stable references: the `user` object MUST keep the same identity across
+// renders, or the `[projectId, user]` dep array on `useProjectPresence`'s
+// effect re-fires every render → cleanup setMyPresenceKey(null) races the
+// async `setMyPresenceKey(user.id)` in subscribe's callback, producing an
+// intermittent `null` vs `'me'` observed by the first test.
+const mockAuthUser = { id: 'me', email: 'me@example.com' };
+const mockAuthValue = { user: mockAuthUser };
 vi.mock('@/shared/contexts/AuthContext', () => ({
-    useAuth: () => ({
-        user: { id: 'me', email: 'me@example.com' },
-    }),
+    useAuth: () => mockAuthValue,
 }));
 
 import { useProjectPresence } from '@/features/projects/hooks/useProjectPresence';

--- a/Testing/unit/features/tasks/hooks/useTaskFilters.test.ts
+++ b/Testing/unit/features/tasks/hooks/useTaskFilters.test.ts
@@ -5,15 +5,22 @@ import { makeTask, makeProject } from '@test/factories';
 const NOW = new Date('2026-04-16T12:00:00.000Z');
 
 // Hierarchy:
-//   project (root)
-//   ├─ phase
-//   │   ├─ milestone-overdue          (due 2026-04-10)
-//   │   ├─ milestone-due-soon         (due 2026-04-18)
-//   │   └─ milestone-current          (due 2026-05-20)
-//   ├─ task-not-yet-due               (start 2026-05-01, due 2026-05-10)
-//   ├─ task-completed                 (is_complete=true)
-//   └─ task-priority-high             (priority='high', due 2026-05-20)
-// template-root (origin='template') + template-child (should be ignored)
+//   project (root, instance, due_soon_threshold=3)
+//   ├─ phase-1   (task_type='phase')
+//   │   ├─ m-overdue   (task_type='milestone', due 2026-04-10)
+//   │   ├─ m-soon      (task_type='milestone', due 2026-04-18)
+//   │   └─ leak-task   (task_type='task'; grand-child but NOT a milestone —
+//   │                   Wave 32 regression guard: structural predicate would
+//   │                   have pulled this into the 'milestones' filter.)
+//   ├─ phase-2   (task_type='phase')
+//   │   └─ m-current   (task_type='milestone', due 2026-05-20)
+//   ├─ t-priority      (task_type='task', priority='high', status='todo', due 2026-05-20)
+//   ├─ t-future        (task_type='task', status='todo', start 2026-05-01, due 2026-05-10)
+//   ├─ t-done          (task_type='task', status='completed', is_complete=true, due 2026-03-15)
+//   └─ t-current       (task_type='task', status='in_progress', due 2026-05-15)
+//
+//   tpl-root (origin='template')
+//   └─ tpl-m (origin='template', task_type='milestone') — excluded by origin
 function buildFixture() {
  const project = makeProject({
   id: 'project',
@@ -21,105 +28,160 @@ function buildFixture() {
   origin: 'instance',
   settings: { due_soon_threshold: 3 },
  });
- const phase = makeTask({
-  id: 'phase',
+ const phase1 = makeTask({
+  id: 'phase-1',
   title: 'Phase 1',
   parent_task_id: 'project',
   root_id: 'project',
   origin: 'instance',
+  task_type: 'phase',
+ });
+ const phase2 = makeTask({
+  id: 'phase-2',
+  title: 'Phase 2',
+  parent_task_id: 'project',
+  root_id: 'project',
+  origin: 'instance',
+  task_type: 'phase',
  });
  const milestoneOverdue = makeTask({
   id: 'm-overdue',
   title: 'Alpha milestone overdue',
-  parent_task_id: 'phase',
+  parent_task_id: 'phase-1',
   root_id: 'project',
   origin: 'instance',
+  task_type: 'milestone',
   due_date: '2026-04-10',
  });
  const milestoneDueSoon = makeTask({
   id: 'm-soon',
   title: 'Beta milestone soon',
-  parent_task_id: 'phase',
+  parent_task_id: 'phase-1',
   root_id: 'project',
   origin: 'instance',
+  task_type: 'milestone',
   due_date: '2026-04-18',
+ });
+ // Wave 32 regression: a grand-child of the root that is NOT a milestone.
+ // The pre-fix structural predicate would have incorrectly classified this
+ // as a milestone; the task_type-based predicate must not.
+ const leakGrandChildTask = makeTask({
+  id: 'leak-task',
+  title: 'Sigma leaked grand-child task',
+  parent_task_id: 'phase-1',
+  root_id: 'project',
+  origin: 'instance',
+  task_type: 'task',
+  status: 'todo',
+  due_date: '2026-05-20',
  });
  const milestoneCurrent = makeTask({
   id: 'm-current',
   title: 'Gamma milestone current',
-  parent_task_id: 'phase',
+  parent_task_id: 'phase-2',
   root_id: 'project',
   origin: 'instance',
-  start_date: '2026-04-01',
+  task_type: 'milestone',
   due_date: '2026-05-20',
  });
- const taskNotYetDue = makeTask({
+ const taskPriority = makeTask({
+  id: 't-priority',
+  title: 'Zeta priority task',
+  parent_task_id: 'project',
+  root_id: 'project',
+  origin: 'instance',
+  task_type: 'task',
+  status: 'todo',
+  priority: 'high',
+  due_date: '2026-05-20',
+ });
+ const taskFuture = makeTask({
   id: 't-future',
   title: 'Delta future task',
   parent_task_id: 'project',
   root_id: 'project',
   origin: 'instance',
+  task_type: 'task',
+  status: 'todo',
   start_date: '2026-05-01',
   due_date: '2026-05-10',
  });
- const taskCompleted = makeTask({
+ const taskDone = makeTask({
   id: 't-done',
   title: 'Epsilon done task',
   parent_task_id: 'project',
   root_id: 'project',
   origin: 'instance',
-  is_complete: true,
+  task_type: 'task',
   status: 'completed',
+  is_complete: true,
   due_date: '2026-03-15',
  });
- const taskPriorityHigh = makeTask({
-  id: 't-high',
-  title: 'Zeta priority task',
+ const taskCurrent = makeTask({
+  id: 't-current',
+  title: 'Eta in-progress task',
   parent_task_id: 'project',
   root_id: 'project',
   origin: 'instance',
-  priority: 'high',
-  due_date: '2026-05-20',
+  task_type: 'task',
+  status: 'in_progress',
+  due_date: '2026-05-15',
  });
  const templateRoot = makeProject({
   id: 'tpl-root',
   title: 'Template root',
   origin: 'template',
  });
- const templateChild = makeTask({
-  id: 'tpl-child',
-  title: 'Template child',
+ const templateMilestone = makeTask({
+  id: 'tpl-m',
+  title: 'Template milestone',
   parent_task_id: 'tpl-root',
   root_id: 'tpl-root',
   origin: 'template',
+  task_type: 'milestone',
   due_date: '2026-04-10',
  });
  return [
   project,
-  phase,
+  phase1,
+  phase2,
   milestoneOverdue,
   milestoneDueSoon,
+  leakGrandChildTask,
   milestoneCurrent,
-  taskNotYetDue,
-  taskCompleted,
-  taskPriorityHigh,
+  taskPriority,
+  taskFuture,
+  taskDone,
+  taskCurrent,
   templateRoot,
-  templateChild,
+  templateMilestone,
  ];
 }
+
+const ALL_INSTANCE_CHILDREN = [
+ 'phase-1',
+ 'phase-2',
+ 'm-overdue',
+ 'm-soon',
+ 'leak-task',
+ 'm-current',
+ 't-priority',
+ 't-future',
+ 't-done',
+ 't-current',
+];
 
 describe('filterAndSortTasks — views', () => {
  it("'my_tasks' excludes roots and templates", () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'my_tasks', sort: 'chronological', now: NOW });
-  const ids = result.map((t) => t.id).sort();
-  expect(ids).toEqual(['m-current', 'm-overdue', 'm-soon', 'phase', 't-done', 't-future', 't-high'].sort());
+  expect(result.map((t) => t.id).sort()).toEqual([...ALL_INSTANCE_CHILDREN].sort());
  });
 
  it("'priority' keeps only priority==='high' and excludes completed", () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'priority', sort: 'chronological', now: NOW });
-  expect(result.map((t) => t.id)).toEqual(['t-high']);
+  expect(result.map((t) => t.id)).toEqual(['t-priority']);
  });
 
  it("'overdue' keeps only urgency==='overdue'", () => {
@@ -137,7 +199,9 @@ describe('filterAndSortTasks — views', () => {
  it("'current' keeps active tasks past start, not imminent", () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'current', sort: 'chronological', now: NOW });
-  expect(result.map((t) => t.id).sort()).toEqual(['m-current', 't-high'].sort());
+  expect(result.map((t) => t.id).sort()).toEqual(
+   ['leak-task', 'm-current', 't-current', 't-priority'].sort(),
+  );
  });
 
  it("'not_yet_due' keeps tasks with start_date in the future", () => {
@@ -155,15 +219,47 @@ describe('filterAndSortTasks — views', () => {
  it("'all_tasks' returns every instance non-root task", () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'all_tasks', sort: 'chronological', now: NOW });
-  expect(result.map((t) => t.id).sort()).toEqual(
-   ['phase', 'm-overdue', 'm-soon', 'm-current', 't-future', 't-done', 't-high'].sort(),
-  );
+  expect(result.map((t) => t.id).sort()).toEqual([...ALL_INSTANCE_CHILDREN].sort());
  });
 
- it("'milestones' returns grand-children of a root (depth 2)", () => {
+ it("'milestones' returns ONLY rows with task_type='milestone'", () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'milestones', sort: 'chronological', now: NOW });
   expect(result.map((t) => t.id).sort()).toEqual(['m-current', 'm-overdue', 'm-soon'].sort());
+ });
+
+ it("'milestones' excludes template-origin rows (origin='template') even when task_type='milestone'", () => {
+  const tasks = buildFixture();
+  const result = filterAndSortTasks({ tasks, filter: 'milestones', sort: 'chronological', now: NOW });
+  expect(result.every((t) => t.origin === 'instance')).toBe(true);
+  expect(result.find((t) => t.id === 'tpl-m')).toBeUndefined();
+ });
+
+ it("'milestones' excludes grand-children whose task_type !== 'milestone' (Wave 32 regression)", () => {
+  const tasks = buildFixture();
+  const result = filterAndSortTasks({ tasks, filter: 'milestones', sort: 'chronological', now: NOW });
+  expect(result.find((t) => t.id === 'leak-task')).toBeUndefined();
+ });
+
+ it("'milestones' uses the task_type discriminator, not hierarchical depth", () => {
+  // Depth-1 row (direct child of root) explicitly marked as a milestone.
+  // The discriminator is the source of truth — the predicate must not reject
+  // it on structural grounds.
+  const project = makeProject({ id: 'p', origin: 'instance' });
+  const depth1Milestone = makeTask({
+   id: 'm-depth1',
+   parent_task_id: 'p',
+   root_id: 'p',
+   origin: 'instance',
+   task_type: 'milestone',
+  });
+  const result = filterAndSortTasks({
+   tasks: [project, depth1Milestone],
+   filter: 'milestones',
+   sort: 'chronological',
+   now: NOW,
+  });
+  expect(result.map((t) => t.id)).toEqual(['m-depth1']);
  });
 });
 
@@ -171,13 +267,14 @@ describe('filterAndSortTasks — sort', () => {
  it('chronological sorts ascending by due_date, nulls last', () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'all_tasks', sort: 'chronological', now: NOW });
-  // Expected ascending by due_date: m-overdue(4/10), m-soon(4/18), t-future(5/10), m-current(5/20), t-high(5/20), t-done(3/15 but completed included), phase(null)
-  // 't-done' has due 2026-03-15 which is before m-overdue
   const ids = result.map((t) => t.id);
-  // phase has no due_date → last
-  expect(ids[ids.length - 1]).toBe('phase');
-  // first should be earliest due
+  // 't-done' has the earliest due (2026-03-15) among instance children.
   expect(ids[0]).toBe('t-done');
+  // Null-due rows (phase-1, phase-2) sort last. Stable sort preserves
+  // insertion order among them, so either could be final — assert
+  // containment rather than position.
+  expect(['phase-1', 'phase-2']).toContain(ids[ids.length - 1]);
+  expect(['phase-1', 'phase-2']).toContain(ids[ids.length - 2]);
  });
 
  it('alphabetical sorts by title', () => {

--- a/src/features/tasks/hooks/useTaskFilters.ts
+++ b/src/features/tasks/hooks/useTaskFilters.ts
@@ -42,27 +42,6 @@ const buildThresholdMap = (tasks: TaskRow[]): Map<string, number> => {
  return map;
 };
 
-/**
- * Milestone convention: a task whose parent is itself a direct child of a root
- * task (i.e. grand-children of a project root, where the parent is a "phase").
- * We compute this structurally, not via a flag.
- */
-const buildMilestoneIdSet = (tasks: TaskRow[]): Set<string> => {
- const roots = new Set<string>();
- for (const t of tasks) {
-  if (t.parent_task_id === null) roots.add(t.id);
- }
- const phases = new Set<string>();
- for (const t of tasks) {
-  if (t.parent_task_id && roots.has(t.parent_task_id)) phases.add(t.id);
- }
- const milestones = new Set<string>();
- for (const t of tasks) {
-  if (t.parent_task_id && phases.has(t.parent_task_id)) milestones.add(t.id);
- }
- return milestones;
-};
-
 export interface UseTaskFiltersArgs {
  tasks: TaskRow[];
  filter: TaskFilterKey;
@@ -77,7 +56,6 @@ export const filterAndSortTasks = ({
  now = new Date(),
 }: UseTaskFiltersArgs): TaskRow[] => {
  const thresholds = buildThresholdMap(tasks);
- const milestoneIds = filter === 'milestones' ? buildMilestoneIdSet(tasks) : null;
 
  const instanceChildren = tasks.filter(
   (t) => t.parent_task_id !== null && t.origin === 'instance',
@@ -115,7 +93,7 @@ export const filterAndSortTasks = ({
    filtered = instanceChildren;
    break;
   case 'milestones':
-   filtered = instanceChildren.filter((t) => milestoneIds!.has(t.id));
+   filtered = instanceChildren.filter((t) => t.task_type === 'milestone');
    break;
   default:
    filtered = instanceChildren;


### PR DESCRIPTION
## Summary

Wave 32 Task 1. Corrects the Milestones view on `/tasks` to filter by the
`task_type` discriminator column (Wave 25) instead of a structural
grand-child-of-root heuristic that silently leaked non-milestone rows.

**What shipped**
- `src/features/tasks/hooks/useTaskFilters.ts` — `milestones` case now
  filters by `t.task_type === 'milestone'`; `buildMilestoneIdSet` helper
  deleted (no remaining callers per `grep`).
- `Testing/unit/features/tasks/hooks/useTaskFilters.test.ts` — fixture
  rebuilt to cover the full 9-filter matrix plus three milestone-specific
  guards:
  1. Template-origin milestone excluded by `origin === 'instance'`.
  2. Grand-child stamped `task_type='task'` **excluded** (regression).
  3. Depth-1 row stamped `task_type='milestone'` **included**
     (discriminator-wins guard; hierarchy is not the source of truth).

**Bundled prep fix (scope creep disclosed)**
- `Testing/unit/features/projects/hooks/useProjectPresence.test.tsx` —
  stabilized the `useAuth` mock so `user` keeps a stable reference across
  renders. The test was failing intermittently (and deterministically in
  isolation) because the mock returned a fresh `user` object on every
  render → `useProjectPresence`'s `[projectId, user]` effect re-fired →
  cleanup `setMyPresenceKey(null)` raced the async subscribe callback's
  `setMyPresenceKey('me')`. Surfaced during Wave 32 Task 1's verification
  gate; reproduced on `main` at `18a288b` and at `0573c19` (pre PR #171),
  so this is pre-existing intermittency that PR #171's 791/791 claim
  didn't actually clear. One-line mock stabilization; no production code
  touched.

## Test count delta

- Baseline (on `main` at 18a288b, stable order): 791 passing across 82 files.
- This branch: **794 passing** across 82 files — `+3` net from Task 1
  (milestone regression guards + discriminator-wins guard). Presence-test
  count unchanged.

## Lint / build

- `npm run lint`: 0 errors, 6 warnings (under the 7-warning baseline).
- `npm run build`: clean (`tsc -b && vite build`).

## Test plan

- [x] `npm run lint` — 0 errors / 6 warnings.
- [x] `npm run build` — clean.
- [x] `npm test` — 794/794 pass (verified across multiple consecutive runs).
- [ ] Manual smoke on `/tasks` after merge: cycle through every filter
      on a project with phases, milestones (`task_type='milestone'`), and
      a mix of todo / in_progress / completed tasks. Milestones view
      must return only the `task_type='milestone'` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)