### PR TITLE
[codex] Reapply PM-1 priority task view

### DIFF
--- a/Testing/unit/features/tasks/hooks/useTaskFilters.test.ts
+++ b/Testing/unit/features/tasks/hooks/useTaskFilters.test.ts
@@ -15,7 +15,7 @@ const USER_ID = 'user-1';
 //   │                   have pulled this into the 'milestones' filter.)
 //   ├─ phase-2   (task_type='phase')
 //   │   └─ m-current   (task_type='milestone', due 2026-05-20)
-//   ├─ t-priority      (task_type='task', priority='high', status='todo', due 2026-05-20)
+//   ├─ t-priority      (task_type='task', status='todo', start 2026-04-01, due 2026-05-20)
 //   ├─ t-future        (task_type='task', status='todo', start 2026-05-01, due 2026-05-10)
 //   ├─ t-done          (task_type='task', status='completed', is_complete=true, due 2026-03-15)
 //   └─ t-current       (task_type='task', status='in_progress', due 2026-05-15)
@@ -97,6 +97,7 @@ function buildFixture() {
   status: 'todo',
   priority: 'high',
   assignee_id: USER_ID,
+  start_date: '2026-04-01',
   due_date: '2026-05-20',
  });
  const taskFuture = makeTask({
@@ -194,7 +195,7 @@ describe('filterAndSortTasks — views', () => {
   expect(result).toEqual([]);
  });
 
- it("'priority' keeps only priority==='high' and excludes completed", () => {
+ it("'priority' keeps overdue, due-soon, or started tasks and excludes completed", () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'priority', sort: 'chronological', now: NOW });
   expect(result.map((t) => t.id)).toEqual(['t-priority']);

--- a/Testing/unit/features/tasks/lib/priority-tasks.test.ts
+++ b/Testing/unit/features/tasks/lib/priority-tasks.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPriorityTaskGroups,
+  filterPriorityTasks,
+  getPriorityTaskMatch,
+  PRIORITY_EXCLUDED_STATUSES,
+} from '@/features/tasks/lib/priority-tasks';
+import { makeProject, makeTask } from '@test/factories';
+
+const NOW = new Date('2026-04-16T12:00:00');
+
+describe('priority task date matching', () => {
+  it('qualifies tasks due yesterday as overdue', () => {
+    expect(getPriorityTaskMatch(makeTask({ due_date: '2026-04-15' }), NOW)).toEqual({
+      overdue: true,
+      dueSoon: false,
+      current: false,
+    });
+  });
+
+  it('qualifies tasks due today as due soon', () => {
+    expect(getPriorityTaskMatch(makeTask({ due_date: '2026-04-16' }), NOW)).toMatchObject({
+      overdue: false,
+      dueSoon: true,
+    });
+  });
+
+  it('qualifies tasks due exactly 7 days from today as due soon', () => {
+    expect(getPriorityTaskMatch(makeTask({ due_date: '2026-04-23' }), NOW)).toMatchObject({
+      dueSoon: true,
+    });
+  });
+
+  it('does not qualify due dates 8 days from today without a started start date', () => {
+    expect(getPriorityTaskMatch(makeTask({ due_date: '2026-04-24' }), NOW)).toEqual({
+      overdue: false,
+      dueSoon: false,
+      current: false,
+    });
+  });
+
+  it('qualifies tasks that start today even when due date is missing', () => {
+    expect(getPriorityTaskMatch(makeTask({ start_date: '2026-04-16', due_date: null }), NOW)).toMatchObject({
+      current: true,
+    });
+  });
+
+  it('does not qualify tasks that start tomorrow', () => {
+    expect(getPriorityTaskMatch(makeTask({ start_date: '2026-04-17', due_date: null }), NOW)).toEqual({
+      overdue: false,
+      dueSoon: false,
+      current: false,
+    });
+  });
+
+  it('excludes completed tasks that would otherwise qualify', () => {
+    expect(
+      getPriorityTaskMatch(
+        makeTask({ status: 'completed', is_complete: true, due_date: '2026-04-15', start_date: '2026-04-01' }),
+        NOW,
+      ),
+    ).toEqual({
+      overdue: false,
+      dueSoon: false,
+      current: false,
+    });
+  });
+
+  it('excludes archived, deleted, and cancelled statuses', () => {
+    for (const status of PRIORITY_EXCLUDED_STATUSES) {
+      expect(getPriorityTaskMatch(makeTask({ status, due_date: '2026-04-15' }), NOW)).toEqual({
+        overdue: false,
+        dueSoon: false,
+        current: false,
+      });
+    }
+  });
+
+  it('does not qualify tasks with missing dates', () => {
+    expect(getPriorityTaskMatch(makeTask({ start_date: null, due_date: null }), NOW)).toEqual({
+      overdue: false,
+      dueSoon: false,
+      current: false,
+    });
+  });
+});
+
+describe('priority task milestone grouping', () => {
+  const buildGroupingFixture = () => {
+    const project = makeProject({
+      id: 'project',
+      title: 'Alpha Project',
+      task_type: 'project',
+      position: 100,
+    });
+    const phase = makeTask({
+      id: 'phase',
+      title: 'Launch Phase',
+      parent_task_id: 'project',
+      root_id: 'project',
+      task_type: 'phase',
+      position: 100,
+    });
+    const emptyMilestone = makeTask({
+      id: 'milestone-empty',
+      title: 'Empty Milestone',
+      parent_task_id: 'phase',
+      root_id: 'project',
+      task_type: 'milestone',
+      position: 100,
+    });
+    const activeMilestone = makeTask({
+      id: 'milestone-active',
+      title: 'Active Milestone',
+      parent_task_id: 'phase',
+      root_id: 'project',
+      task_type: 'milestone',
+      position: 200,
+    });
+    const laterDue = makeTask({
+      id: 'task-later-due',
+      title: 'Later due',
+      parent_task_id: 'milestone-active',
+      root_id: 'project',
+      task_type: 'task',
+      due_date: '2026-04-18',
+      position: 100,
+    });
+    const earlierDue = makeTask({
+      id: 'task-earlier-due',
+      title: 'Earlier due',
+      parent_task_id: 'milestone-active',
+      root_id: 'project',
+      task_type: 'task',
+      due_date: '2026-04-16',
+      position: 200,
+    });
+    const missingDueStarted = makeTask({
+      id: 'task-started-no-due',
+      title: 'Started without due date',
+      parent_task_id: 'milestone-active',
+      root_id: 'project',
+      task_type: 'task',
+      start_date: '2026-04-01',
+      due_date: null,
+      position: 300,
+    });
+    const hiddenFuture = makeTask({
+      id: 'task-hidden-future',
+      title: 'Future hidden',
+      parent_task_id: 'milestone-active',
+      root_id: 'project',
+      task_type: 'task',
+      start_date: '2026-04-17',
+      due_date: '2026-04-24',
+      position: 400,
+    });
+    const orphan = makeTask({
+      id: 'task-orphan',
+      title: 'Orphan due soon',
+      parent_task_id: 'phase',
+      root_id: 'project',
+      task_type: 'task',
+      due_date: '2026-04-17',
+      position: 500,
+    });
+
+    return [
+      project,
+      phase,
+      emptyMilestone,
+      activeMilestone,
+      laterDue,
+      earlierDue,
+      missingDueStarted,
+      hiddenFuture,
+      orphan,
+    ];
+  };
+
+  it('hides empty milestones and shows milestones with qualifying tasks', () => {
+    const groups = buildPriorityTaskGroups({ tasks: buildGroupingFixture(), now: NOW });
+    expect(groups.map((group) => group.title)).toContain('Active Milestone');
+    expect(groups.map((group) => group.title)).not.toContain('Empty Milestone');
+  });
+
+  it('hides non-qualifying tasks inside a visible milestone', () => {
+    const groups = buildPriorityTaskGroups({ tasks: buildGroupingFixture(), now: NOW });
+    const activeGroup = groups.find((group) => group.title === 'Active Milestone');
+    expect(activeGroup?.tasks.map((entry) => entry.task.id)).not.toContain('task-hidden-future');
+  });
+
+  it('sorts tasks inside a milestone by due date and places missing due dates last', () => {
+    const groups = buildPriorityTaskGroups({ tasks: buildGroupingFixture(), now: NOW });
+    const activeGroup = groups.find((group) => group.title === 'Active Milestone');
+    expect(activeGroup?.tasks.map((entry) => entry.task.id)).toEqual([
+      'task-earlier-due',
+      'task-later-due',
+      'task-started-no-due',
+    ]);
+  });
+
+  it('keeps qualifying orphan tasks in a clearly labeled project group', () => {
+    const groups = buildPriorityTaskGroups({ tasks: buildGroupingFixture(), now: NOW });
+    const orphanGroup = groups.find((group) => group.id === 'orphan-project');
+    expect(orphanGroup?.title).toBe('No milestone');
+    expect(orphanGroup?.projectTitle).toBe('Alpha Project');
+    expect(orphanGroup?.tasks.map((entry) => entry.task.id)).toEqual(['task-orphan']);
+  });
+
+  it('assigns display-only Dewey-style task numbers from group and task order', () => {
+    const groups = buildPriorityTaskGroups({ tasks: buildGroupingFixture(), now: NOW });
+    const activeGroup = groups.find((group) => group.title === 'Active Milestone');
+    expect(activeGroup?.tasks.map((entry) => entry.displayNumber)).toEqual(['1.1', '1.2', '1.3']);
+  });
+
+  it('filters to only qualifying candidate tasks', () => {
+    const result = filterPriorityTasks(buildGroupingFixture(), NOW);
+    expect(result.map((task) => task.id)).toEqual([
+      'task-earlier-due',
+      'task-later-due',
+      'task-started-no-due',
+      'task-orphan',
+    ]);
+  });
+});

--- a/Testing/unit/pages/TasksPage.test.tsx
+++ b/Testing/unit/pages/TasksPage.test.tsx
@@ -46,28 +46,78 @@ vi.mock('@/shared/api/planterClient', () => {
             task_type: 'project',
         },
         {
+            id: 'phase-alpha',
+            title: 'Launch Phase',
+            parent_task_id: 'p-alpha',
+            root_id: 'p-alpha',
+            origin: 'instance',
+            creator: 'u1',
+            status: 'in_progress',
+            task_type: 'phase',
+        },
+        {
+            id: 'm-empty',
+            title: 'Empty Milestone',
+            parent_task_id: 'phase-alpha',
+            root_id: 'p-alpha',
+            origin: 'instance',
+            creator: 'u1',
+            status: 'todo',
+            task_type: 'milestone',
+            position: 1,
+        },
+        {
+            id: 'm-launch',
+            title: 'Launch Milestone',
+            parent_task_id: 'phase-alpha',
+            root_id: 'p-alpha',
+            origin: 'instance',
+            creator: 'u1',
+            status: 'todo',
+            task_type: 'milestone',
+            position: 2,
+        },
+        {
             id: 't-1',
             title: 'Buy a domain',
-            parent_task_id: 'p-alpha',
+            parent_task_id: 'm-launch',
             root_id: 'p-alpha',
             origin: 'instance',
             creator: 'u1',
             assignee_id: 'u1',
             status: 'in_progress',
             task_type: 'task',
+            start_date: '2026-04-01',
             due_date: '2026-04-22',
+            position: 1,
         },
         {
             id: 't-2',
             title: 'Write welcome letter',
-            parent_task_id: 'p-alpha',
+            parent_task_id: 'm-launch',
             root_id: 'p-alpha',
             origin: 'instance',
             creator: 'u2',
             assignee_id: 'u1',
             status: 'in_progress',
             task_type: 'task',
+            start_date: '2026-04-01',
             due_date: '2026-05-10',
+            position: 2,
+        },
+        {
+            id: 't-hidden',
+            title: 'Future hidden task',
+            parent_task_id: 'm-launch',
+            root_id: 'p-alpha',
+            origin: 'instance',
+            creator: 'u2',
+            assignee_id: 'u1',
+            status: 'todo',
+            task_type: 'task',
+            start_date: '2099-01-01',
+            due_date: '2099-01-08',
+            position: 3,
         },
         {
             id: 't-1-child',
@@ -145,7 +195,7 @@ function renderTasksPage() {
     );
 }
 
-describe('TasksPage — click-to-details + tooltip wiring (Wave 33)', () => {
+describe('TasksPage — PM-1 priority view + details dialog', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
@@ -156,16 +206,38 @@ describe('TasksPage — click-to-details + tooltip wiring (Wave 33)', () => {
         expect(screen.queryByTestId('tasks-page-details-panel')).not.toBeInTheDocument();
     });
 
-    it('opens the details panel with the clicked task', async () => {
+    it('defaults to the grouped priority view and hides empty or non-qualifying rows', async () => {
+        renderTasksPage();
+
+        expect(await screen.findByRole('heading', { name: 'Priority' })).toBeInTheDocument();
+        expect(screen.getByTestId('priority-task-group-milestone-m-launch')).toBeInTheDocument();
+        expect(screen.getByText('Launch Milestone')).toBeInTheDocument();
+        expect(screen.queryByText('Empty Milestone')).not.toBeInTheDocument();
+        expect(screen.queryByText('Future hidden task')).not.toBeInTheDocument();
+    });
+
+    it('opens the details dialog with the clicked task', async () => {
         const user = userEvent.setup();
         renderTasksPage();
 
         const row = await screen.findByTestId('task-row-t-1');
         await user.click(row);
 
+        expect(await screen.findByRole('dialog', { name: 'Buy a domain' })).toBeInTheDocument();
         const panel = await screen.findByTestId('tasks-page-details-panel');
         expect(panel).toBeInTheDocument();
         expect(screen.getByTestId('tasks-page-details-panel-title')).toHaveTextContent('Buy a domain');
+    });
+
+    it('opens the details dialog from the keyboard', async () => {
+        const user = userEvent.setup();
+        renderTasksPage();
+
+        const row = await screen.findByTestId('task-row-t-1');
+        row.focus();
+        await user.keyboard('{Enter}');
+
+        expect(await screen.findByRole('dialog', { name: 'Buy a domain' })).toBeInTheDocument();
     });
 
     it('hydrates the clicked task with project context for the details panel', async () => {
@@ -175,7 +247,7 @@ describe('TasksPage — click-to-details + tooltip wiring (Wave 33)', () => {
         await user.click(await screen.findByTestId('task-row-t-1'));
 
         expect(await screen.findByTestId('tasks-page-details-panel-child-count')).toHaveTextContent('1');
-        expect(screen.getByTestId('tasks-page-details-panel-project-task-count')).toHaveTextContent('4');
+        expect(screen.getByTestId('tasks-page-details-panel-project-task-count')).toHaveTextContent('8');
     });
 
     it('closes the details panel via onClose', async () => {

--- a/Testing/unit/pages/TasksPage.test.tsx
+++ b/Testing/unit/pages/TasksPage.test.tsx
@@ -214,6 +214,7 @@ describe('TasksPage — PM-1 priority view + details dialog', () => {
         expect(screen.getByText('Launch Milestone')).toBeInTheDocument();
         expect(screen.queryByText('Empty Milestone')).not.toBeInTheDocument();
         expect(screen.queryByText('Future hidden task')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Sort order')).not.toBeInTheDocument();
     });
 
     it('opens the details dialog with the clicked task', async () => {

--- a/Testing/unit/pages/admin/AdminLayout.test.tsx
+++ b/Testing/unit/pages/admin/AdminLayout.test.tsx
@@ -37,7 +37,7 @@ function renderAt(initialEntry = '/admin') {
                 <Route path="/admin" element={<AdminLayout />}>
                     <Route index element={<div data-testid="admin-home-stub">home</div>} />
                 </Route>
-                <Route path="/dashboard" element={<div data-testid="dashboard-stub">dashboard</div>} />
+                <Route path="/tasks" element={<div data-testid="tasks-stub">tasks</div>} />
             </Routes>
         </MemoryRouter>,
     );
@@ -48,11 +48,11 @@ describe('AdminLayout auth gate (Wave 34)', () => {
         toastError.mockReset();
     });
 
-    it('redirects non-admin users to /dashboard with a toast', async () => {
+    it('redirects non-admin users to /tasks with a toast', async () => {
         authState.user = { id: 'u1', role: 'editor' };
         authState.loading = false;
         renderAt();
-        expect(await screen.findByTestId('dashboard-stub')).toBeInTheDocument();
+        expect(await screen.findByTestId('tasks-stub')).toBeInTheDocument();
         expect(toastError).toHaveBeenCalledWith('You need admin access for this page.');
     });
 

--- a/src/features/navigation/components/AppSidebar.tsx
+++ b/src/features/navigation/components/AppSidebar.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui/button';
-import { LayoutDashboard, BarChart3, Settings, HelpCircle, ChevronLeft, Calendar } from 'lucide-react';
+import { BarChart3, Settings, HelpCircle, ChevronLeft, Calendar } from 'lucide-react';
 import type { TaskRow } from '@/shared/db/app.types';
 
 interface AppSidebarProps {
@@ -20,7 +20,6 @@ export default function AppSidebar({ onClose, currentProject, className }: AppSi
   {
    title: t('nav.section_main'),
    items: [
-    { name: t('nav.project_dashboard'), icon: LayoutDashboard, path: 'Dashboard' },
     { name: t('nav.my_tasks'), icon: Calendar, path: 'tasks' },
     { name: t('nav.reports'), icon: BarChart3, path: 'Reports' },
    ],

--- a/src/features/navigation/components/Header.tsx
+++ b/src/features/navigation/components/Header.tsx
@@ -59,7 +59,7 @@ export default function Header({ onMenuToggle, showMenuButton = false }: HeaderP
                             </Button>
                         )}
 
-                        <Link to="/Dashboard" className="flex items-center gap-2" aria-label={t('nav.planterplan_home_aria')}>
+                        <Link to="/tasks" className="flex items-center gap-2" aria-label={t('nav.planterplan_home_aria')}>
                             <div className="w-9 h-9 bg-orange-500 rounded-lg flex items-center justify-center shadow-sm">
                                 <CheckCircle2 className="w-5 h-5 text-white" />
                             </div>

--- a/src/features/navigation/components/ProjectSidebar.tsx
+++ b/src/features/navigation/components/ProjectSidebar.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '@/shared/contexts/AuthContext';
 import InstanceList from '@/features/projects/components/InstanceList';
 import JoinedProjectsList from '@/features/projects/components/JoinedProjectsList';
 import TemplateList from '@/features/library/components/TemplateList';
-import { LayoutDashboard, BarChart, Settings, Calendar } from 'lucide-react';
+import { BarChart, Settings, Calendar } from 'lucide-react';
 import GlobalNavItem from './GlobalNavItem';
 
 const SectionSkeleton = () => (
@@ -80,12 +80,6 @@ const ProjectSidebar = ({
  return (
  <div className="flex flex-col h-full bg-card text-card-foreground border-r border-border shadow-sm">
  <div className="px-4 py-4 space-y-1">
- <GlobalNavItem
- label={t('nav.project_dashboard')}
- isActive={location.pathname === '/dashboard'}
- onClick={() => handleGlobalNav('/dashboard')}
- icon={<LayoutDashboard className="w-5 h-5" />}
- />
  <GlobalNavItem
  label={t('nav.my_tasks')}
  isActive={location.pathname === '/tasks'}

--- a/src/features/tasks/components/TaskDetailsPanel.tsx
+++ b/src/features/tasks/components/TaskDetailsPanel.tsx
@@ -7,6 +7,7 @@ import type { TaskItemData } from '@/features/tasks/components/TaskItem';
 import TaskForm from '@/features/tasks/components/TaskForm';
 import TaskDetailsView from '@/features/tasks/components/TaskDetailsView';
 import { X } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
 
 type TaskFormState = { mode?: 'create' | 'edit'; origin?: 'instance' | 'template'; isPhase?: boolean } | null;
 
@@ -54,6 +55,7 @@ export interface TaskDetailsPanelProps {
  fetchTasks?: () => void;
  membershipRole?: string;
  allProjectTasks?: TaskRow[];
+ className?: string;
 }
 
 export default function TaskDetailsPanel({
@@ -73,6 +75,7 @@ export default function TaskDetailsPanel({
  fetchTasks,
  membershipRole,
  allProjectTasks,
+ className,
 }: TaskDetailsPanelProps) {
  const { t } = useTranslation();
  const panelTitle = useMemo(() => {
@@ -84,7 +87,13 @@ export default function TaskDetailsPanel({
  const projectId = selectedTask?.root_id ?? selectedTask?.id ?? null;
 
  return (
- <aside data-testid="task-details-panel" className="w-full sm:w-1/3 sm:min-w-80 sm:max-w-md bg-white border-l border-slate-200 flex flex-col shadow-2xl z-30 h-full overflow-hidden transition-all duration-300">
+ <aside
+ data-testid="task-details-panel"
+ className={cn(
+ 'w-full sm:w-1/3 sm:min-w-80 sm:max-w-md bg-white border-l border-slate-200 flex flex-col shadow-2xl z-30 h-full overflow-hidden transition-all duration-300',
+ className,
+ )}
+ >
  <div className="pt-8 px-6 pb-6 border-b border-slate-100 flex justify-between items-start bg-white sticky top-0 z-20">
  <h2 className="font-bold text-xl text-slate-800 truncate pr-4" title={panelTitle}>{panelTitle}</h2>
  <button

--- a/src/features/tasks/components/TaskItem.tsx
+++ b/src/features/tasks/components/TaskItem.tsx
@@ -137,6 +137,21 @@ const TaskItem = ({
  }
  };
 
+ const handleCardKeyDown = (e: React.KeyboardEvent) => {
+ const target = e.target as HTMLElement;
+ if (
+ target.closest('.expand-button') ||
+ target.closest('select') ||
+ target.closest('button') ||
+ target.closest('input')
+ ) {
+ return;
+ }
+ if (e.key !== 'Enter' && e.key !== ' ') return;
+ e.preventDefault();
+ onTaskClick?.(task);
+ };
+
  const handleToggleExpandClick = (e: React.MouseEvent) => {
  e.stopPropagation();
  if (onToggleExpand) {
@@ -185,6 +200,8 @@ const TaskItem = ({
  aria-level={level + 1}
  aria-expanded={canHaveChildren ? isExpanded : undefined}
  aria-selected={isSelected}
+ aria-label={onTaskClick ? t('tasks.open_task_details_aria', { title: task.title ?? '' }) : undefined}
+ tabIndex={!isLocked && onTaskClick ? 0 : undefined}
  className={cn(
  'relative flex flex-col min-w-0 py-4 px-5 mb-3 rounded-xl border transition-all duration-200 shadow-sm',
  'bg-card text-card-foreground',
@@ -198,6 +215,7 @@ const TaskItem = ({
  )}
  style={{ marginLeft: `${indentWidth}px` }}
  onClick={!isLocked ? handleCardClick : undefined}
+ onKeyDown={!isLocked ? handleCardKeyDown : undefined}
  data-testid={`task-row-${task.id}`}
  >
  {focusPeers.length > 0 && (

--- a/src/features/tasks/hooks/useTaskFilters.ts
+++ b/src/features/tasks/hooks/useTaskFilters.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { TaskRow } from '@/shared/db/app.types';
 import { deriveUrgency, compareDateAsc, toIsoDate } from '@/shared/lib/date-engine/index';
+import { filterPriorityTasks } from '@/features/tasks/lib/priority-tasks';
 
 export type TaskFilterKey =
  | 'my_tasks'
@@ -100,7 +101,7 @@ export const filterAndSortTasks = ({
     : [];
    break;
   case 'priority':
-   filtered = instanceChildren.filter((t) => t.priority === 'high' && !isCompleted(t));
+   filtered = filterPriorityTasks(tasks, now);
    break;
   case 'overdue':
    filtered = instanceChildren.filter((t) => urgencyOf(t) === 'overdue');
@@ -163,7 +164,7 @@ export const FILTER_LABELS: Record<TaskFilterKey, string> = {
 
 export const EMPTY_STATE_COPY: Record<TaskFilterKey, string> = {
  my_tasks: 'No tasks found across your projects.',
- priority: 'No high-priority tasks right now.',
+ priority: 'No overdue, due-soon, or started tasks right now.',
  overdue: 'Nothing is overdue. Nice work.',
  due_soon: 'No tasks are due in the next few days.',
  current: 'No tasks are currently active.',

--- a/src/features/tasks/lib/priority-tasks.ts
+++ b/src/features/tasks/lib/priority-tasks.ts
@@ -2,7 +2,7 @@ import type { TaskRow } from '@/shared/db/app.types';
 import {
   addDaysToDate,
   compareDateAsc,
-  formatDate,
+  getNow,
   toIsoDate,
 } from '@/shared/lib/date-engine';
 
@@ -49,7 +49,7 @@ export interface BuildPriorityTaskGroupsArgs {
   candidateTasks?: TaskRow[];
 }
 
-const localIsoDate = (date: Date): string => formatDate(date, 'yyyy-MM-dd');
+const utcIsoDate = (date: Date): string => toIsoDate(date) ?? '';
 
 const compareNullablePosition = (a: number | null | undefined, b: number | null | undefined): number => {
   const left = a ?? Number.MAX_SAFE_INTEGER;
@@ -68,15 +68,15 @@ export const isPriorityExcluded = (task: Pick<TaskRow, 'is_complete' | 'status'>
 
 export const getPriorityTaskMatch = (
   task: Pick<TaskRow, 'due_date' | 'is_complete' | 'start_date' | 'status'>,
-  now: Date = new Date(),
+  now: Date = getNow(),
 ): PriorityTaskMatch => {
-  if (isPriorityExcluded(task as Pick<TaskRow, 'is_complete' | 'status'>)) {
+  if (isPriorityExcluded(task)) {
     return { overdue: false, dueSoon: false, current: false };
   }
 
-  const todayIso = localIsoDate(now);
+  const todayIso = utcIsoDate(now);
   const cutoff = addDaysToDate(now, PRIORITY_DUE_SOON_DAYS);
-  const soonCutoffIso = cutoff ? localIsoDate(cutoff) : todayIso;
+  const soonCutoffIso = cutoff ? utcIsoDate(cutoff) : todayIso;
   const dueIso = toIsoDate(task.due_date);
   const startIso = toIsoDate(task.start_date);
 
@@ -89,7 +89,7 @@ export const getPriorityTaskMatch = (
 
 export const isPriorityQualifyingTask = (
   task: Pick<TaskRow, 'due_date' | 'is_complete' | 'start_date' | 'status'>,
-  now: Date = new Date(),
+  now: Date = getNow(),
 ): boolean => {
   const match = getPriorityTaskMatch(task, now);
   return match.overdue || match.dueSoon || match.current;
@@ -134,7 +134,7 @@ export const getTaskMilestoneContext = (task: TaskRow, tasks: TaskRow[]): TaskMi
 
 export const buildPriorityTaskGroups = ({
   tasks,
-  now = new Date(),
+  now = getNow(),
   candidateTasks,
 }: BuildPriorityTaskGroupsArgs): PriorityTaskGroup[] => {
   const taskById = new Map(tasks.map((task) => [task.id, task]));
@@ -195,5 +195,5 @@ export const buildPriorityTaskGroups = ({
     });
 };
 
-export const filterPriorityTasks = (tasks: TaskRow[], now: Date = new Date()): TaskRow[] =>
+export const filterPriorityTasks = (tasks: TaskRow[], now: Date = getNow()): TaskRow[] =>
   buildPriorityTaskGroups({ tasks, now }).flatMap((group) => group.tasks.map((entry) => entry.task));

--- a/src/features/tasks/lib/priority-tasks.ts
+++ b/src/features/tasks/lib/priority-tasks.ts
@@ -1,0 +1,199 @@
+import type { TaskRow } from '@/shared/db/app.types';
+import {
+  addDaysToDate,
+  compareDateAsc,
+  formatDate,
+  toIsoDate,
+} from '@/shared/lib/date-engine';
+
+export const PRIORITY_DUE_SOON_DAYS = 7;
+
+export const PRIORITY_EXCLUDED_STATUSES = [
+  'completed',
+  'archived',
+  'deleted',
+  'cancelled',
+  'canceled',
+] as const;
+
+const EXCLUDED_STATUS_SET = new Set<string>(PRIORITY_EXCLUDED_STATUSES);
+const NON_TASK_TYPES = new Set(['project', 'phase', 'milestone']);
+
+export interface PriorityTaskMatch {
+  overdue: boolean;
+  dueSoon: boolean;
+  current: boolean;
+}
+
+export interface PriorityTaskEntry {
+  task: TaskRow;
+  displayNumber: string;
+}
+
+export interface PriorityTaskGroup {
+  id: string;
+  title: string;
+  projectTitle: string | null;
+  milestone: TaskRow | null;
+  tasks: PriorityTaskEntry[];
+}
+
+export interface TaskMilestoneContext {
+  milestone: TaskRow | null;
+  projectTitle: string | null;
+}
+
+export interface BuildPriorityTaskGroupsArgs {
+  tasks: TaskRow[];
+  now?: Date;
+  candidateTasks?: TaskRow[];
+}
+
+const localIsoDate = (date: Date): string => formatDate(date, 'yyyy-MM-dd');
+
+const compareNullablePosition = (a: number | null | undefined, b: number | null | undefined): number => {
+  const left = a ?? Number.MAX_SAFE_INTEGER;
+  const right = b ?? Number.MAX_SAFE_INTEGER;
+  return left - right;
+};
+
+const compareTitle = (a: string | null | undefined, b: string | null | undefined): number =>
+  (a ?? '').localeCompare(b ?? '');
+
+export const isPriorityExcluded = (task: Pick<TaskRow, 'is_complete' | 'status'>): boolean => {
+  if (task.is_complete) return true;
+  const status = task.status?.toLowerCase();
+  return status ? EXCLUDED_STATUS_SET.has(status) : false;
+};
+
+export const getPriorityTaskMatch = (
+  task: Pick<TaskRow, 'due_date' | 'is_complete' | 'start_date' | 'status'>,
+  now: Date = new Date(),
+): PriorityTaskMatch => {
+  if (isPriorityExcluded(task as Pick<TaskRow, 'is_complete' | 'status'>)) {
+    return { overdue: false, dueSoon: false, current: false };
+  }
+
+  const todayIso = localIsoDate(now);
+  const cutoff = addDaysToDate(now, PRIORITY_DUE_SOON_DAYS);
+  const soonCutoffIso = cutoff ? localIsoDate(cutoff) : todayIso;
+  const dueIso = toIsoDate(task.due_date);
+  const startIso = toIsoDate(task.start_date);
+
+  const overdue = dueIso !== null && dueIso < todayIso;
+  const dueSoon = dueIso !== null && dueIso >= todayIso && dueIso <= soonCutoffIso;
+  const current = startIso !== null && startIso <= todayIso;
+
+  return { overdue, dueSoon, current };
+};
+
+export const isPriorityQualifyingTask = (
+  task: Pick<TaskRow, 'due_date' | 'is_complete' | 'start_date' | 'status'>,
+  now: Date = new Date(),
+): boolean => {
+  const match = getPriorityTaskMatch(task, now);
+  return match.overdue || match.dueSoon || match.current;
+};
+
+export const isPriorityTaskCandidate = (task: TaskRow): boolean => {
+  if (task.origin !== 'instance') return false;
+  if (task.parent_task_id === null) return false;
+  const taskType = task.task_type?.toLowerCase();
+  return !taskType || !NON_TASK_TYPES.has(taskType);
+};
+
+const findNearestMilestone = (task: TaskRow, taskById: Map<string, TaskRow>): TaskRow | null => {
+  let parentId = task.parent_task_id;
+  const seen = new Set<string>();
+
+  while (parentId && !seen.has(parentId)) {
+    seen.add(parentId);
+    const parent = taskById.get(parentId);
+    if (!parent) return null;
+    if (parent.task_type?.toLowerCase() === 'milestone') return parent;
+    parentId = parent.parent_task_id;
+  }
+
+  return null;
+};
+
+const getProject = (task: TaskRow, taskById: Map<string, TaskRow>): TaskRow | null => {
+  if (task.root_id) return taskById.get(task.root_id) ?? null;
+  return null;
+};
+
+export const getTaskMilestoneContext = (task: TaskRow, tasks: TaskRow[]): TaskMilestoneContext => {
+  const taskById = new Map(tasks.map((row) => [row.id, row]));
+  const milestone = findNearestMilestone(task, taskById);
+  const project = getProject(task, taskById);
+  return {
+    milestone,
+    projectTitle: project?.title ?? null,
+  };
+};
+
+export const buildPriorityTaskGroups = ({
+  tasks,
+  now = new Date(),
+  candidateTasks,
+}: BuildPriorityTaskGroupsArgs): PriorityTaskGroup[] => {
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const candidates = (candidateTasks ?? tasks).filter(
+    (task) => isPriorityTaskCandidate(task) && isPriorityQualifyingTask(task, now),
+  );
+  const groups = new Map<string, Omit<PriorityTaskGroup, 'tasks'> & { tasks: TaskRow[] }>();
+
+  for (const task of candidates) {
+    const milestone = findNearestMilestone(task, taskById);
+    const project = getProject(task, taskById);
+    const groupId = milestone ? `milestone-${milestone.id}` : `orphan-${task.root_id ?? 'unknown'}`;
+
+    if (!groups.has(groupId)) {
+      groups.set(groupId, {
+        id: groupId,
+        title: milestone?.title ?? 'No milestone',
+        projectTitle: project?.title ?? null,
+        milestone,
+        tasks: [],
+      });
+    }
+
+    groups.get(groupId)?.tasks.push(task);
+  }
+
+  return Array.from(groups.values())
+    .sort((a, b) => {
+      const projectTitleCompare = compareTitle(a.projectTitle, b.projectTitle);
+      if (projectTitleCompare !== 0) return projectTitleCompare;
+
+      const orphanCompare = (a.milestone ? 0 : 1) - (b.milestone ? 0 : 1);
+      if (orphanCompare !== 0) return orphanCompare;
+
+      const positionCompare = compareNullablePosition(a.milestone?.position, b.milestone?.position);
+      if (positionCompare !== 0) return positionCompare;
+
+      return compareTitle(a.title, b.title);
+    })
+    .map((group, groupIndex) => {
+      const sortedTasks = [...group.tasks].sort((a, b) => {
+        const dateCompare = compareDateAsc(a.due_date, b.due_date);
+        if (dateCompare !== 0) return dateCompare;
+
+        const positionCompare = compareNullablePosition(a.position, b.position);
+        if (positionCompare !== 0) return positionCompare;
+
+        return compareTitle(a.title, b.title);
+      });
+
+      return {
+        ...group,
+        tasks: sortedTasks.map((task, taskIndex) => ({
+          task,
+          displayNumber: `${groupIndex + 1}.${taskIndex + 1}`,
+        })),
+      };
+    });
+};
+
+export const filterPriorityTasks = (tasks: TaskRow[], now: Date = new Date()): TaskRow[] =>
+  buildPriorityTaskGroups({ tasks, now }).flatMap((group) => group.tasks.map((entry) => entry.task));

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -24,6 +24,7 @@ import {
        type TaskFilterKey,
        type TaskSortKey,
 } from '@/features/tasks/hooks/useTaskFilters';
+import { buildPriorityTaskGroups } from '@/features/tasks/lib/priority-tasks';
 import {
        Select,
        SelectContent,
@@ -31,6 +32,12 @@ import {
        SelectTrigger,
        SelectValue,
 } from '@/shared/ui/select';
+import {
+       Dialog,
+       DialogContent,
+       DialogHeader,
+       DialogTitle,
+} from '@/shared/ui/dialog';
 
 const FILTER_KEYS: TaskFilterKey[] = [
        'my_tasks', 'priority', 'overdue', 'due_soon', 'current', 'not_yet_due', 'completed', 'all_tasks', 'milestones',
@@ -51,7 +58,7 @@ export default function TasksPage() {
        const invalidateTasks = useCallback(() => queryClient.invalidateQueries({ queryKey: ['tasks'] }), [queryClient]);
 
        const [viewMode, setViewMode] = useState('list');
-       const [filter, setFilter] = useState<TaskFilterKey>('my_tasks');
+       const [filter, setFilter] = useState<TaskFilterKey>('priority');
        const [sort, setSort] = useState<TaskSortKey>('chronological');
        const [selectedTask, setSelectedTask] = useState<TaskRow | null>(null);
        const [dueStart, setDueStart] = useState<string>('');
@@ -187,6 +194,12 @@ export default function TasksPage() {
        }, [currentSelectedTask, selectedTeamMembers, selectedProjectRoot, currentUserId]);
 
        const visibleTasks = useTaskFilters({ tasks, filter, sort, dueDateRange, currentUserId });
+       const priorityGroups = useMemo(
+              () => filter === 'priority' && viewMode === 'list'
+                     ? buildPriorityTaskGroups({ tasks, candidateTasks: visibleTasks })
+                     : [],
+              [filter, tasks, viewMode, visibleTasks],
+       );
 
        // Wave 33: map of root-task-id → project title, used to reveal each task's
        // parent-project name in a hover tooltip on the row. Projects live in the
@@ -369,28 +382,80 @@ export default function TasksPage() {
                                                  ) : (
                                                         viewMode === 'list' ? (
                                                                <div className="space-y-6 overflow-y-auto h-full pb-20">
-                                                                      <div className="flex flex-col gap-2">
-                                                                             {visibleTasks.map(task => {
-                                                                                    const projectTitle = task.root_id && task.root_id !== task.id
-                                                                                           ? projectTitleByRootId.get(task.root_id) ?? null
-                                                                                           : null;
-                                                                                    return (
-                                                                                           <TaskItem
-                                                                                                  key={task.id}
-                                                                                                  task={task}
-                                                                                                  level={0}
-                                                                                                  onStatusChange={handleStatusChange}
-                                                                                                  hideExpansion={true}
-                                                                                                  disableDrag={true}
-                                                                                                  onTaskClick={handleTaskClick}
-                                                                                                  onAddChildTask={handleNoop}
-                                                                                                  onInviteMember={handleNoop}
-                                                                                                  selectedTaskId={selectedTaskId}
-                                                                                                  parentProjectTitle={projectTitle}
-                                                                                           />
-                                                                                    );
-                                                                             })}
-                                                                      </div>
+                                                                      {filter === 'priority' ? (
+                                                                             priorityGroups.map((group) => (
+                                                                                    <section
+                                                                                           key={group.id}
+                                                                                           className="rounded-xl border border-border bg-card p-4 shadow-sm"
+                                                                                           data-testid={`priority-task-group-${group.id}`}
+                                                                                    >
+                                                                                           <div className="mb-3 border-b border-border pb-3">
+                                                                                                  <h2
+                                                                                                         id={`priority-group-heading-${group.id}`}
+                                                                                                         className="text-base font-semibold text-card-foreground"
+                                                                                                  >
+                                                                                                         {group.title}
+                                                                                                  </h2>
+                                                                                                  {group.projectTitle && (
+                                                                                                         <p className="text-sm text-muted-foreground">{group.projectTitle}</p>
+                                                                                                  )}
+                                                                                           </div>
+                                                                                           <div
+                                                                                                  role="tree"
+                                                                                                  aria-labelledby={`priority-group-heading-${group.id}`}
+                                                                                                  className="flex flex-col gap-2"
+                                                                                           >
+                                                                                                  {group.tasks.map(({ task, displayNumber }) => (
+                                                                                                         <div key={task.id} className="flex min-w-0 gap-3">
+                                                                                                                <span
+                                                                                                                       className="mt-5 w-10 flex-shrink-0 text-right font-mono text-xs font-semibold text-muted-foreground"
+                                                                                                                       aria-hidden="true"
+                                                                                                                >
+                                                                                                                       {displayNumber}
+                                                                                                                </span>
+                                                                                                                <div className="min-w-0 flex-1">
+                                                                                                                       <TaskItem
+                                                                                                                              task={task}
+                                                                                                                              level={0}
+                                                                                                                              onStatusChange={handleStatusChange}
+                                                                                                                              hideExpansion={true}
+                                                                                                                              disableDrag={true}
+                                                                                                                              onTaskClick={handleTaskClick}
+                                                                                                                              onAddChildTask={handleNoop}
+                                                                                                                              onInviteMember={handleNoop}
+                                                                                                                              selectedTaskId={selectedTaskId}
+                                                                                                                              parentProjectTitle={group.projectTitle}
+                                                                                                                       />
+                                                                                                                </div>
+                                                                                                         </div>
+                                                                                                  ))}
+                                                                                           </div>
+                                                                                    </section>
+                                                                             ))
+                                                                      ) : (
+                                                                             <div className="flex flex-col gap-2">
+                                                                                    {visibleTasks.map(task => {
+                                                                                           const projectTitle = task.root_id && task.root_id !== task.id
+                                                                                                  ? projectTitleByRootId.get(task.root_id) ?? null
+                                                                                                  : null;
+                                                                                           return (
+                                                                                                  <TaskItem
+                                                                                                         key={task.id}
+                                                                                                         task={task}
+                                                                                                         level={0}
+                                                                                                         onStatusChange={handleStatusChange}
+                                                                                                         hideExpansion={true}
+                                                                                                         disableDrag={true}
+                                                                                                         onTaskClick={handleTaskClick}
+                                                                                                         onAddChildTask={handleNoop}
+                                                                                                         onInviteMember={handleNoop}
+                                                                                                         selectedTaskId={selectedTaskId}
+                                                                                                         parentProjectTitle={projectTitle}
+                                                                                                  />
+                                                                                           );
+                                                                                    })}
+                                                                             </div>
+                                                                      )}
                                                                </div>
                                                         ) : (
                                                                <div className="h-full">
@@ -407,16 +472,32 @@ export default function TasksPage() {
                             </div>
                      </DndContext>
 
-                     {selectedTaskForPanel && (
-                            <TaskDetailsPanel
-                                   showForm={false}
-                                   selectedTask={selectedTaskForPanel}
-                                   allProjectTasks={selectedProjectTasks}
-                                   membershipRole={selectedMembershipRole}
-                                   onClose={closeDetailsPanel}
-                                   onDeleteTaskWrapper={handleDeleteTaskById}
-                            />
-                     )}
+                     <Dialog
+                            open={selectedTaskForPanel !== null}
+                            onOpenChange={(open) => {
+                                   if (!open) closeDetailsPanel();
+                            }}
+                     >
+                            <DialogContent
+                                   hideClose
+                                   className="h-[85vh] max-h-[85vh] w-[calc(100vw-2rem)] max-w-3xl overflow-hidden p-0"
+                            >
+                                   <DialogHeader className="sr-only">
+                                          <DialogTitle>{selectedTaskForPanel?.title ?? t('tasks.panel.details')}</DialogTitle>
+                                   </DialogHeader>
+                                   {selectedTaskForPanel && (
+                                          <TaskDetailsPanel
+                                                 showForm={false}
+                                                 selectedTask={selectedTaskForPanel}
+                                                 allProjectTasks={selectedProjectTasks}
+                                                 membershipRole={selectedMembershipRole}
+                                                 onClose={closeDetailsPanel}
+                                                 onDeleteTaskWrapper={handleDeleteTaskById}
+                                                 className="w-full border-l-0 shadow-none sm:w-full sm:min-w-0 sm:max-w-none"
+                                          />
+                                   )}
+                            </DialogContent>
+                     </Dialog>
               </>
        );
 }

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -68,6 +68,7 @@ export default function TasksPage() {
               [dueStart, dueEnd],
        );
        const hasDueRange = dueDateRange.start !== null || dueDateRange.end !== null;
+       const effectiveSort: TaskSortKey = filter === 'priority' ? 'chronological' : sort;
        const clearDueRange = useCallback(() => {
               setDueStart('');
               setDueEnd('');
@@ -193,7 +194,7 @@ export default function TasksPage() {
               return undefined;
        }, [currentSelectedTask, selectedTeamMembers, selectedProjectRoot, currentUserId]);
 
-       const visibleTasks = useTaskFilters({ tasks, filter, sort, dueDateRange, currentUserId });
+       const visibleTasks = useTaskFilters({ tasks, filter, sort: effectiveSort, dueDateRange, currentUserId });
        const priorityGroups = useMemo(
               () => filter === 'priority' && viewMode === 'list'
                      ? buildPriorityTaskGroups({ tasks, candidateTasks: visibleTasks })
@@ -298,18 +299,20 @@ export default function TasksPage() {
                                                                </Select>
                                                         </div>
 
-                                                        <div className="flex flex-col gap-1">
-                                                               <label htmlFor="task-sort" className="text-xs font-medium text-muted-foreground">{t('tasks.sort_label')}</label>
-                                                               <Select value={sort} onValueChange={(v) => setSort(v as TaskSortKey)}>
-                                                                      <SelectTrigger id="task-sort" className="w-[180px] bg-card" aria-label={t('tasks.sort_aria')}>
-                                                                             <SelectValue />
-                                                                      </SelectTrigger>
-                                                                      <SelectContent>
-                                                                             <SelectItem value="chronological">{t('tasks.sort_chronological')}</SelectItem>
-                                                                             <SelectItem value="alphabetical">{t('tasks.sort_alphabetical')}</SelectItem>
-                                                                      </SelectContent>
-                                                               </Select>
-                                                        </div>
+                                                        {filter !== 'priority' && (
+                                                               <div className="flex flex-col gap-1">
+                                                                      <label htmlFor="task-sort" className="text-xs font-medium text-muted-foreground">{t('tasks.sort_label')}</label>
+                                                                      <Select value={sort} onValueChange={(v) => setSort(v as TaskSortKey)}>
+                                                                             <SelectTrigger id="task-sort" className="w-[180px] bg-card" aria-label={t('tasks.sort_aria')}>
+                                                                                    <SelectValue />
+                                                                             </SelectTrigger>
+                                                                             <SelectContent>
+                                                                                    <SelectItem value="chronological">{t('tasks.sort_chronological')}</SelectItem>
+                                                                                    <SelectItem value="alphabetical">{t('tasks.sort_alphabetical')}</SelectItem>
+                                                                             </SelectContent>
+                                                                      </Select>
+                                                               </div>
+                                                        )}
 
                                                         <div className="flex flex-col gap-1">
                                                                <span className="text-xs font-medium text-muted-foreground">
@@ -480,7 +483,7 @@ export default function TasksPage() {
                      >
                             <DialogContent
                                    hideClose
-                                   className="h-[85vh] max-h-[85vh] w-[calc(100vw-2rem)] max-w-3xl overflow-hidden p-0"
+                                   className="h-full max-h-screen max-w-3xl overflow-hidden p-0 sm:h-5/6"
                             >
                                    <DialogHeader className="sr-only">
                                           <DialogTitle>{selectedTaskForPanel?.title ?? t('tasks.panel.details')}</DialogTitle>

--- a/src/pages/admin/AdminLayout.tsx
+++ b/src/pages/admin/AdminLayout.tsx
@@ -33,7 +33,7 @@ const NAV_ITEMS: NavItem[] = [
 
 /**
  * Wave 34: admin shell. Hard-gates every `/admin/*` route via `useIsAdmin`.
- * Non-admin users are redirected to `/dashboard` with a Sonner toast.
+ * Non-admin users are redirected to `/tasks` with a Sonner toast.
  * Nav on the left, `<Outlet>` renders the matched child route.
  *
  * Templates + Projects are shallow links into the existing routes, not new
@@ -59,7 +59,7 @@ export default function AdminLayout() {
     }
 
     if (!isAdmin) {
-        return <Navigate to="/dashboard" replace />;
+        return <Navigate to="/tasks" replace />;
     }
 
     return (

--- a/src/pages/components/LoginForm.tsx
+++ b/src/pages/components/LoginForm.tsx
@@ -51,7 +51,7 @@ const LoginForm = () => {
  if (result.error) {
  throw result.error;
  } else {
- navigate('/dashboard');
+ navigate('/tasks');
  }
  } catch (err: unknown) {
  toast.error(isSignUp ? t('errors.signup_failed') : t('errors.login_failed'), {

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -174,7 +174,7 @@
       },
       "empty": {
         "my_tasks": "No tasks found across your projects.",
-        "priority": "No high-priority tasks right now.",
+        "priority": "No overdue, due-soon, or started tasks right now.",
         "overdue": "Nothing is overdue. Nice work.",
         "due_soon": "No tasks are due in the next few days.",
         "current": "No tasks are currently active.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -180,7 +180,7 @@
       },
       "empty": {
         "my_tasks": "No se han encontrado tareas en tus proyectos.",
-        "priority": "No hay tareas de alta prioridad ahora mismo.",
+        "priority": "No hay tareas vencidas, próximas a vencer o iniciadas ahora mismo.",
         "overdue": "Nada está atrasado. Buen trabajo.",
         "due_soon": "No hay tareas que venzan en los próximos días.",
         "current": "No hay tareas activas actualmente.",

--- a/src/shared/ui/CommandPalette.tsx
+++ b/src/shared/ui/CommandPalette.tsx
@@ -2,11 +2,10 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
- LayoutDashboard,
  FolderOpen,
  Settings,
  User,
- Calendar
+ Calendar,
 } from 'lucide-react';
 
 import {
@@ -69,10 +68,6 @@ export function CommandPalette({ projects = [] }: CommandPaletteProps) {
  <CommandEmpty>{t('nav.command_empty')}</CommandEmpty>
 
  <CommandGroup heading={t('nav.command_suggestions')}>
- <CommandItem onSelect={() => runCommand(() => navigate('/dashboard'))}>
- <LayoutDashboard className="mr-2 h-4 w-4" />
- <span>{t('nav.project_dashboard')}</span>
- </CommandItem>
  <CommandItem onSelect={() => runCommand(() => navigate('/tasks'))}>
  <Calendar className="mr-2 h-4 w-4" />
  <span>{t('nav.my_tasks')}</span>


### PR DESCRIPTION
## Summary
- Reapplies the PM-1 priority task view onto the clean branch from `main`.
- Makes `/tasks` the default priority landing surface and removes dashboard from normal navigation/login/admin fallback paths while preserving the `/dashboard` deep link for project/template creation behavior.
- Adds priority filtering/grouping utilities, milestone-grouped list rendering, keyboard-accessible task opening, and dialog-wrapped task details using the existing task details panel.
- Adds focused unit coverage for priority boundaries, milestone grouping, task filtering, TasksPage behavior, and admin redirect behavior.

## Validation
- `npx vitest --run Testing/unit/features/tasks/lib/priority-tasks.test.ts`
- `npx vitest --run Testing/unit/features/tasks/hooks/useTaskFilters.test.ts`
- `npx vitest --run Testing/unit/pages/TasksPage.test.tsx`
- `npx vitest --run Testing/unit/pages/admin/AdminLayout.test.tsx`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck:agent`
- `npx tsc --noEmit --pretty false`
- `npm test` (104 files, 919 tests passed)
- `npm run build`

## Notes
- No DB schema, Supabase migrations, generated DB types, RLS, CI, package files, coverage, or Vercel artifacts were touched.
- `/dashboard` remains available as a deep link until project/template creation is moved elsewhere.