### PR TITLE
fix: route date logic through shared date utilities

### DIFF
--- a/scripts/verify-architecture.cjs
+++ b/scripts/verify-architecture.cjs
@@ -45,6 +45,103 @@ function read(file) {
   return readFileSync(file, 'utf8');
 }
 
+function stripCodeComments(source) {
+  let result = '';
+  let state = 'code';
+  let blockDepth = 0;
+  let templateExpressionDepth = 0;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (state === 'lineComment') {
+      if (char === '\n' || char === '\r') {
+        result += char;
+        state = 'code';
+      } else {
+        result += ' ';
+      }
+      continue;
+    }
+
+    if (state === 'blockComment') {
+      if (char === '\n' || char === '\r') {
+        result += char;
+      } else if (char === '*' && next === '/') {
+        result += '  ';
+        i += 1;
+        blockDepth -= 1;
+        if (blockDepth === 0) state = 'code';
+      } else {
+        result += ' ';
+      }
+      continue;
+    }
+
+    if (state === 'singleQuote' || state === 'doubleQuote' || state === 'template') {
+      result += char;
+      if (char === '\\') {
+        if (i + 1 < source.length) {
+          result += source[i + 1];
+          i += 1;
+        }
+        continue;
+      }
+      if (state === 'singleQuote' && char === "'") state = 'code';
+      if (state === 'doubleQuote' && char === '"') state = 'code';
+      if (state === 'template' && char === '`') state = templateExpressionDepth > 0 ? 'templateExpression' : 'code';
+      if (state === 'template' && char === '$' && next === '{') {
+        result += next;
+        i += 1;
+        templateExpressionDepth += 1;
+        state = 'templateExpression';
+      }
+      continue;
+    }
+
+    if (state === 'templateExpression' && char === '}') {
+      result += char;
+      templateExpressionDepth -= 1;
+      if (templateExpressionDepth === 0) state = 'template';
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      result += '  ';
+      i += 1;
+      state = 'lineComment';
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      result += '  ';
+      i += 1;
+      blockDepth = 1;
+      state = 'blockComment';
+      continue;
+    }
+    if (char === "'") {
+      result += char;
+      state = 'singleQuote';
+      continue;
+    }
+    if (char === '"') {
+      result += char;
+      state = 'doubleQuote';
+      continue;
+    }
+    if (char === '`') {
+      result += char;
+      state = 'template';
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
 function nonTestFile(file) {
   return !/\.test\.tsx?$/.test(file);
 }
@@ -52,10 +149,12 @@ function nonTestFile(file) {
 function findMatches(files, rule, predicate) {
   const matches = [];
   for (const file of files) {
-    const lines = read(file).split(/\r?\n/);
-    lines.forEach((line, index) => {
+    const source = read(file);
+    const originalLines = source.split(/\r?\n/);
+    const codeLines = stripCodeComments(source).split(/\r?\n/);
+    codeLines.forEach((line, index) => {
       if (predicate(line, file)) {
-        matches.push(`${toRepoPath(file)}:${index + 1}:${line}`);
+        matches.push(`${toRepoPath(file)}:${index + 1}:${originalLines[index] ?? line}`);
       }
     });
   }

--- a/scripts/verify-architecture.cjs
+++ b/scripts/verify-architecture.cjs
@@ -46,7 +46,7 @@ function read(file) {
 }
 
 function stripCodeComments(source) {
-  const chars = Array.from(source);
+  const chars = source.split('');
   const stack = [{ type: 'code' }];
   const current = () => stack[stack.length - 1];
   const blank = (index) => {

--- a/scripts/verify-architecture.cjs
+++ b/scripts/verify-architecture.cjs
@@ -46,100 +46,108 @@ function read(file) {
 }
 
 function stripCodeComments(source) {
-  let result = '';
-  let state = 'code';
-  let blockDepth = 0;
-  let templateExpressionDepth = 0;
+  const chars = Array.from(source);
+  const stack = [{ type: 'code' }];
+  const current = () => stack[stack.length - 1];
+  const blank = (index) => {
+    if (chars[index] !== '\n' && chars[index] !== '\r') chars[index] = ' ';
+  };
 
   for (let i = 0; i < source.length; i += 1) {
     const char = source[i];
     const next = source[i + 1];
+    const state = current();
 
-    if (state === 'lineComment') {
-      if (char === '\n' || char === '\r') {
-        result += char;
-        state = 'code';
-      } else {
-        result += ' ';
-      }
+    if (state.type === 'lineComment') {
+      if (char === '\n' || char === '\r') stack.pop();
+      else blank(i);
       continue;
     }
 
-    if (state === 'blockComment') {
-      if (char === '\n' || char === '\r') {
-        result += char;
-      } else if (char === '*' && next === '/') {
-        result += '  ';
+    if (state.type === 'blockComment') {
+      blank(i);
+      if (char === '*' && next === '/') {
+        blank(i + 1);
         i += 1;
-        blockDepth -= 1;
-        if (blockDepth === 0) state = 'code';
-      } else {
-        result += ' ';
+        stack.pop();
       }
       continue;
     }
 
-    if (state === 'singleQuote' || state === 'doubleQuote' || state === 'template') {
-      result += char;
+    if (state.type === 'singleQuote' || state.type === 'doubleQuote') {
       if (char === '\\') {
-        if (i + 1 < source.length) {
-          result += source[i + 1];
-          i += 1;
-        }
+        i += 1;
         continue;
       }
-      if (state === 'singleQuote' && char === "'") state = 'code';
-      if (state === 'doubleQuote' && char === '"') state = 'code';
-      if (state === 'template' && char === '`') state = templateExpressionDepth > 0 ? 'templateExpression' : 'code';
-      if (state === 'template' && char === '$' && next === '{') {
-        result += next;
-        i += 1;
-        templateExpressionDepth += 1;
-        state = 'templateExpression';
+      if (
+        (state.type === 'singleQuote' && char === "'") ||
+        (state.type === 'doubleQuote' && char === '"')
+      ) {
+        stack.pop();
       }
       continue;
     }
 
-    if (state === 'templateExpression' && char === '}') {
-      result += char;
-      templateExpressionDepth -= 1;
-      if (templateExpressionDepth === 0) state = 'template';
+    if (state.type === 'template') {
+      if (char === '\\') {
+        i += 1;
+        continue;
+      }
+      if (char === '`') {
+        stack.pop();
+        continue;
+      }
+      if (char === '$' && next === '{') {
+        i += 1;
+        stack.push({ type: 'templateExpression', braceDepth: 1 });
+      }
       continue;
+    }
+
+    if (state.type === 'templateExpression') {
+      if (char === '{') {
+        state.braceDepth += 1;
+        continue;
+      }
+      if (char === '}') {
+        state.braceDepth -= 1;
+        if (state.braceDepth === 0) stack.pop();
+        continue;
+      }
     }
 
     if (char === '/' && next === '/') {
-      result += '  ';
+      blank(i);
+      blank(i + 1);
       i += 1;
-      state = 'lineComment';
-      continue;
-    }
-    if (char === '/' && next === '*') {
-      result += '  ';
-      i += 1;
-      blockDepth = 1;
-      state = 'blockComment';
-      continue;
-    }
-    if (char === "'") {
-      result += char;
-      state = 'singleQuote';
-      continue;
-    }
-    if (char === '"') {
-      result += char;
-      state = 'doubleQuote';
-      continue;
-    }
-    if (char === '`') {
-      result += char;
-      state = 'template';
+      stack.push({ type: 'lineComment' });
       continue;
     }
 
-    result += char;
+    if (char === '/' && next === '*') {
+      blank(i);
+      blank(i + 1);
+      i += 1;
+      stack.push({ type: 'blockComment' });
+      continue;
+    }
+
+    if (char === "'") {
+      stack.push({ type: 'singleQuote' });
+      continue;
+    }
+
+    if (char === '"') {
+      stack.push({ type: 'doubleQuote' });
+      continue;
+    }
+
+    if (char === '`') {
+      stack.push({ type: 'template' });
+    }
   }
 
-  return result;
+  return chars.join('');
 }
 
 function nonTestFile(file) {

--- a/src/features/gantt/lib/gantt-adapter.ts
+++ b/src/features/gantt/lib/gantt-adapter.ts
@@ -8,7 +8,7 @@
  */
 import type { Task as GanttTaskApiType } from 'gantt-task-react';
 import type { HierarchyTask } from '@/shared/db/app.types';
-import { compareDateAsc } from '@/shared/lib/date-engine';
+import { addDaysToDate, compareDateAsc } from '@/shared/lib/date-engine';
 
 export interface GanttRowOptions {
     includeLeafTasks: boolean;
@@ -23,6 +23,11 @@ export interface AdapterResult {
 const BRAND_COLOR_FALLBACK = 'hsl(19, 96%, 41%)';
 
 type WithChildren = HierarchyTask & { __kids?: HierarchyTask[] };
+
+const toGanttDate = (iso: string): Date | null => addDaysToDate(
+    /^\d{4}-\d{2}-\d{2}$/.test(iso) ? `${iso}T00:00:00.000Z` : iso,
+    0,
+);
 
 /**
  * Walks a flat hierarchy of tasks and emits one gantt row per phase + milestone,
@@ -105,8 +110,12 @@ export function tasksToGanttRows(tasks: HierarchyTask[], opts: GanttRowOptions):
             return;
         }
 
-        const start = new Date(startIso);
-        let end = new Date(endIso);
+        const start = toGanttDate(startIso);
+        let end = toGanttDate(endIso);
+        if (!start || !end) {
+            skippedCount += 1;
+            return;
+        }
         if (compareDateAsc(startIso, endIso) > 0) {
             console.warn(`[gantt-adapter] Task ${node.id} has due_date before start_date; collapsing to start.`);
             end = start;

--- a/src/features/projects/components/ProjectActivityTab.tsx
+++ b/src/features/projects/components/ProjectActivityTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Button } from '@/shared/ui/button';
-import { formatDisplayDate, addDaysToDate } from '@/shared/lib/date-engine';
+import { formatDisplayDate, addDaysToDate, formatDate, getNow } from '@/shared/lib/date-engine';
 import { planter } from '@/shared/api/planterClient';
 import { useProjectActivity } from '@/features/projects/hooks/useProjectActivity';
 import { ActivityRow } from './ActivityRow';
@@ -21,20 +21,12 @@ const FILTERS: ReadonlyArray<{ key: Filter; label: string }> = [
 
 const PAGE_SIZE = 50;
 
-function sameLocalDay(a: Date, b: Date): boolean {
-    return (
-        a.getFullYear() === b.getFullYear() &&
-        a.getMonth() === b.getMonth() &&
-        a.getDate() === b.getDate()
-    );
-}
-
 function dayLabel(isoString: string): string {
-    const today = new Date();
-    const rowDay = new Date(isoString);
-    if (sameLocalDay(rowDay, today)) return 'Today';
+    const today = getNow();
+    const rowDayKey = formatDate(isoString, 'yyyy-MM-dd');
+    if (rowDayKey && rowDayKey === formatDate(today, 'yyyy-MM-dd')) return 'Today';
     const yesterday = addDaysToDate(today, -1);
-    if (yesterday && sameLocalDay(rowDay, yesterday)) return 'Yesterday';
+    if (yesterday && rowDayKey === formatDate(yesterday, 'yyyy-MM-dd')) return 'Yesterday';
     return formatDisplayDate(isoString);
 }
 

--- a/src/features/projects/hooks/useProjectReports.ts
+++ b/src/features/projects/hooks/useProjectReports.ts
@@ -4,6 +4,8 @@ import { CheckCircle2, Clock, AlertTriangle, Circle } from 'lucide-react';
 import {
  dateStringToMonthKey,
  dateStringToUtcMidnight,
+ getNow,
+ toIsoDate,
  toMonthKey,
 } from '@/shared/lib/date-engine';
 import type { TaskRow } from '@/shared/db/app.types';
@@ -20,7 +22,7 @@ export function useProjectReports(
  phases: TaskRow[],
  options: UseProjectReportsOptions = {},
 ) {
- const { selectedMonth, now = new Date() } = options;
+ const { selectedMonth, now = getNow() } = options;
  return useMemo(() => {
  // Basic task counts
  const tasksByStatus = {
@@ -106,11 +108,7 @@ export function useProjectReports(
 
  // Month-scoped milestone lists (Wave 20)
  const monthKey = selectedMonth ?? toMonthKey(now);
- const todayMidnight = (() => {
-  const d = new Date(now.getTime());
-  d.setUTCHours(0, 0, 0, 0);
-  return d.getTime();
- })();
+ const todayMidnight = dateStringToUtcMidnight(toIsoDate(now)) ?? 0;
 
  const isMilestoneComplete = (m: (typeof milestones)[number]) =>
   Boolean(m.is_complete) || m.status === TASK_STATUS.COMPLETED;

--- a/src/features/tasks/hooks/useTaskComments.ts
+++ b/src/features/tasks/hooks/useTaskComments.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { planter } from '@/shared/api/planterClient';
 import { useAuth } from '@/shared/contexts/AuthContext';
+import { nowUtcIso } from '@/shared/lib/date-engine';
 import type { TaskCommentWithAuthor } from '@/shared/db/app.types';
 
 type CommentsCache = TaskCommentWithAuthor[];
@@ -48,7 +49,7 @@ export function useCreateComment(taskId: string) {
             await qc.cancelQueries({ queryKey: key });
             const previous = qc.getQueryData<CommentsCache>(key);
             if (user) {
-                const now = new Date().toISOString();
+                const now = nowUtcIso();
                 const temp: TaskCommentWithAuthor = {
                     id: `optimistic-${globalThis.crypto.randomUUID()}`,
                     task_id: taskId,
@@ -101,7 +102,7 @@ export function useUpdateComment(taskId: string) {
                               ...c,
                               body: payload.body,
                               mentions: payload.mentions,
-                              edited_at: new Date().toISOString(),
+                              edited_at: nowUtcIso(),
                           }
                         : c,
                 ),
@@ -132,7 +133,7 @@ export function useDeleteComment(taskId: string) {
         onMutate: async (commentId) => {
             await qc.cancelQueries({ queryKey: key });
             const previous = qc.getQueryData<CommentsCache>(key);
-            const now = new Date().toISOString();
+            const now = nowUtcIso();
             qc.setQueryData<CommentsCache>(key, (old = []) =>
                 old.map((c) => (c.id === commentId ? { ...c, deleted_at: now, body: '' } : c)),
             );

--- a/src/features/tasks/hooks/useTaskFilters.ts
+++ b/src/features/tasks/hooks/useTaskFilters.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { TaskRow } from '@/shared/db/app.types';
-import { deriveUrgency, compareDateAsc, toIsoDate } from '@/shared/lib/date-engine/index';
+import { deriveUrgency, compareDateAsc, getNow, toIsoDate } from '@/shared/lib/date-engine/index';
 import { filterPriorityTasks } from '@/features/tasks/lib/priority-tasks';
 
 export type TaskFilterKey =
@@ -77,7 +77,7 @@ export const filterAndSortTasks = ({
  filter,
  sort,
  currentUserId = null,
- now = new Date(),
+ now = getNow(),
  dueDateRange,
 }: UseTaskFiltersArgs): TaskRow[] => {
  const thresholds = buildThresholdMap(tasks);

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -8,7 +8,7 @@ import { Card } from '@/shared/ui/card';
 import { Progress } from '@/shared/ui/progress';
 import { ArrowLeft, Loader2, BarChart, TrendingUp, CheckCircle2, AlertTriangle, Clock } from 'lucide-react';
 import { STALE_TIMES } from '@/shared/lib/react-query-config';
-import { toMonthKey } from '@/shared/lib/date-engine';
+import { getNow, toMonthKey } from '@/shared/lib/date-engine';
 import { useAuth } from '@/shared/contexts/AuthContext';
 import {
     Select,
@@ -68,7 +68,7 @@ export default function Reports() {
     const phases = allTasks.filter((t) => t.parent_task_id === projectId);
     const tasks = allTasks.filter((t) => t.parent_task_id !== projectId);
 
-    const [selectedMonth, setSelectedMonth] = useState<string>(() => toMonthKey(new Date()));
+    const [selectedMonth, setSelectedMonth] = useState<string>(() => toMonthKey(getNow()));
 
     const {
         statsConfig,
@@ -236,7 +236,7 @@ export default function Reports() {
                                             <input
                                                 type="month"
                                                 value={selectedMonth}
-                                                onChange={(e) => setSelectedMonth(e.target.value || toMonthKey(new Date()))}
+                                                onChange={(e) => setSelectedMonth(e.target.value || toMonthKey(getNow()))}
                                                 className="px-2 py-1 rounded-md border border-border bg-card text-sm"
                                                 aria-label={t('projects.reports.month_aria')}
                                             />

--- a/src/shared/i18n/formatters.ts
+++ b/src/shared/i18n/formatters.ts
@@ -1,5 +1,5 @@
 import { i18n } from '@/shared/i18n';
-import { diffInCalendarDays } from '@/shared/lib/date-engine';
+import { addDaysToDate, diffInCalendarDays, getNow } from '@/shared/lib/date-engine';
 
 const currentLocale = (): string => i18n.language || 'en';
 
@@ -54,11 +54,11 @@ export function formatDateLocalized(
   format: 'short' | 'long' | 'relative',
 ): string {
   if (!iso) return '';
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return '';
+  const d = addDaysToDate(/^\d{4}-\d{2}-\d{2}$/.test(iso) ? `${iso}T00:00:00.000Z` : iso, 0);
+  if (!d) return '';
   const locale = currentLocale();
   if (format === 'relative') {
-    const diffDays = diffInCalendarDays(d, new Date());
+    const diffDays = diffInCalendarDays(d, getNow());
     if (diffDays === null) return '';
     const rtf = getRelativeTimeFormat(locale);
     // RelativeTimeFormat 'day' is the finest-grained unit we render. For


### PR DESCRIPTION
## Summary
- Route raw date/time call sites through the shared date-engine utilities.
- Preserve UTC date-only handling for reports and Gantt rows.
- Keep localized display formatting on the existing Intl path while centralizing parsing/current-clock access.
- Include the Wave 0 verifier cleanup that ignores comment-only architecture-rule hits while preserving executable-code enforcement.

## Validation
- npm run verify-architecture: raw date math category removed; remaining failures are type masking and FSD lateral dependencies.
- npm run lint: passed with existing warnings.
- npm run typecheck:agent: passed.
- npx tsc --noEmit --pretty false: passed.
- Targeted Vitest files for changed date consumers: passed.
- npm test: passed, 104 files / 919 tests.

## Notes
- No DB, Supabase, generated type, CI workflow, package, PM-1 behavior, or dashboard routing changes.
- This PR does not address remaining type masking or FSD import-boundary violations.