### PR TITLE
chore: update ci to node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- updates both GitHub Actions jobs from Node 20 to Node 22
- addresses the Node 20 runner deprecation warning without changing job order or commands

## Validation
- `git diff --check`
- `npm ci`
- `npm run verify-architecture`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck:agent`
- `npx tsc --noEmit --pretty false`
- `npm test`
- `npm run db:local:test`
- `npm run build` (passes with existing Vite chunk-size warning)

## Notes
- No Playwright E2E was run locally.
