### PR TITLE
feat(wave-32): surface New Template button alongside New Project on D…

### DIFF
--- a/Testing/unit/pages/Dashboard.test.tsx
+++ b/Testing/unit/pages/Dashboard.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+// Dashboard mounts a lot of downstream widgets. Replace the heavy ones with
+// no-op stubs so the test is focused on the header button wiring.
+vi.mock('@/features/projects/hooks/useProjectRealtime', () => ({
+    useProjectRealtime: () => undefined,
+}));
+vi.mock('@/features/projects/hooks/useProjectMutations', () => ({
+    useCreateProject: () => ({ mutateAsync: vi.fn() }),
+    useUpdateProjectStatus: () => ({ mutateAsync: vi.fn() }),
+}));
+vi.mock('@/shared/api/planterClient', () => ({
+    planter: {
+        entities: {
+            Task: { create: vi.fn() },
+            TeamMember: { create: vi.fn() },
+        },
+    },
+}));
+vi.mock('@/features/dashboard/components/StatsOverview', () => ({
+    default: () => null,
+}));
+vi.mock('@/features/dashboard/components/ProjectPipelineBoard', () => ({
+    default: () => null,
+}));
+vi.mock('@/features/dashboard/components/CreateProjectModal', () => ({
+    default: () => null,
+}));
+vi.mock('@/features/dashboard/components/CreateTemplateModal', () => ({
+    default: () => null,
+}));
+vi.mock('@/features/mobile/MobileAgenda', () => ({
+    default: () => null,
+}));
+vi.mock('@/pages/components/OnboardingWizard', () => ({
+    default: () => null,
+}));
+
+const setShowTemplateModal = vi.fn();
+const setShowCreateModal = vi.fn();
+const handleDismissWizard = vi.fn();
+
+const dashboardState = {
+    isLoading: false,
+    isError: false,
+    error: null,
+    user: { id: 'u1', email: 'u1@example.com' },
+    showCreateModal: false,
+    showTemplateModal: false,
+    wizardDismissed: true,
+    searchQuery: '',
+    selectedProjectId: null,
+};
+
+const dashboardData = {
+    projects: [{ id: 'p1', title: 'Alpha project' }],
+    activeProjects: [],
+    archivedProjects: [],
+    allTasks: [],
+    filteredTasks: [],
+    teamMembers: [],
+};
+
+vi.mock('@/features/dashboard/hooks/useDashboard', () => ({
+    useDashboard: () => ({
+        state: dashboardState,
+        data: dashboardData,
+        actions: {
+            setShowCreateModal,
+            setShowTemplateModal,
+            setSearchQuery: vi.fn(),
+            setSelectedProjectId: vi.fn(),
+            handleDismissWizard,
+        },
+    }),
+}));
+
+import Dashboard from '@/pages/Dashboard';
+
+function renderDashboard() {
+    function Wrapper({ children }: { children: ReactNode }) {
+        const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+        return (
+            <QueryClientProvider client={qc}>
+                <MemoryRouter initialEntries={['/dashboard']}>{children}</MemoryRouter>
+            </QueryClientProvider>
+        );
+    }
+    return render(<Dashboard />, { wrapper: Wrapper });
+}
+
+describe('Dashboard header (Wave 32)', () => {
+    beforeEach(() => {
+        setShowTemplateModal.mockReset();
+        setShowCreateModal.mockReset();
+    });
+
+    it('renders both "New Project" and "New Template" buttons in the header', () => {
+        renderDashboard();
+        expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /new template/i })).toBeInTheDocument();
+    });
+
+    it('opens the template modal when the "New Template" button is clicked', () => {
+        renderDashboard();
+        fireEvent.click(screen.getByTestId('dashboard-new-template-btn'));
+        expect(setShowTemplateModal).toHaveBeenCalledTimes(1);
+        expect(setShowTemplateModal).toHaveBeenCalledWith(true);
+        // The project modal must NOT be opened by the template button.
+        expect(setShowCreateModal).not.toHaveBeenCalled();
+    });
+
+    it('opens the project modal when the "New Project" button is clicked', () => {
+        renderDashboard();
+        fireEvent.click(screen.getByRole('button', { name: /new project/i }));
+        expect(setShowCreateModal).toHaveBeenCalledTimes(1);
+        expect(setShowCreateModal).toHaveBeenCalledWith(true);
+        expect(setShowTemplateModal).not.toHaveBeenCalled();
+    });
+});

