### PR TITLE
feat(wave-37): template UI guards — progress bars, dates, and status

### DIFF
--- a/Testing/unit/features/projects/components/EditProjectModal.test.tsx
+++ b/Testing/unit/features/projects/components/EditProjectModal.test.tsx
@@ -344,3 +344,29 @@ describe('EditProjectModal — shiftedCount toast feedback', () => {
     expect(message).toContain('2 tasks rescheduled');
   });
 });
+
+describe('EditProjectModal — start/end date visibility (Wave 37)', () => {
+  it('hides the date section for template projects', () => {
+    const template = makeTask({
+      id: 'tmpl-1',
+      title: 'A Template',
+      origin: 'template',
+      start_date: '2026-01-01',
+      settings: null,
+    });
+    renderModal(template);
+    expect(screen.queryByLabelText(/launch date/i)).toBeNull();
+    expect(screen.queryByLabelText(/due date/i)).toBeNull();
+  });
+
+  it('shows the date section for instance projects', () => {
+    const instance = makeTask({
+      id: 'proj-1',
+      title: 'A Project',
+      origin: 'instance',
+      start_date: '2026-01-01',
+    });
+    renderModal(instance);
+    expect(screen.getByLabelText(/launch date/i)).toBeInTheDocument();
+  });
+});

--- a/Testing/unit/features/tasks/components/TaskItem.dueBadge.test.tsx
+++ b/Testing/unit/features/tasks/components/TaskItem.dueBadge.test.tsx
@@ -90,4 +90,28 @@ describe('TaskItem due-date badge (Wave 33)', () => {
         const badge = within(row).getByTestId('task-row-due-badge-rightside');
         expect(badge).toBeInTheDocument();
     });
+
+    it('hides the due badge for template tasks even when due_date is set', () => {
+        const task = makeTask({
+            id: 'tmpl-due',
+            title: 'Template Task',
+            origin: 'template',
+            due_date: '2026-04-22',
+        }) as TaskItemData;
+        renderTaskItem(task);
+        expect(screen.queryByTestId('task-row-due-badge-tmpl-due')).not.toBeInTheDocument();
+    });
+
+    it('hides the status select for template tasks', () => {
+        const task = makeTask({
+            id: 'tmpl-status',
+            title: 'Template Task',
+            origin: 'template',
+            due_date: null,
+        }) as TaskItemData;
+        renderTaskItem(task);
+        // Status select renders a combobox / role=combobox per Radix Select
+        const row = screen.getByTestId('task-row-tmpl-status');
+        expect(within(row).queryByRole('combobox')).not.toBeInTheDocument();
+    });
 });

--- a/src/features/projects/components/EditProjectModal.tsx
+++ b/src/features/projects/components/EditProjectModal.tsx
@@ -286,6 +286,7 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
       )}
      </div>
 
+     {!isTemplate && (
      <div className="bg-amber-50 p-4 rounded-lg border border-amber-200 space-y-4">
       <div>
        <Label htmlFor="start_date" className="block mb-1 font-semibold text-amber-800">
@@ -310,6 +311,7 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
        <Input type="date" id="due_date" {...register('due_date')} />
       </div>
      </div>
+     )}
 
      <div className="flex justify-end gap-3 pt-2">
       <Button variant="outline" onClick={onClose} type="button">

--- a/src/features/projects/components/EditProjectModal.tsx
+++ b/src/features/projects/components/EditProjectModal.tsx
@@ -48,14 +48,16 @@ export default function EditProjectModal({ project, isOpen, onClose }: EditProje
    z.object({
     title: z.string().min(1, t('projects.form.title_required_short')),
     description: z.string().optional(),
-    start_date: z.string().min(1, t('projects.form.start_date_required')),
+    start_date: isTemplate
+     ? z.string().optional()
+     : z.string().min(1, t('projects.form.start_date_required')),
     due_date: z.string().optional(),
     due_soon_threshold: z.coerce.number()
      .min(1, t('projects.edit_modal.due_soon_threshold_min'))
      .max(30, t('projects.edit_modal.due_soon_threshold_max')),
     supervisor_email: z.string().email(t('projects.edit_modal.supervisor_email_invalid')).optional().or(z.literal('')),
    }),
-  [t],
+  [t, isTemplate],
  );
 
  type EditProjectFormData = z.infer<typeof editProjectSchema>;

