### PR TITLE
fix: guard template-origin task inserts

### DIFF
--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -2745,11 +2745,11 @@ CREATE POLICY "Activity log select by project members" ON "public"."activity_log
 
 
 
-CREATE POLICY "Allow project creation" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((((("root_id" IS NULL) OR ("root_id" = "id")) AND ("parent_task_id" IS NULL) AND ("creator" = ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")))));
+CREATE POLICY "Allow project creation" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((((("root_id" IS NULL) OR ("root_id" = "id")) AND ("parent_task_id" IS NULL) AND ("creator" = ( SELECT "auth"."uid"() AS "uid"))) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid")))));
 
 
 
-CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((("root_id" IS NOT NULL) AND "public"."has_project_role"("root_id", ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"), ARRAY['owner'::"text", 'editor'::"text"]) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")))));
+CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((("root_id" IS NOT NULL) AND "public"."has_project_role"("root_id", ( SELECT "auth"."uid"() AS "uid"), ARRAY['owner'::"text", 'editor'::"text"]) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid")))));
 
 
 

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -2745,11 +2745,11 @@ CREATE POLICY "Activity log select by project members" ON "public"."activity_log
 
 
 
-CREATE POLICY "Allow project creation" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK (((("root_id" IS NULL) OR ("root_id" = "id")) AND ("parent_task_id" IS NULL) AND ("creator" = ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))));
+CREATE POLICY "Allow project creation" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((((("root_id" IS NULL) OR ("root_id" = "id")) AND ("parent_task_id" IS NULL) AND ("creator" = ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")))));
 
 
 
-CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((("root_id" IS NOT NULL) AND "public"."has_project_role"("root_id", ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"), ARRAY['owner'::"text", 'editor'::"text"])));
+CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((("root_id" IS NOT NULL) AND "public"."has_project_role"("root_id", ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"), ARRAY['owner'::"text", 'editor'::"text"]) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")))));
 
 
 

--- a/supabase/migrations/20260428000000_guard_template_origin_insert_policies.sql
+++ b/supabase/migrations/20260428000000_guard_template_origin_insert_policies.sql
@@ -6,10 +6,10 @@ CREATE POLICY "Allow project creation" ON "public"."tasks" FOR INSERT TO "authen
   (
     (("root_id" IS NULL) OR ("root_id" = "id"))
     AND ("parent_task_id" IS NULL)
-    AND ("creator" = (SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))
+    AND ("creator" = (SELECT "auth"."uid"()))
     AND (
       ("origin" IS DISTINCT FROM 'template'::"text")
-      OR "public"."is_admin"((SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))
+      OR "public"."is_admin"((SELECT "auth"."uid"()))
     )
   )
 );
@@ -20,12 +20,12 @@ CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT
     ("root_id" IS NOT NULL)
     AND "public"."has_project_role"(
       "root_id",
-      (SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"),
+      (SELECT "auth"."uid"()),
       ARRAY['owner'::"text", 'editor'::"text"]
     )
     AND (
       ("origin" IS DISTINCT FROM 'template'::"text")
-      OR "public"."is_admin"((SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))
+      OR "public"."is_admin"((SELECT "auth"."uid"()))
     )
   )
 );

--- a/supabase/migrations/20260428000000_guard_template_origin_insert_policies.sql
+++ b/supabase/migrations/20260428000000_guard_template_origin_insert_policies.sql
@@ -1,0 +1,31 @@
+-- Harden permissive task INSERT policies so non-admin users cannot create
+-- template-origin rows through project-root or subtask insertion paths.
+
+DROP POLICY IF EXISTS "Allow project creation" ON "public"."tasks";
+CREATE POLICY "Allow project creation" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK (
+  (
+    (("root_id" IS NULL) OR ("root_id" = "id"))
+    AND ("parent_task_id" IS NULL)
+    AND ("creator" = (SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))
+    AND (
+      ("origin" IS DISTINCT FROM 'template'::"text")
+      OR "public"."is_admin"((SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))
+    )
+  )
+);
+
+DROP POLICY IF EXISTS "Allow subtask creation by members" ON "public"."tasks";
+CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK (
+  (
+    ("root_id" IS NOT NULL)
+    AND "public"."has_project_role"(
+      "root_id",
+      (SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"),
+      ARRAY['owner'::"text", 'editor'::"text"]
+    )
+    AND (
+      ("origin" IS DISTINCT FROM 'template'::"text")
+      OR "public"."is_admin"((SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))
+    )
+  )
+);

--- a/supabase/tests/pgtap_rls_tasks.sql
+++ b/supabase/tests/pgtap_rls_tasks.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(12);
+SELECT plan(14);
 
 -- Clean state
 DELETE FROM auth.users WHERE email IN ('taskowner@example.com', 'team1@example.com', 'unauthorized@example.com', 'owner1@example.com', 'member1@example.com', 'random1@example.com');
@@ -87,6 +87,20 @@ SELECT is(
     'Team member should see 3 tasks now'
 );
 
+-- Test 8: Non-admin Cannot Insert Template-Origin Root Task
+SELECT throws_ok(
+    $$ INSERT INTO tasks (id, root_id, parent_task_id, creator, title, origin) VALUES ('44444444-4444-4444-4444-444444444444', '44444444-4444-4444-4444-444444444444', NULL, '00000000-0000-0000-0000-000000000002', 'Unauthorized Template Root', 'template') $$,
+    'new row violates row-level security policy for table "tasks"',
+    'Non-admin users cannot insert template-origin root tasks'
+);
+
+-- Test 9: Non-admin Editor Cannot Insert Template-Origin Subtask
+SELECT throws_ok(
+    $$ INSERT INTO tasks (id, root_id, parent_task_id, title, origin) VALUES ('55555555-5555-5555-5555-555555555555', '11111111-1111-1111-1111-111111111111', '11111111-1111-1111-1111-111111111111', 'Unauthorized Template Child', 'template') $$,
+    'new row violates row-level security policy for table "tasks"',
+    'Project editors cannot insert template-origin subtasks'
+);
+
 -- =========================================================
 -- START TDD Observations for has_permission Helper
 -- =========================================================
@@ -103,7 +117,7 @@ INSERT INTO project_members (project_id, user_id, role) VALUES
     ('11111111-1111-1111-1111-111111111101', '00000000-0000-0000-0000-000000000101', 'owner'),
     ('11111111-1111-1111-1111-111111111101', '00000000-0000-0000-0000-000000000102', 'editor');
 
--- Test 8: has_permission (Owner Requesting Owner Role)
+-- Test 10: has_permission (Owner Requesting Owner Role)
 -- `has_permission` is an internal helper with direct EXECUTE revoked from
 -- authenticated; test its claim-binding logic as the function owner.
 set local role postgres;
@@ -114,7 +128,7 @@ SELECT is(
     'Owner should have owner permission'
 );
 
--- Test 9: has_permission (Member Requesting Owner Role)
+-- Test 11: has_permission (Member Requesting Owner Role)
 set local request.jwt.claims to '{"sub": "00000000-0000-0000-0000-000000000102"}';
 SELECT is(
     public.has_permission('11111111-1111-1111-1111-111111111101'::uuid, '00000000-0000-0000-0000-000000000102'::uuid, 'owner'::text),
@@ -122,14 +136,14 @@ SELECT is(
     'Member should NOT have owner permission'
 );
 
--- Test 10: has_permission (Member Requesting Editor Role)
+-- Test 12: has_permission (Member Requesting Editor Role)
 SELECT is(
     public.has_permission('11111111-1111-1111-1111-111111111101'::uuid, '00000000-0000-0000-0000-000000000102'::uuid, 'editor'::text),
     true,
     'Editor should have editor permission'
 );
 
--- Test 11: has_permission (Unauthorized User)
+-- Test 13: has_permission (Unauthorized User)
 set local request.jwt.claims to '{"sub": "00000000-0000-0000-0000-000000000103"}';
 SELECT is(
     public.has_permission('11111111-1111-1111-1111-111111111101'::uuid, '00000000-0000-0000-0000-000000000103'::uuid, 'editor'::text),
@@ -137,7 +151,7 @@ SELECT is(
     'Unauthorized user should NOT have editor permission'
 );
 
--- Test 12: has_permission (Mismatched Claim vs Request)
+-- Test 14: has_permission (Mismatched Claim vs Request)
 set local request.jwt.claims to '{"sub": "00000000-0000-0000-0000-000000000103"}';
 SELECT is(
     public.has_permission('11111111-1111-1111-1111-111111111101'::uuid, '00000000-0000-0000-0000-000000000101'::uuid, 'owner'::text),


### PR DESCRIPTION
## Summary
- Add pgTAP coverage proving non-admin users cannot insert `origin = 'template'` rows through root or subtask task insert paths.
- Add a forward Supabase migration that recreates the permissive task INSERT policies with the same admin-only template guard already used by the general insert policy.
- Update `docs/db/schema.sql` to mirror the hardened policy state.

## TDD Signal
- With the tests added before the migration, `npm run db:local:test` failed on the two new template-origin insert assertions.
- After the migration/schema update, `npm run db:local:test` passed.

## Validation
- `git diff --check`
- `npm ci`
- `npm run verify-architecture`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck:agent`
- `npx tsc --noEmit --pretty false`
- `npm test`
- `npm run db:local:test`
- `npm run build`