--- a/Testing/unit/pages/Dashboard.test.tsx
+++ b/Testing/unit/pages/Dashboard.test.tsx
@@ -82,8 +82,8 @@ vi.mock('@/features/dashboard/hooks/useDashboard', () => ({
 import Dashboard from '@/pages/Dashboard';
 
 function renderDashboard() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     function Wrapper({ children }: { children: ReactNode }) {
-        const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
         return (
             <QueryClientProvider client={qc}>
                 <MemoryRouter initialEntries={['/dashboard']}>{children}</MemoryRouter>
@@ -107,7 +107,7 @@ describe('Dashboard header (Wave 32)', () => {
 
     it('opens the template modal when the "New Template" button is clicked', () => {
         renderDashboard();
-        fireEvent.click(screen.getByTestId('dashboard-new-template-btn'));
+        fireEvent.click(screen.getByRole('button', { name: /new template/i }));
         expect(setShowTemplateModal).toHaveBeenCalledTimes(1);
         expect(setShowTemplateModal).toHaveBeenCalledWith(true);
         // The project modal must NOT be opened by the template button.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import type { TaskRow, Project, TaskInsert, CreateProjectFormData } from '@/shar
 import type { Database } from '@/shared/db/database.types';
 import type { CreateProjectPayload } from '@/features/projects/hooks/useProjectMutations';
 import { Button } from '@/shared/ui/button';
-import { Plus, FolderKanban, Loader2 } from 'lucide-react';
+import { Plus, FolderKanban, Loader2, BookTemplate } from 'lucide-react';
 import { motion } from 'framer-motion';
 
 // Hooks
@@ -124,6 +124,14 @@ export default function Dashboard() {
                 </div>
 
                 <div className="flex items-center gap-3">
+                    <Button
+                        variant="secondary"
+                        onClick={() => actions.setShowTemplateModal(true)}
+                        data-testid="dashboard-new-template-btn"
+                    >
+                        <BookTemplate className="w-5 h-5 mr-2" />
+                        {t('dashboard.new_template')}
+                    </Button>
                     <Button
                         onClick={() => actions.setShowCreateModal(true)}
                         className="bg-orange-500 hover:bg-orange-600 shadow-lg shadow-orange-500/20 "

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -306,6 +306,7 @@
     "title": "Project Dashboard",
     "subtitle": "Manage your church planting projects",
     "new_project": "New Project",
+    "new_template": "New Template",
     "no_projects_title": "No projects yet",
     "no_projects_description": "Start your church planting journey by creating your first project",
     "create_first_project": "Create Your First Project",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -312,6 +312,7 @@
     "title": "Panel de proyectos",
     "subtitle": "Gestiona tus proyectos de plantación de iglesias",
     "new_project": "Nuevo proyecto",
+    "new_template": "Nueva plantilla",
     "no_projects_title": "Aún no hay proyectos",
     "no_projects_description": "Inicia tu camino de plantación de iglesias creando tu primer proyecto",
     "create_first_project": "Crea tu primer proyecto",


### PR DESCRIPTION
…ashboard

Template creation was only discoverable via the `/dashboard?action=new-template` URL hack or the `ProjectSidebar` "New Template" button (which is only visible inside an already-open project). Cold-loading `/dashboard` gave users a "New Project" button but no template counterpart.

`CreateTemplateModal` is already imported and mounted on Dashboard, and `useDashboard()` already exposes `state.showTemplateModal` + `actions.setShowTemplateModal`. Only the trigger was missing.

- Add a "New Template" button in the Dashboard header, next to "New Project". Uses `Button variant="secondary"` + the `BookTemplate` icon (same icon `CreateTemplateModal` uses for visual consistency). `onClick` wires directly to `actions.setShowTemplateModal(true)`. Un-gated, matching the sibling `ProjectSidebar` button's lack of role check.
- Localize via new `dashboard.new_template` key in `en.json` + `es.json`.
- New `Testing/unit/pages/Dashboard.test.tsx` covers: both buttons render, the template button fires `setShowTemplateModal(true)` only, and the project button fires `setShowCreateModal(true)` only.

Deliberately NOT propagated: the existing New Project button's inline `bg-orange-500 hover:bg-orange-600` classes. Those predate the `variant` system and are pre-existing styleguide drift; per the wave plan, the new button uses the shared secondary variant instead.

# Pull Request

<!--
Copy contents from `PR_DESCRIPTION_DRAFT.md` (generated by Agent) or fill manually.
-->

## 📋 Summary

<!-- 2-3 sentence executive summary. User-facing language. -->

## ✨ Highlights

<!--
- **Bold Concept:** Detail...
-->

## 🗺️ Roadmap Progress

| Item ID | Feature Name | Phase | Status | Notes |
| ------- | ------------ | ----- | ------ | ----- |
|         |              |       |        |       |

## 🏗️ Architecture Decisions

### Key Patterns & Decisions

-

### Logic Flow / State Changes

```mermaid
graph TD
    A[User Action] --> B[Component]
```

## 🔍 Review Guide

### 🚨 High Risk / Security Sensitive

-

### 🧠 Medium Complexity

-

### 🟢 Low Risk / Boilerplate

-

## 🧪 Verification Plan

### 1. Environment Setup

- [ ] Run `npm install`
- [ ] Run migration: `[filename].sql`

### 2. Manual Verification

- **[Feature Area]**:
  1. [Instruction]
  2. [Outcome]

### 3. Automated Tests

- [ ] `npm run lint` passed (Zero warnings).
- [ ] `npm test` passed.
- [ ] `npm run build` passed.
