### PR TITLE
docs: record user-testing product baseline

### DIFF
--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -18,6 +18,7 @@
   - `api/`: API adapters (`planterClient`).
 - **`docs/`**: Source of Truth.
   - `docs/architecture/*.md`: The definitive, modular Single Source of Truth for all domain business rules (Date Engine, RBAC, Tasks). **Always check here first before attempting architectural refactors.**
+  - `docs/architecture/user-testing-baseline.md`: The active user-testing gap-closure baseline and ordered PR guardrails. Use it before dashboard, comments, template flags, clone/import, or date-engine tranche work.
   - `supabase/migrations/20260426000000_baseline_schema.sql`: Current local Supabase baseline.
   - `docs/db/schema.sql`: Generated schema snapshot mirror.
   - `docs/db/README.md`: Current DB bootstrap contract. Local/CI DB validation uses `npm run db:local:bootstrap`, not raw `supabase start`.
@@ -109,7 +110,8 @@ This is wired in `src/features/tasks/hooks/useTaskMutations.ts` (`useCreateTask`
 ## 4. Testing & Verification
 
 - **Unit/Integration**: `npm test` (Vitest).
-- **E2E Tests**: `npm run test:e2e` (Playwright BDD — feature files in `Testing/e2e/features/`).
+- **Release E2E Smoke**: `npm run test:e2e:release` (Playwright BDD `@release` scenarios; required in CI).
+- **Full E2E Suite**: `npm run test:e2e` (legacy Playwright BDD suite in `Testing/e2e/features/`; run manually when changing broad E2E coverage, but do not treat it as the current release gate without first seeding/curating stale scenarios).
 - **Linting**: `npm run lint` (Zero-tolerance for errors, including `noUnusedLocals`).
 
 ## 5. Deployment / Build

--- a/docs/architecture/dashboard-analytics.md
+++ b/docs/architecture/dashboard-analytics.md
@@ -16,7 +16,7 @@ The Dashboard & Analytics domain aggregates telemetry across Projects, Tasks, an
 4. **Dashboard Broadcast:** Real-time hooks push the updated percentage to the Project Card and Dashboard Overview.
 
 ## Business Rules & Constraints
-* **User-testing tranche directive (pending PR C/D):** do not add new product
+* **User-testing tranche directive (pending PR C, PR D):** do not add new product
   ownership to the user dashboard. Project/template creation must move to
   non-dashboard routes first, then `/dashboard`, `ProjectPipelineBoard`, and
   manual project-lifecycle status mutation are scheduled for removal. Derived

--- a/docs/architecture/dashboard-analytics.md
+++ b/docs/architecture/dashboard-analytics.md
@@ -16,6 +16,12 @@ The Dashboard & Analytics domain aggregates telemetry across Projects, Tasks, an
 4. **Dashboard Broadcast:** Real-time hooks push the updated percentage to the Project Card and Dashboard Overview.
 
 ## Business Rules & Constraints
+* **User-testing tranche directive (pending PR C/D):** do not add new product
+  ownership to the user dashboard. Project/template creation must move to
+  non-dashboard routes first, then `/dashboard`, `ProjectPipelineBoard`, and
+  manual project-lifecycle status mutation are scheduled for removal. Derived
+  project lifecycle indicators should come from task state; archive may remain
+  a visibility-only action unless product revises that decision.
 * **Required Visualizations:**
   * Total Projects counts.
   * Task Arrays: Current, Due Soon, Overdue.

--- a/docs/architecture/date-engine.md
+++ b/docs/architecture/date-engine.md
@@ -32,7 +32,7 @@ Calculated dynamically based on system time vs. Task End Dates:
 
 ## Known Gaps / Technical Debt
 * Algorithms for auto-adjusting dates currently lack logic for skipping weekends and regional holidays.
-* **User-testing tranche direction (pending PR H/I):** keep `date-fns`
+* **User-testing tranche direction (pending PR H, PR I+):** keep `date-fns`
   constrained to `src/shared/lib/date-engine` and introduce a custom
   business-calendar abstraction with a mirrored edge-function utility layer.
   PR H must add characterization and a decision record before any behavior

--- a/docs/architecture/date-engine.md
+++ b/docs/architecture/date-engine.md
@@ -32,3 +32,10 @@ Calculated dynamically based on system time vs. Task End Dates:
 
 ## Known Gaps / Technical Debt
 * Algorithms for auto-adjusting dates currently lack logic for skipping weekends and regional holidays.
+* **User-testing tranche direction (pending PR H/I):** keep `date-fns`
+  constrained to `src/shared/lib/date-engine` and introduce a custom
+  business-calendar abstraction with a mirrored edge-function utility layer.
+  PR H must add characterization and a decision record before any behavior
+  change. PR I slices must preserve UTC/date-only semantics, checkpoint-project
+  exclusions, template exclusions, task hierarchy rollups, and
+  `nightly-sync` / `supabase/functions/_shared/date.ts` parity.

--- a/docs/architecture/library-templates.md
+++ b/docs/architecture/library-templates.md
@@ -18,6 +18,13 @@ The Library & Templates domain provides the administrative scaffolding for Plant
 2. **Cloning:** The Master Template tree is recursively copied into a new Project ID instance.
 3. **Date Resolution:** Relative `duration` and `days from start` are converted into hard ISO dates based on the user's `Target Launch Date`.
 
+**User-testing tranche note:** PR G must characterize and fix the current
+template-to-project clone/import behavior. The current SQL clone path copies
+`notes` into instance rows; the accepted target is that template notes do not
+copy into project items. The same PR must keep hierarchy, order, clone metadata,
+and displayed project state consistent across template-created projects and any
+inline project import paths.
+
 ## Business Rules & Constraints
 * **Template UI Limitations:** Template items do *not* possess progress bars, status dropdowns, or Date Engine urgency states.
 * **Master Library Strictness:**

--- a/docs/architecture/projects-phases.md
+++ b/docs/architecture/projects-phases.md
@@ -42,6 +42,12 @@ _Historical lifecycle summary:_
 * **Deprecation:** Project `Location` field is officially deprecated.
 
 ## Archive & Completion Semantics
+> **User-testing tranche note:** current code still exposes manual project
+> status mutation through dashboard/pipeline surfaces. PR D must remove those
+> manual lifecycle controls after a derived read-only project-state selector
+> exists. Treat archive as a reversible visibility action, not a lifecycle
+> pipeline state, unless a later product decision says otherwise.
+
 * **Archived project:** Root task carries `status = 'archived'` (set/cleared via the Archive / Unarchive action in `EditProjectModal`). Archiving is reversible and **never cascades** to descendants — children keep their own status and continue to resolve dates normally.
 * **Active project:** Any project root where `status !== 'archived'` **and** `is_complete !== true`. This is the default-visible set for `useDashboard`, `ProjectSidebar`, and `ProjectSwitcher`.
 * **Completed project:** Indicated by `is_complete = true` on the root task (and `status !== 'archived'`). Wave 23's `sync_task_completion_flags` DB trigger makes `is_complete === (status === 'completed')` an unconditional invariant (see `tasks-subtasks.md`); the `updateStatus` bubble-up logic keeps the value propagating up the tree. The UI filter inspects `is_complete` only.

--- a/docs/architecture/tasks-subtasks.md
+++ b/docs/architecture/tasks-subtasks.md
@@ -59,6 +59,12 @@ normalises into the nested JSONB shape before persisting.
 
 ## Coaching Tasks (Wave 22)
 
+> **User-testing tranche note:** current implementation exposes coaching flag
+> authoring on instance tasks. PR F must invert authoring so the flag is
+> editable only on template rows and sanitize instance create/update payloads so
+> project instances cannot mutate `settings.is_coaching_task`. Existing
+> instance badges/coach behavior may remain read-only inherited behavior.
+
 Any **instance task** (`origin = 'instance'`) may be tagged as a *coaching
 task* via `settings.is_coaching_task: true`. The flag widens edit access
 to users with the project `coach` role via an additive RLS UPDATE policy
@@ -124,6 +130,12 @@ unrelated projects are never touched.
 
 ## Strategy Templates (Wave 24)
 
+> **User-testing tranche note:** current implementation exposes strategy flag
+> authoring on instance tasks. PR F must invert authoring so the flag is
+> editable only on template rows and sanitize instance create/update payloads so
+> project instances cannot mutate `settings.is_strategy_template`. Existing
+> instance badges/follow-up behavior may remain read-only inherited behavior.
+
 Any **instance task** (`origin = 'instance'`) may be tagged as a *strategy
 template* via `settings.is_strategy_template: true`. The flag is purely a
 UX convention — no RLS carve-out, no additional DB triggers. It tells the
@@ -176,6 +188,11 @@ RLS policy needed. Owners / editors already have UPDATE access on
 instance tasks.
 
 ## Comments (Wave 26)
+
+> **User-testing tranche note:** PR E must remove comments from the project
+> task detail UI as a UI-only change first. Do not remove `public.task_comments`,
+> RLS policies, realtime hooks, activity-log triggers, or notification mention
+> plumbing without a separate data-retention decision.
 
 Threaded task comments live in `public.task_comments`. Each row carries
 `task_id` (the comment's target), `root_id` (auto-filled from the parent

--- a/docs/architecture/user-testing-baseline.md
+++ b/docs/architecture/user-testing-baseline.md
@@ -1,0 +1,88 @@
+# User-Testing Baseline
+
+This document records the user-testing gap-closure baseline for the PR series
+that starts after PR A (`test: stabilize release baseline`). It is a planning
+and release-control source of truth: it does not claim the target behavior is
+implemented until the matching PR lands.
+
+## Source Status
+
+Verified primary-source facts from the planning pass:
+
+* The public Notion root page and public subpages `archive`, `Spec md`, and
+  `temp` were accessible. Relevant linked Notion task pages for due-date
+  engine, dashboard, project creation from template, template-note copying,
+  and item details were also inspected.
+* Direct Notion database row querying was not available, so row-level evidence
+  came from Notion search and direct page fetches.
+* Notion-backed requirements found in that pass: project creation from
+  template is in progress or buggy, template notes must not copy into project
+  items, date-engine work is in progress, and item detail behavior differs
+  between projects and templates.
+* Notion did not directly state "kill dashboard" or "remove comments from the
+  project task view"; those are accepted prompt directives for this tranche.
+
+Repo baseline after PR A:
+
+* Mainline CI has a required release E2E smoke suite (`npm run
+  test:e2e:release`) covering login, signup, login validation, and blank
+  project creation. The legacy full BDD suite remains available as
+  `npm run test:e2e`, but it is not the required release gate because it
+  contains stale broad scenarios that assume unseeded data.
+* `initialize_default_project` is characterized by pgTAP baseline tests:
+  blank project creation creates owner membership, six phases, and the current
+  scaffold shape.
+* `clone_project_template` is characterized in its current state, including
+  the known note-copy behavior that PR G must intentionally change.
+
+## Accepted Target Directives
+
+These directives guide the ordered PR series. If a future Notion source or
+owner decision conflicts, prefer a smaller reversible PR plus characterization
+coverage before changing behavior.
+
+* Remove the project dashboard as a product surface. Move project/template
+  creation entry points first, then remove `/dashboard` and its pipeline board.
+* Project lifecycle should be derived from task state. Manual project state
+  changes through drag/drop pipeline controls must be removed after a derived
+  read-only replacement exists.
+* Remove comments from the project task detail UI first. Keep
+  `task_comments`, RLS, realtime, and notification plumbing intact unless a
+  later explicit data-retention decision says otherwise.
+* Coaching task and strategy-template flags must be editable only on template
+  rows. Project instances may retain inherited read-only badges/behavior, but
+  instance create/update paths must not mutate those flags.
+* Template-to-project creation/import must be characterized and fixed so
+  hierarchy, ordering, settings, clone metadata, and displayed project state
+  are consistent.
+* Template notes must not copy into project items.
+* Date-engine work must start with characterization and an ADR. The selected
+  direction is to keep `date-fns` constrained to the app date-engine layer and
+  add a custom business-calendar abstraction with mirrored edge-function
+  utilities before changing behavior.
+
+## Current Implementation Gaps
+
+| Area | Current implementation | Target gap | Planned PR |
+| --- | --- | --- | --- |
+| Dashboard | `/dashboard` still renders `StatsOverview`, onboarding, New Project/New Template, and `ProjectPipelineBoard`. | Creation must move off dashboard; dashboard then redirects or disappears. | PR C, PR D |
+| Project state | Pipeline board and project mutation hooks still support manual root `status` changes. | Lifecycle badges/selectors derive from child task state; archive remains visibility-only unless product revises it. | PR D |
+| Comments | `TaskDetailsView` still renders `TaskComments` in project task detail. | Project-context task detail hides comments; backend unchanged. | PR E |
+| Coaching flag | Current UI exposes `settings.is_coaching_task` editing on instance tasks. | Edit only on templates; instances preserve inherited behavior read-only. | PR F |
+| Strategy flag | Current UI exposes `settings.is_strategy_template` editing on instance tasks. | Edit only on templates; instances preserve inherited behavior read-only. | PR F |
+| Template clone | `clone_project_template` copies task notes into instance clones. | Instance clones receive blank notes while preserving approved metadata. | PR G |
+| Date engine | Custom UTC/date-only engine uses `date-fns` and lacks business-calendar/weekend/holiday abstraction. | Add ADR, characterization, and business-calendar abstraction before behavior changes. | PR H, PR I+ |
+
+## Release Rules
+
+Every PR in this tranche must:
+
+* branch from current `main`;
+* change one behavior slice only;
+* add characterization before high-risk refactors;
+* update docs and tests in the same PR as behavior changes;
+* run the narrowest useful validation first, then broader validation;
+* follow the 5-minute / 10-minute PR comment and CI loop before merge.
+
+Do not start PR C until this baseline doc is merged. Do not start PR D until
+creation works without `/dashboard`.


### PR DESCRIPTION
## Summary
- add a user-testing baseline doc that separates verified Notion facts from accepted prompt directives
- document the current dashboard/comments/template-flag/clone/date-engine gaps and target PR ownership
- update architecture notes and agent context with release E2E smoke guidance from PR A

## Validation
- AGENT_MODE=true npm run verify-architecture
- git diff --check
- npm run build