--- a/src/features/projects/components/MilestoneSection.tsx
+++ b/src/features/projects/components/MilestoneSection.tsx
@@ -118,12 +118,14 @@ export default function MilestoneSection({
                 </div>
 
                 <div className="flex items-center gap-4">
-                    <div className="hidden sm:flex items-center gap-3">
-                        <div className="w-32">
-                            <Progress value={progress} className="h-2 bg-slate-100" />
+                    {milestone.origin !== 'template' && (
+                        <div className="hidden sm:flex items-center gap-3">
+                            <div className="w-32">
+                                <Progress value={progress} className="h-2 bg-slate-100" />
+                            </div>
+                            <span className="text-sm font-medium text-slate-600 w-12 text-right">{progress}%</span>
                         </div>
-                        <span className="text-sm font-medium text-slate-600 w-12 text-right">{progress}%</span>
-                    </div>
+                    )}
                     {milestone.is_locked && (
                         <Badge
                             variant="outline"

--- a/src/features/projects/components/PhaseCard.tsx
+++ b/src/features/projects/components/PhaseCard.tsx
@@ -2,6 +2,7 @@ import { Card } from '@/shared/ui/card';
 import { Progress } from '@/shared/ui/progress';
 import { ProgressRing } from '@/shared/ui/progress-ring';
 
+import { useTranslation } from 'react-i18next';
 import { ChevronRight, CheckCircle2, Lock } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { TASK_STATUS } from '@/shared/constants';
@@ -37,6 +38,7 @@ interface PhaseCardProps {
 }
 
 export default function PhaseCard({ phase, tasks = [], milestones = [], isActive, onClick, rootTask }: PhaseCardProps) {
+ const { t } = useTranslation();
  const order = phase.position || 1;
  const isLocked = phase.is_locked;
 
@@ -111,7 +113,7 @@ export default function PhaseCard({ phase, tasks = [], milestones = [], isActive
 
  <div className="space-y-2">
  {phase.origin === 'template' ? (
- <p className="text-xs text-muted-foreground">{totalTasks} task{totalTasks !== 1 ? 's' : ''}</p>
+ <p className="text-xs text-muted-foreground">{t('projects.phase_template_task_count', { count: totalTasks })}</p>
  ) : isCheckpoint ? (
  <div className="flex items-center justify-between gap-3" data-testid="phase-donut">
  <div className="relative h-16 w-16">

--- a/src/features/projects/components/PhaseCard.tsx
+++ b/src/features/projects/components/PhaseCard.tsx
@@ -110,7 +110,9 @@ export default function PhaseCard({ phase, tasks = [], milestones = [], isActive
  </div>
 
  <div className="space-y-2">
- {isCheckpoint ? (
+ {phase.origin === 'template' ? (
+ <p className="text-xs text-muted-foreground">{totalTasks} task{totalTasks !== 1 ? 's' : ''}</p>
+ ) : isCheckpoint ? (
  <div className="flex items-center justify-between gap-3" data-testid="phase-donut">
  <div className="relative h-16 w-16">
  <ProgressRing

--- a/src/features/tasks/components/TaskDetailsView.tsx
+++ b/src/features/tasks/components/TaskDetailsView.tsx
@@ -227,7 +227,8 @@ const TaskDetailsView = ({
                 </>
             )}
 
-            {/* Schedule */}
+            {/* Schedule — hidden for template tasks */}
+            {task.origin !== 'template' && (
             <div className="detail-section mb-6">
                 <h3 className="text-sm font-bold text-slate-900 mb-3 uppercase tracking-wide">Schedule</h3>
                 <div className="grid grid-cols-2 gap-3">
@@ -249,6 +250,7 @@ const TaskDetailsView = ({
                     </div>
                 </div>
             </div>
+            )}
 
             {/* Status Badges */}
             <div className="detail-section mb-6">

--- a/src/features/tasks/components/TaskItem.tsx
+++ b/src/features/tasks/components/TaskItem.tsx
@@ -338,7 +338,7 @@ const TaskItem = ({
  <div className="flex items-center gap-3 flex-shrink-0">
  {task.membership_role && <RoleIndicator role={task.membership_role} />}
 
- {dueBadge && dueBadgeText && (
+ {task.origin !== 'template' && dueBadge && dueBadgeText && (
  <span
  className={cn(
  'text-sm font-medium whitespace-nowrap',
@@ -351,12 +351,14 @@ const TaskItem = ({
  </span>
  )}
 
+ {task.origin !== 'template' && (
  <TaskStatusSelect
  status={task.status}
  taskId={task.id}
  taskTitle={task.title}
  onStatusChange={handleStatusChange}
  />
+ )}
 
  <TaskControlButtons
  task={task}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -259,6 +259,8 @@
     "add_milestone_button": "Add Milestone",
     "phases_heading": "Phases",
     "phase_heading_title": "Phase {{position}}: {{title}}",
+    "phase_template_task_count_one": "{{count}} task",
+    "phase_template_task_count_other": "{{count}} tasks",
     "no_milestones_in_phase": "No milestones in this phase yet",
     "milestone_tasks_aria": "Tasks under {{title}}",
     "task_created_toast": "Task created",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -265,6 +265,8 @@
     "add_milestone_button": "Añadir hito",
     "phases_heading": "Fases",
     "phase_heading_title": "Fase {{position}}: {{title}}",
+    "phase_template_task_count_one": "{{count}} tarea",
+    "phase_template_task_count_other": "{{count}} tareas",
     "no_milestones_in_phase": "Aún no hay hitos en esta fase",
     "milestone_tasks_aria": "Tareas bajo {{title}}",
     "task_created_toast": "Tarea creada",


### PR DESCRIPTION
## Summary

Addresses 4 items from the product feature board (all previously "Not started"):

- **Template phases/milestones: no progress bar** — `PhaseCard` renders a plain task count; `MilestoneSection` hides the progress bar + percentage when `origin === 'template'`
- **Template Settings: no start/end date** — `EditProjectModal` hides the amber launch date and due date inputs for template projects; the existing date is preserved on save via RHF default values
- **Template task/subtask: no start/due date** — `TaskDetailsView` hides the Schedule section entirely for template tasks
- **Template task/subtask: no completion status** — `TaskItem` hides the due-date badge and `TaskStatusSelect` for template-origin tasks

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [x] 37/37 EditProjectModal + TaskItem tests passing (2 new tests each)
- [ ] Manual: open a template's project view — phase cards show "X tasks" not a progress %
- [ ] Manual: open a template's milestone — no progress bar in header
- [ ] Manual: open a template task detail pane — no Schedule section
- [ ] Manual: template task rows — no due-date badge, no status dropdown
- [ ] Manual: edit a template in EditProjectModal — no date inputs shown
- [ ] Manual: instance project unaffected — all above still present for instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)