### PR TITLE
fix: add Vercel SPA rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a Vercel SPA catch-all rewrite so direct route loads and refreshes serve `index.html`.
- Fixes production 404s for client routes such as `/dashboard`, `/tasks`, `/settings`, `/project/:id`, `/gantt`, and gated `/admin`.

## Validation
- `git diff --check`
- `npm ci`
- `npm run verify-architecture`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck:agent`
- `npx tsc --noEmit --pretty false`
- `npm test`
- `npm run build`

## Follow-up
- Verify direct route refreshes against the Vercel preview deployment once available.
