### PR TITLE
chore: apply safe audit fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6670,9 +6670,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- applies the non-breaking `npm audit fix` result
- updates `postcss` in the lockfile from 8.5.9 to 8.5.12
- leaves the `uuid` / `playwright-bdd` chain unchanged because npm only offers a breaking `--force` path

## Validation
- `git diff --check`
- `npm ci` (passes; remaining 5 moderate vulnerabilities are the known `uuid` / `playwright-bdd` chain)
- `npm run verify-architecture`
- `npm run lint` (passes with existing warnings)
- `npm run typecheck:agent`
- `npx tsc --noEmit --pretty false`
- `npm test`
- `npm run build` (passes with existing Vite chunk-size warning)
- `npm audit --audit-level=moderate` confirms only the known breaking-force chain remains

## Notes
- Did not run `npm audit fix --force`.
- No Playwright E2E was run locally.
