### PR TITLE
feat: move creation flows off dashboard

### DIFF
--- a/Testing/e2e/features/dashboard/create-project.feature
+++ b/Testing/e2e/features/dashboard/create-project.feature
@@ -46,8 +46,9 @@ Feature: Create Project
     Then the template selection is visible
 
   @release
-  Scenario: Successful project creation navigates to project page
-    When the user creates a new project "E2E Project"
+  Scenario: Successful project creation from tasks action navigates to project page
+    When the user navigates to "/tasks?action=new-project"
+    And the user completes the new project modal with "E2E Project"
     Then the user is redirected to a project page
     And the project title "E2E Project" is visible
 

--- a/Testing/e2e/features/navigation/sidebar.feature
+++ b/Testing/e2e/features/navigation/sidebar.feature
@@ -21,13 +21,13 @@ Feature: Sidebar Navigation
     When the user is on a project page
     Then that project is highlighted in the sidebar
 
-  Scenario: New Project button navigates to dashboard
+  Scenario: New Project button opens project creation from tasks
     When the user clicks the sidebar "New Project" button
-    Then the user is navigated to the dashboard
+    Then the user is navigated to the tasks creation action
 
-  Scenario: New Template button navigates to dashboard
+  Scenario: New Template button opens template creation from tasks
     When the user clicks the sidebar "New Template" button
-    Then the user is navigated to the dashboard
+    Then the user is navigated to the tasks template action
 
   Scenario: Load more pagination for projects list
     Given there are more projects than the initial page size

--- a/Testing/e2e/steps/dashboard.steps.ts
+++ b/Testing/e2e/steps/dashboard.steps.ts
@@ -37,6 +37,14 @@ When('the user opens the create template modal', async ({ page }) => {
 
 When('the user creates a new project {string}', async ({ page }, name: string) => {
   await page.locator('#main-content').getByRole('button', { name: /^New Project$/i }).click();
+  await completeNewProjectModal(page, name);
+});
+
+When('the user completes the new project modal with {string}', async ({ page }, name: string) => {
+  await completeNewProjectModal(page, name);
+});
+
+async function completeNewProjectModal(page: import('@playwright/test').Page, name: string) {
   await page.locator('[role="dialog"]').waitFor();
   // Select scratch or default template
   const continueBtn = page.getByRole('button', { name: /continue/i });
@@ -46,7 +54,7 @@ When('the user creates a new project {string}', async ({ page }, name: string) =
   await page.locator('[role="dialog"]').getByLabel(/title|name/i).fill(name);
   await page.getByRole('button', { name: /create project/i }).click();
   await page.waitForURL(/\/project\//);
-});
+}
 
 When('the user creates a new template {string}', async ({ page }, name: string) => {
   await page.locator('#main-content').getByRole('button', { name: /^New Template$/i }).click();

--- a/Testing/e2e/steps/navigation.steps.ts
+++ b/Testing/e2e/steps/navigation.steps.ts
@@ -65,6 +65,17 @@ Then('the user is navigated to the dashboard', async ({ page }) => {
   await expect(page).toHaveURL(/\/dashboard/);
 });
 
+Then('the user is navigated to the tasks creation action', async ({ page }) => {
+  await expect(page).toHaveURL(/\/tasks/);
+  await expect(page.locator('[data-testid="create-project-modal"]')).toBeVisible();
+});
+
+Then('the user is navigated to the tasks template action', async ({ page }) => {
+  await expect(page).toHaveURL(/\/tasks/);
+  await expect(page.locator('[role="dialog"]')).toBeVisible();
+  await expect(page.getByRole('heading', { name: /new template/i })).toBeVisible();
+});
+
 Then('additional projects are shown', async ({ page }) => {
   const projects = page.locator('[data-testid="project-switcher"]').getByRole('link');
   expect(await projects.count()).toBeGreaterThan(0);

--- a/Testing/unit/features/dashboard/hooks/useDashboard.test.ts
+++ b/Testing/unit/features/dashboard/hooks/useDashboard.test.ts
@@ -25,13 +25,6 @@ vi.mock('@/shared/contexts/AuthContext', () => ({
   useAuth: () => ({ user: { id: 'user-1' }, loading: false }),
 }));
 
-const mockSearchParams = new URLSearchParams();
-const mockSetSearchParams = vi.fn();
-
-vi.mock('react-router-dom', () => ({
-  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
-}));
-
 import { useDashboard } from '@/features/dashboard/hooks/useDashboard';
 
 function createWrapper() {
@@ -51,8 +44,6 @@ describe('useDashboard', () => {
     mockProjectList.mockResolvedValue([]);
     mockTaskListByCreator.mockResolvedValue([]);
     mockTeamMemberFilter.mockResolvedValue([]);
-    // Reset search params
-    mockSearchParams.delete('action');
     localStorage.removeItem('gettingStartedDismissed');
   });
 
@@ -207,24 +198,6 @@ describe('useDashboard', () => {
 
       expect(result.current.state.wizardDismissed).toBe(true);
       expect(localStorage.getItem('gettingStartedDismissed')).toBe('true');
-    });
-  });
-
-  describe('modal controls', () => {
-    it('toggles create modal', () => {
-      const { result } = renderHook(() => useDashboard(), { wrapper: createWrapper() });
-
-      expect(result.current.state.showCreateModal).toBe(false);
-      act(() => { result.current.actions.setShowCreateModal(true); });
-      expect(result.current.state.showCreateModal).toBe(true);
-    });
-
-    it('toggles template modal', () => {
-      const { result } = renderHook(() => useDashboard(), { wrapper: createWrapper() });
-
-      expect(result.current.state.showTemplateModal).toBe(false);
-      act(() => { result.current.actions.setShowTemplateModal(true); });
-      expect(result.current.state.showTemplateModal).toBe(true);
     });
   });
 

--- a/Testing/unit/features/library/hooks/useTemplateMutations.test.tsx
+++ b/Testing/unit/features/library/hooks/useTemplateMutations.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCreateTemplate } from '@/features/library/hooks/useTemplateMutations';
+
+const mockTaskCreate = vi.fn();
+const mockTeamMemberCreate = vi.fn();
+
+vi.mock('@/shared/api/planterClient', () => ({
+    planter: {
+        entities: {
+            Task: { create: (...args: unknown[]) => mockTaskCreate(...args) },
+            TeamMember: { create: (...args: unknown[]) => mockTeamMemberCreate(...args) },
+        },
+    },
+}));
+
+function createWrapper(queryClient: QueryClient) {
+    return function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={queryClient}>
+                {children}
+            </QueryClientProvider>
+        );
+    };
+}
+
+describe('useCreateTemplate', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockTaskCreate.mockResolvedValue({ id: 'template-1', title: 'Template from hook' });
+        mockTeamMemberCreate.mockResolvedValue({});
+    });
+
+    it('creates a template root, creates owner membership, and invalidates template project queries', async () => {
+        const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        const { result } = renderHook(() => useCreateTemplate(), { wrapper: createWrapper(queryClient) });
+
+        await act(async () => {
+            await result.current.mutateAsync({
+                title: 'Template from hook',
+                description: 'Reusable',
+                isPublished: true,
+                userId: 'user-1',
+            });
+        });
+
+        expect(mockTaskCreate).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'Template from hook',
+            description: 'Reusable',
+            origin: 'template',
+            parent_task_id: null,
+            root_id: null,
+            creator: 'user-1',
+            assignee_id: 'user-1',
+            settings: { published: true },
+        }));
+        expect(mockTeamMemberCreate).toHaveBeenCalledWith({
+            project_id: 'template-1',
+            user_id: 'user-1',
+            role: 'owner',
+        });
+        await waitFor(() => {
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['projects'] });
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['projects', 'template'] });
+        });
+    });
+});

--- a/Testing/unit/features/projects/components/CreateProjectModal.test.tsx
+++ b/Testing/unit/features/projects/components/CreateProjectModal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CreateProjectModal from '@/features/projects/components/CreateProjectModal';
+
+const dateState = vi.hoisted(() => ({
+    now: '2026-06-01T12:00:00.000Z',
+}));
+
+vi.mock('@/shared/lib/date-engine', () => ({
+    nowUtcIso: () => dateState.now,
+    toIsoDate: (value: string | null | undefined) => value?.slice(0, 10) ?? null,
+}));
+
+vi.mock('@/shared/lib/use-dirty-close-guard', () => ({
+    useDirtyCloseGuard: (_isDirty: boolean, onClose: () => void) => onClose,
+}));
+
+const launchTemplate = {
+    id: 'template-launch',
+    title: 'Launch Large',
+    description: 'Seeded template',
+    parent_task_id: null,
+    settings: { seed_key: 'launch_large' },
+};
+
+describe('CreateProjectModal', () => {
+    it('recomputes the default launch date each time the modal opens', () => {
+        const onClose = vi.fn();
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+        const { rerender } = render(
+            <CreateProjectModal open onClose={onClose} onSubmit={onSubmit} />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /continue to details/i }));
+        expect(screen.getByLabelText(/launch date/i)).toHaveValue('2026-06-01');
+
+        rerender(<CreateProjectModal open={false} onClose={onClose} onSubmit={onSubmit} />);
+        dateState.now = '2026-06-02T12:00:00.000Z';
+        rerender(<CreateProjectModal open onClose={onClose} onSubmit={onSubmit} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /continue to details/i }));
+        expect(screen.getByLabelText(/launch date/i)).toHaveValue('2026-06-02');
+    });
+
+    it('applies initial onboarding values and resolves seeded template choices', async () => {
+        const onClose = vi.fn();
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+        render(
+            <CreateProjectModal
+                open
+                onClose={onClose}
+                onSubmit={onSubmit}
+                templates={[launchTemplate]}
+                initialStep={2}
+                initialValues={{
+                    title: 'Onboarding Church',
+                    start_date: '2026-07-04',
+                    templateSeedKey: 'launch_large',
+                }}
+            />,
+        );
+
+        expect(screen.getByLabelText(/project name/i)).toHaveValue('Onboarding Church');
+        expect(screen.getByLabelText(/launch date/i)).toHaveValue('2026-07-04');
+
+        fireEvent.click(screen.getByRole('button', { name: /create project/i }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+                title: 'Onboarding Church',
+                start_date: '2026-07-04',
+                templateId: 'template-launch',
+            }));
+        });
+    });
+});

--- a/Testing/unit/layouts/CreationActionHost.test.tsx
+++ b/Testing/unit/layouts/CreationActionHost.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const mockCreateProject = vi.fn();
+const mockCreateTemplate = vi.fn();
+
+vi.mock('@/features/projects/hooks/useProjectMutations', () => ({
+    useCreateProject: () => ({ mutateAsync: mockCreateProject }),
+}));
+
+vi.mock('@/features/library/hooks/useTemplateMutations', () => ({
+    useCreateTemplate: () => ({ mutateAsync: mockCreateTemplate }),
+}));
+
+vi.mock('@/features/library/hooks/useMasterLibrarySearch', () => ({
+    default: () => ({ results: [], isLoading: false }),
+}));
+
+vi.mock('@/shared/contexts/AuthContext', () => ({
+    useAuth: () => ({ user: { id: 'user-1', email: 'user@example.com' } }),
+}));
+
+vi.mock('@/features/projects/components/CreateProjectModal', () => ({
+    default: ({
+        open,
+        onSubmit,
+        initialValues,
+        initialStep,
+    }: {
+        open: boolean;
+        onSubmit: (data: { title: string; start_date: string }) => Promise<void>;
+        initialValues?: { title?: string; start_date?: string; templateSeedKey?: string };
+        initialStep?: 1 | 2;
+    }) => (
+        open ? (
+            <button
+                type="button"
+                data-testid="create-project-modal"
+                data-initial-title={initialValues?.title ?? ''}
+                data-initial-start-date={initialValues?.start_date ?? ''}
+                data-initial-template={initialValues?.templateSeedKey ?? ''}
+                data-initial-step={initialStep ?? 1}
+                onClick={() => void onSubmit({ title: 'Project from action', start_date: '2026-06-01' })}
+            >
+                create project
+            </button>
+        ) : null
+    ),
+}));
+
+vi.mock('@/features/library/components/CreateTemplateModal', () => ({
+    default: ({ open, onSubmit }: { open: boolean; onSubmit: (data: { title: string; description: string; isPublished: boolean }) => Promise<void> }) => (
+        open ? (
+            <button
+                type="button"
+                data-testid="create-template-modal"
+                onClick={() => void onSubmit({ title: 'Template from action', description: 'Reusable', isPublished: true })}
+            >
+                create template
+            </button>
+        ) : null
+    ),
+}));
+
+import CreationActionHost from '@/layouts/CreationActionHost';
+
+function LocationDisplay() {
+    const location = useLocation();
+    return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderHost(initialEntry: string) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>
+            </QueryClientProvider>
+        );
+    }
+
+    return render(
+        <>
+            <CreationActionHost />
+            <LocationDisplay />
+        </>,
+        { wrapper: Wrapper },
+    );
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateProject.mockResolvedValue({ id: 'project-1' });
+    mockCreateTemplate.mockResolvedValue({ id: 'template-1' });
+});
+
+describe('CreationActionHost', () => {
+    it('opens project creation from the URL action and clears the query param', async () => {
+        renderHost('/tasks?action=new-project');
+
+        expect(await screen.findByTestId('create-project-modal')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId('location')).toHaveTextContent('/tasks');
+        });
+    });
+
+    it('passes project creation query params as initial modal values before clearing the URL', async () => {
+        renderHost('/tasks?action=new-project&title=Onboarding%20Church&start_date=2026-07-04&template=launch_large');
+
+        const modal = await screen.findByTestId('create-project-modal');
+        expect(modal).toHaveAttribute('data-initial-title', 'Onboarding Church');
+        expect(modal).toHaveAttribute('data-initial-start-date', '2026-07-04');
+        expect(modal).toHaveAttribute('data-initial-template', 'launch_large');
+        expect(modal).toHaveAttribute('data-initial-step', '2');
+        await waitFor(() => {
+            expect(screen.getByTestId('location')).toHaveTextContent('/tasks');
+        });
+    });
+
+    it('opens template creation from the URL action and clears the query param', async () => {
+        renderHost('/tasks?action=new-template');
+
+        expect(await screen.findByTestId('create-template-modal')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId('location')).toHaveTextContent('/tasks');
+        });
+    });
+
+    it('submits project creation and navigates to the new project', async () => {
+        renderHost('/tasks?action=new-project');
+
+        fireEvent.click(await screen.findByTestId('create-project-modal'));
+
+        await waitFor(() => {
+            expect(mockCreateProject).toHaveBeenCalledWith({
+                title: 'Project from action',
+                description: undefined,
+                start_date: '2026-06-01',
+                templateId: undefined,
+            });
+            expect(screen.getByTestId('location')).toHaveTextContent('/project/project-1');
+        });
+    });
+
+    it('submits template creation through the library mutation and navigates to the template', async () => {
+        renderHost('/tasks?action=new-template');
+
+        fireEvent.click(await screen.findByTestId('create-template-modal'));
+
+        await waitFor(() => {
+            expect(mockCreateTemplate).toHaveBeenCalledWith(expect.objectContaining({
+                title: 'Template from action',
+                description: 'Reusable',
+                isPublished: true,
+                userId: 'user-1',
+            }));
+            expect(screen.getByTestId('location')).toHaveTextContent('/project/template-1');
+        });
+    });
+});

--- a/Testing/unit/pages/Dashboard.test.tsx
+++ b/Testing/unit/pages/Dashboard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
@@ -9,20 +9,8 @@ import type { ReactNode } from 'react';
 vi.mock('@/features/projects/hooks/useProjectRealtime', () => ({
     useProjectRealtime: () => undefined,
 }));
-vi.mock('@/features/library/hooks/useMasterLibrarySearch', () => ({
-    default: () => ({ results: [], isLoading: false }),
-}));
 vi.mock('@/features/projects/hooks/useProjectMutations', () => ({
-    useCreateProject: () => ({ mutateAsync: vi.fn() }),
     useUpdateProjectStatus: () => ({ mutateAsync: vi.fn() }),
-}));
-vi.mock('@/shared/api/planterClient', () => ({
-    planter: {
-        entities: {
-            Task: { create: vi.fn() },
-            TeamMember: { create: vi.fn() },
-        },
-    },
 }));
 vi.mock('@/features/dashboard/components/StatsOverview', () => ({
     default: () => null,
@@ -30,21 +18,34 @@ vi.mock('@/features/dashboard/components/StatsOverview', () => ({
 vi.mock('@/features/dashboard/components/ProjectPipelineBoard', () => ({
     default: () => null,
 }));
-vi.mock('@/features/dashboard/components/CreateProjectModal', () => ({
-    default: () => null,
-}));
-vi.mock('@/features/dashboard/components/CreateTemplateModal', () => ({
-    default: () => null,
-}));
 vi.mock('@/features/mobile/components/MobileAgenda', () => ({
     default: () => null,
 }));
 vi.mock('@/pages/components/OnboardingWizard', () => ({
-    default: () => null,
+    default: ({
+        open,
+        onCreateProject,
+    }: {
+        open: boolean;
+        onCreateProject: (data: { title: string; due_date: string | null; template: string; status: string }) => Promise<void>;
+    }) => (
+        open ? (
+            <button
+                type="button"
+                data-testid="finish-onboarding"
+                onClick={() => void onCreateProject({
+                    title: 'Onboarding Church',
+                    due_date: '2026-07-04',
+                    template: 'launch_large',
+                    status: 'planning',
+                })}
+            >
+                finish onboarding
+            </button>
+        ) : null
+    ),
 }));
 
-const setShowTemplateModal = vi.fn();
-const setShowCreateModal = vi.fn();
 const handleDismissWizard = vi.fn();
 
 const dashboardState = {
@@ -52,8 +53,6 @@ const dashboardState = {
     isError: false,
     error: null,
     user: { id: 'u1', email: 'u1@example.com' },
-    showCreateModal: false,
-    showTemplateModal: false,
     wizardDismissed: true,
     searchQuery: '',
     selectedProjectId: null,
@@ -73,8 +72,6 @@ vi.mock('@/features/dashboard/hooks/useDashboard', () => ({
         state: dashboardState,
         data: dashboardData,
         actions: {
-            setShowCreateModal,
-            setShowTemplateModal,
             setSearchQuery: vi.fn(),
             setSelectedProjectId: vi.fn(),
             handleDismissWizard,
@@ -83,6 +80,11 @@ vi.mock('@/features/dashboard/hooks/useDashboard', () => ({
 }));
 
 import Dashboard from '@/pages/Dashboard';
+
+function LocationDisplay() {
+    const location = useLocation();
+    return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
 
 function renderDashboard() {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -93,13 +95,20 @@ function renderDashboard() {
             </QueryClientProvider>
         );
     }
-    return render(<Dashboard />, { wrapper: Wrapper });
+    return render(
+        <>
+            <Dashboard />
+            <LocationDisplay />
+        </>,
+        { wrapper: Wrapper },
+    );
 }
 
 describe('Dashboard header (Wave 32)', () => {
     beforeEach(() => {
-        setShowTemplateModal.mockReset();
-        setShowCreateModal.mockReset();
+        handleDismissWizard.mockReset();
+        dashboardState.wizardDismissed = true;
+        dashboardData.projects = [{ id: 'p1', title: 'Alpha project' }];
     });
 
     it('renders both "New Project" and "New Template" buttons in the header', () => {
@@ -108,20 +117,34 @@ describe('Dashboard header (Wave 32)', () => {
         expect(screen.getByRole('button', { name: /new template/i })).toBeInTheDocument();
     });
 
-    it('opens the template modal when the "New Template" button is clicked', () => {
+    it('routes template creation to the creation host on /tasks', () => {
         renderDashboard();
         fireEvent.click(screen.getByRole('button', { name: /new template/i }));
-        expect(setShowTemplateModal).toHaveBeenCalledTimes(1);
-        expect(setShowTemplateModal).toHaveBeenCalledWith(true);
-        // The project modal must NOT be opened by the template button.
-        expect(setShowCreateModal).not.toHaveBeenCalled();
+        expect(screen.getByTestId('location')).toHaveTextContent('/tasks?action=new-template');
     });
 
-    it('opens the project modal when the "New Project" button is clicked', () => {
+    it('routes project creation to the creation host on /tasks', () => {
         renderDashboard();
         fireEvent.click(screen.getByRole('button', { name: /new project/i }));
-        expect(setShowCreateModal).toHaveBeenCalledTimes(1);
-        expect(setShowCreateModal).toHaveBeenCalledWith(true);
-        expect(setShowTemplateModal).not.toHaveBeenCalled();
+        expect(screen.getByTestId('location')).toHaveTextContent('/tasks?action=new-project');
+    });
+
+    it('preserves onboarding project inputs when routing to the creation host', () => {
+        dashboardState.wizardDismissed = false;
+        dashboardData.projects = [];
+
+        renderDashboard();
+        fireEvent.click(screen.getByTestId('finish-onboarding'));
+
+        const locationText = screen.getByTestId('location').textContent ?? '';
+        const [, query = ''] = locationText.split('?');
+        const params = new URLSearchParams(query);
+
+        expect(locationText).toMatch(/^\/tasks\?/);
+        expect(params.get('action')).toBe('new-project');
+        expect(params.get('title')).toBe('Onboarding Church');
+        expect(params.get('start_date')).toBe('2026-07-04');
+        expect(params.get('template')).toBe('launch_large');
+        expect(handleDismissWizard).toHaveBeenCalledTimes(1);
     });
 });

--- a/docs/architecture/dashboard-analytics.md
+++ b/docs/architecture/dashboard-analytics.md
@@ -16,12 +16,13 @@ The Dashboard & Analytics domain aggregates telemetry across Projects, Tasks, an
 4. **Dashboard Broadcast:** Real-time hooks push the updated percentage to the Project Card and Dashboard Overview.
 
 ## Business Rules & Constraints
-* **User-testing tranche directive (pending PR C, PR D):** do not add new product
-  ownership to the user dashboard. Project/template creation must move to
-  non-dashboard routes first, then `/dashboard`, `ProjectPipelineBoard`, and
-  manual project-lifecycle status mutation are scheduled for removal. Derived
-  project lifecycle indicators should come from task state; archive may remain
-  a visibility-only action unless product revises that decision.
+* **User-testing tranche directive (PR C shipped, PR D pending):** do not add
+  new product ownership to the user dashboard. Project/template creation is
+  hosted by the authenticated creation action host via `/tasks?action=...`;
+  `/dashboard`, `ProjectPipelineBoard`, and manual project-lifecycle status
+  mutation are scheduled for removal in PR D. Derived project lifecycle
+  indicators should come from task state; archive may remain a visibility-only
+  action unless product revises that decision.
 * **Required Visualizations:**
   * Total Projects counts.
   * Task Arrays: Current, Due Soon, Overdue.

--- a/docs/architecture/user-testing-baseline.md
+++ b/docs/architecture/user-testing-baseline.md
@@ -65,7 +65,7 @@ coverage before changing behavior.
 
 | Area | Current implementation | Target gap | Planned PR |
 | --- | --- | --- | --- |
-| Dashboard | `/dashboard` still renders `StatsOverview`, onboarding, New Project/New Template, and `ProjectPipelineBoard`. | Creation must move off dashboard; dashboard then redirects or disappears. | PR C, PR D |
+| Dashboard | `/dashboard` still renders `StatsOverview`, onboarding, creation buttons, and `ProjectPipelineBoard`; PR C routes creation buttons/sidebar/mobile actions to the authenticated creation host on `/tasks?action=...`. | Dashboard redirects or disappears after replacement creation entry points are stable. | PR D |
 | Project state | Pipeline board and project mutation hooks still support manual root `status` changes. | Lifecycle badges/selectors derive from child task state; archive remains visibility-only unless product revises it. | PR D |
 | Comments | `TaskDetailsView` still renders `TaskComments` in project task detail. | Project-context task detail hides comments; backend unchanged. | PR E |
 | Coaching flag | Current UI exposes `settings.is_coaching_task` editing on instance tasks. | Edit only on templates; instances preserve inherited behavior read-only. | PR F |
@@ -84,5 +84,4 @@ Every PR in this tranche must:
 * run the narrowest useful validation first, then broader validation;
 * follow the 5-minute / 10-minute PR comment and CI loop before merge.
 
-Do not start PR C until this baseline doc is merged. Do not start PR D until
-creation works without `/dashboard`.
+Do not start PR D until creation works without `/dashboard`.

--- a/src/features/dashboard/hooks/useDashboard.ts
+++ b/src/features/dashboard/hooks/useDashboard.ts
@@ -1,5 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { planter } from '@/shared/api/planterClient';
 import { useAuth } from '@/shared/contexts/AuthContext';
@@ -12,10 +11,6 @@ type TeamMemberRow = Database['public']['Tables']['project_members']['Row'];
 
 export function useDashboard() {
  const { user, loading: authLoading } = useAuth();
- // URL Action State
- const [searchParams, setSearchParams] = useSearchParams();
- const [showCreateModal, setShowCreateModal] = useState(false);
- const [showTemplateModal, setShowTemplateModal] = useState(false);
 
  // Dashboard Specific Local State
  const [wizardDismissed, setWizardDismissed] = useState<boolean>(() => {
@@ -23,21 +18,6 @@ export function useDashboard() {
  });
  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
  const [searchQuery, setSearchQuery] = useState('');
-
- // Auto-open modal when navigated with ?action=new-project or ?action=new-template
- useEffect(() => {
- const action = searchParams.get('action');
- if (action === 'new-project') {
- // eslint-disable-next-line react-hooks/set-state-in-effect
- setShowCreateModal(true);
- searchParams.delete('action');
- setSearchParams(searchParams, { replace: true });
- } else if (action === 'new-template') {
- setShowTemplateModal(true);
- searchParams.delete('action');
- setSearchParams(searchParams, { replace: true });
- }
- }, [searchParams, setSearchParams]);
 
  // Data Fetching. `staleTime: STALE_TIMES.medium` across the board so
  // Dashboard ↔ Tasks ↔ Project toggles don't refetch 3 times per nav.
@@ -115,8 +95,6 @@ export function useDashboard() {
  isError,
  error,
  user,
- showCreateModal,
- showTemplateModal,
  wizardDismissed,
  searchQuery,
  selectedProjectId
@@ -130,8 +108,6 @@ export function useDashboard() {
  teamMembers
  },
  actions: {
- setShowCreateModal,
- setShowTemplateModal,
  setSearchQuery,
  setSelectedProjectId,
  handleDismissWizard

--- a/src/features/library/components/CreateTemplateModal.tsx
+++ b/src/features/library/components/CreateTemplateModal.tsx
@@ -45,7 +45,7 @@ export default function CreateTemplateModal({ open, onClose, onSubmit }: CreateT
 
     return (
         <Dialog open={open} onOpenChange={onClose}>
-            <DialogContent className="sm:max-w-[500px] p-0 overflow-hidden bg-white border-slate-200">
+            <DialogContent data-testid="create-template-modal" className="sm:max-w-[500px] p-0 overflow-hidden bg-white border-slate-200">
                 <DialogHeader className="p-8 bg-brand-600 text-white">
                     <DialogTitle className="text-2xl font-bold flex items-center gap-2">
                         <BookTemplate className="w-6 h-6" />

--- a/src/features/library/hooks/useTemplateMutations.ts
+++ b/src/features/library/hooks/useTemplateMutations.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { planter } from '@/shared/api/planterClient';
+import type { TaskInsert, TaskRow } from '@/shared/db/app.types';
+import type { Database } from '@/shared/db/database.types';
+
+type ProjectMemberInsert = Database['public']['Tables']['project_members']['Insert'];
+
+export interface CreateTemplatePayload {
+    title: string;
+    description: string;
+    isPublished: boolean;
+    userId: string;
+}
+
+/**
+ * Creates a root template and owner membership through the shared API layer.
+ *
+ * @returns React Query mutation for creating a template root.
+ */
+export function useCreateTemplate() {
+    const queryClient = useQueryClient();
+
+    return useMutation<TaskRow, Error, CreateTemplatePayload>({
+        mutationFn: async (data) => {
+            const templateInsert = {
+                title: data.title,
+                description: data.description,
+                origin: 'template',
+                parent_task_id: null,
+                root_id: null,
+                status: 'planning',
+                creator: data.userId,
+                assignee_id: data.userId,
+                settings: { published: data.isPublished },
+            } satisfies TaskInsert;
+
+            const template = await planter.entities.Task.create(templateInsert);
+            if (!template?.id) {
+                throw new Error('Template creation did not return an id');
+            }
+
+            const ownerMembership = {
+                project_id: template.id,
+                user_id: data.userId,
+                role: 'owner',
+            } satisfies ProjectMemberInsert;
+
+            await planter.entities.TeamMember.create(ownerMembership);
+            return template;
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['projects'] });
+            queryClient.invalidateQueries({ queryKey: ['projects', 'template'] });
+        },
+    });
+}

--- a/src/features/mobile/components/MobileFAB.tsx
+++ b/src/features/mobile/components/MobileFAB.tsx
@@ -7,9 +7,11 @@ import {
  DropdownMenuTrigger,
 } from '@/shared/ui/dropdown-menu';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 export default function MobileFAB() {
  const navigate = useNavigate();
+ const { t } = useTranslation();
 
  return (
  <div data-testid="mobile-fab" className="fixed bottom-6 right-6 md:hidden z-50">
@@ -25,8 +27,11 @@ export default function MobileFAB() {
  </DropdownMenuTrigger>
  <DropdownMenuContent align="end" className="mb-2">
 
- <DropdownMenuItem onClick={() => navigate('/projects/new')} className="cursor-pointer">
- New Project
+ <DropdownMenuItem onClick={() => navigate('/tasks?action=new-project')} className="cursor-pointer">
+ {t('dashboard.new_project')}
+ </DropdownMenuItem>
+ <DropdownMenuItem onClick={() => navigate('/tasks?action=new-template')} className="cursor-pointer">
+ {t('dashboard.new_template')}
  </DropdownMenuItem>
  </DropdownMenuContent>
  </DropdownMenu>

--- a/src/features/projects/components/CreateProjectModal.tsx
+++ b/src/features/projects/components/CreateProjectModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     Dialog,
@@ -30,7 +30,15 @@ import type { CreateProjectFormData, TaskRow } from '@/shared/db/app.types';
 /** Special ID for the built-in default scaffold (not a real DB template). */
 const DEFAULT_SCAFFOLD_ID = '__default__';
 
-type ProjectTemplateOption = Pick<TaskRow, 'id' | 'title' | 'description' | 'parent_task_id'>;
+type ProjectTemplateOption = Pick<TaskRow, 'id' | 'title' | 'description' | 'parent_task_id' | 'settings'>;
+
+export interface ProjectCreationInitialValues {
+    title?: string;
+    description?: string;
+    start_date?: string;
+    templateId?: string | null;
+    templateSeedKey?: string | null;
+}
 
 interface CreateProjectModalProps {
     open: boolean;
@@ -38,6 +46,48 @@ interface CreateProjectModalProps {
     onSubmit: (data: CreateProjectFormData) => Promise<void>;
     templates?: readonly ProjectTemplateOption[];
     templatesLoading?: boolean;
+    initialValues?: ProjectCreationInitialValues;
+    initialStep?: 1 | 2;
+}
+
+function getDefaultStartDate() {
+    return toIsoDate(nowUtcIso()) || '';
+}
+
+function getTemplateSeedKey(settings: TaskRow['settings']) {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings) || !('seed_key' in settings)) {
+        return null;
+    }
+
+    return typeof settings.seed_key === 'string' ? settings.seed_key : null;
+}
+
+function resolveInitialTemplateId(
+    initialValues: ProjectCreationInitialValues | undefined,
+    templates: readonly ProjectTemplateOption[],
+) {
+    const initialTemplateId = initialValues?.templateId?.trim();
+    if (initialTemplateId && templates.some((template) => template.id === initialTemplateId)) {
+        return initialTemplateId;
+    }
+
+    const seedKey = initialValues?.templateSeedKey?.trim();
+    if (!seedKey) return null;
+
+    return templates.find((template) => getTemplateSeedKey(template.settings) === seedKey)?.id ?? null;
+}
+
+function buildInitialFormData(
+    defaultStartDate: string,
+    initialValues: ProjectCreationInitialValues | undefined,
+    templates: readonly ProjectTemplateOption[],
+): CreateProjectFormData {
+    return {
+        title: initialValues?.title?.trim() ?? '',
+        description: initialValues?.description ?? '',
+        templateId: resolveInitialTemplateId(initialValues, templates) ?? DEFAULT_SCAFFOLD_ID,
+        start_date: initialValues?.start_date || defaultStartDate,
+    };
 }
 
 export default function CreateProjectModal({
@@ -46,22 +96,52 @@ export default function CreateProjectModal({
     onSubmit,
     templates = [],
     templatesLoading = false,
+    initialValues,
+    initialStep = 1,
 }: CreateProjectModalProps) {
     const { t } = useTranslation();
     const [step, setStep] = useState(1);
     const [loading, setLoading] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
-    const [formData, setFormData] = useState<CreateProjectFormData>({
-        title: '',
-        description: '',
-        templateId: DEFAULT_SCAFFOLD_ID,
-        start_date: toIsoDate(nowUtcIso()) || '',
-    });
+    const [defaultStartDate, setDefaultStartDate] = useState(getDefaultStartDate);
+    const hasAppliedOpenState = useRef(false);
+    const [formData, setFormData] = useState<CreateProjectFormData>(() => (
+        buildInitialFormData(defaultStartDate, initialValues, templates)
+    ));
 
     // Filter templates that are root-level (no parent) for project creation
     const rootTemplates = useMemo(() => {
         return templates.filter((t) => !t.parent_task_id);
     }, [templates]);
+
+    useEffect(() => {
+        if (!open) {
+            hasAppliedOpenState.current = false;
+            return;
+        }
+
+        if (hasAppliedOpenState.current) return;
+
+        hasAppliedOpenState.current = true;
+        const nextDefaultStartDate = getDefaultStartDate();
+        setDefaultStartDate(nextDefaultStartDate);
+        setStep(initialStep);
+        setSearchQuery('');
+        setFormData(buildInitialFormData(nextDefaultStartDate, initialValues, rootTemplates));
+    }, [initialStep, initialValues, open, rootTemplates]);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const resolvedTemplateId = resolveInitialTemplateId(initialValues, rootTemplates);
+        if (!resolvedTemplateId) return;
+
+        setFormData((current) => (
+            current.templateId === DEFAULT_SCAFFOLD_ID
+                ? { ...current, templateId: resolvedTemplateId }
+                : current
+        ));
+    }, [initialValues, open, rootTemplates]);
 
     const filteredTemplates = useMemo(() => {
         if (!searchQuery.trim()) return rootTemplates;
@@ -78,7 +158,8 @@ export default function CreateProjectModal({
     const isDirty =
         (formData.title?.trim().length ?? 0) > 0 ||
         (formData.description?.trim().length ?? 0) > 0 ||
-        formData.templateId !== DEFAULT_SCAFFOLD_ID;
+        formData.templateId !== DEFAULT_SCAFFOLD_ID ||
+        formData.start_date !== defaultStartDate;
     const guardedClose = useDirtyCloseGuard(isDirty, onClose);
 
     const handleNext = () => setStep(2);
@@ -104,12 +185,9 @@ export default function CreateProjectModal({
             setLoading(false);
             setStep(1);
             setSearchQuery('');
-            setFormData({
-                title: '',
-                description: '',
-                templateId: DEFAULT_SCAFFOLD_ID,
-                start_date: toIsoDate(nowUtcIso()) || '',
-            });
+            const nextDefaultStartDate = getDefaultStartDate();
+            setDefaultStartDate(nextDefaultStartDate);
+            setFormData(buildInitialFormData(nextDefaultStartDate, undefined, []));
         }
     };
 
@@ -296,6 +374,18 @@ export default function CreateProjectModal({
                                             setFormData({ ...formData, description: e.target.value })
                                         }
                                         className="min-h-[120px] border-slate-200 focus:ring-brand-500/20 focus:border-brand-500 rounded-xl resize-none"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="start_date" className="text-slate-700 font-semibold">
+                                        {t('dashboard.create_project_modal.launch_date')}
+                                    </Label>
+                                    <Input
+                                        id="start_date"
+                                        type="date"
+                                        value={formData.start_date}
+                                        onChange={(e) => setFormData({ ...formData, start_date: e.target.value })}
+                                        className="h-12 border-slate-200 focus:ring-brand-500/20 focus:border-brand-500 rounded-xl"
                                     />
                                 </div>
                                 <div className="flex gap-4">

--- a/src/layouts/CreationActionHost.tsx
+++ b/src/layouts/CreationActionHost.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import type { CreateProjectFormData } from '@/shared/db/app.types';
+import type { CreateProjectPayload } from '@/features/projects/hooks/useProjectMutations';
+import type { ProjectCreationInitialValues } from '@/features/projects/components/CreateProjectModal';
+import CreateProjectModal from '@/features/projects/components/CreateProjectModal';
+import CreateTemplateModal from '@/features/library/components/CreateTemplateModal';
+import useMasterLibrarySearch from '@/features/library/hooks/useMasterLibrarySearch';
+import { useCreateTemplate } from '@/features/library/hooks/useTemplateMutations';
+import { useCreateProject } from '@/features/projects/hooks/useProjectMutations';
+import { useAuth } from '@/shared/contexts/AuthContext';
+
+/**
+ * Reads a non-empty query parameter.
+ *
+ * @param searchParams - Current URL search parameters.
+ * @param key - Query parameter name to read.
+ * @returns Trimmed parameter value, or undefined when absent.
+ */
+function optionalParam(searchParams: URLSearchParams, key: string) {
+    const value = searchParams.get(key)?.trim();
+    return value || undefined;
+}
+
+/**
+ * Converts route action query parameters into initial project form values.
+ *
+ * @param searchParams - Current URL search parameters.
+ * @returns Initial values for the create-project modal, when any were provided.
+ */
+function getProjectInitialValues(searchParams: URLSearchParams): ProjectCreationInitialValues | undefined {
+    const initialValues: ProjectCreationInitialValues = {
+        title: optionalParam(searchParams, 'title'),
+        description: optionalParam(searchParams, 'description'),
+        start_date: optionalParam(searchParams, 'start_date'),
+        templateId: optionalParam(searchParams, 'templateId'),
+        templateSeedKey: optionalParam(searchParams, 'template'),
+    };
+
+    return Object.values(initialValues).some(Boolean) ? initialValues : undefined;
+}
+
+/**
+ * Hosts authenticated route-triggered project and template creation dialogs.
+ *
+ * @returns Project/template creation modal host.
+ */
+export default function CreationActionHost() {
+    const { t } = useTranslation();
+    const navigate = useNavigate();
+    const { user } = useAuth();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [showCreateModal, setShowCreateModal] = useState(false);
+    const [showTemplateModal, setShowTemplateModal] = useState(false);
+    const [projectInitialValues, setProjectInitialValues] = useState<ProjectCreationInitialValues | undefined>();
+    const createProjectMutation = useCreateProject();
+    const createTemplateMutation = useCreateTemplate();
+
+    const {
+        results: projectTemplateOptions,
+        isLoading: projectTemplatesLoading,
+    } = useMasterLibrarySearch({
+        query: '',
+        enabled: showCreateModal,
+    });
+
+    useEffect(() => {
+        const action = searchParams.get('action');
+        if (action !== 'new-project' && action !== 'new-template') return;
+
+        if (action === 'new-project') {
+            setProjectInitialValues(getProjectInitialValues(searchParams));
+            setShowCreateModal(true);
+        } else {
+            setShowTemplateModal(true);
+        }
+
+        const nextParams = new URLSearchParams(searchParams);
+        nextParams.delete('action');
+        setSearchParams(nextParams, { replace: true });
+    }, [searchParams, setSearchParams]);
+
+    const handleCreateProject = async (projectData: CreateProjectFormData) => {
+        try {
+            const payload: CreateProjectPayload = {
+                title: projectData.title,
+                description: projectData.description,
+                start_date: projectData.start_date,
+                templateId: projectData.templateId ?? undefined,
+            };
+            const project = await createProjectMutation.mutateAsync(payload);
+            if (project?.id) {
+                navigate(`/project/${project.id}`);
+            }
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : t('errors.unknown');
+            toast.error(t('errors.failed_create_project'), { description: message });
+        }
+    };
+
+    const handleCreateTemplate = async (data: { title: string; description: string; isPublished: boolean }) => {
+        try {
+            const userId = user?.id;
+            if (!userId) throw new Error(t('errors.user_must_be_logged_in'));
+
+            const template = await createTemplateMutation.mutateAsync({
+                title: data.title,
+                description: data.description,
+                isPublished: data.isPublished,
+                userId,
+            });
+
+            if (template?.id) {
+                toast.success(t('dashboard.template_created_toast'));
+                navigate(`/project/${template.id}`);
+            }
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : t('errors.unknown');
+            toast.error(t('errors.failed_create_template'), { description: message });
+        }
+    };
+
+    return (
+        <>
+            <CreateProjectModal
+                open={showCreateModal}
+                onClose={() => {
+                    setShowCreateModal(false);
+                    setProjectInitialValues(undefined);
+                }}
+                onSubmit={handleCreateProject}
+                templates={projectTemplateOptions}
+                templatesLoading={projectTemplatesLoading}
+                initialValues={projectInitialValues}
+                initialStep={projectInitialValues ? 2 : 1}
+            />
+
+            <CreateTemplateModal
+                open={showTemplateModal}
+                onClose={() => setShowTemplateModal(false)}
+                onSubmit={handleCreateTemplate}
+            />
+        </>
+    );
+}

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -7,6 +7,7 @@ import ProjectSwitcherContainer from '@/layouts/ProjectSwitcherContainer';
 import { CommandPalette } from '@/shared/ui/CommandPalette';
 import { useAuth } from '@/shared/contexts/AuthContext';
 import MobileFAB from '@/features/mobile/components/MobileFAB';
+import CreationActionHost from '@/layouts/CreationActionHost';
 
 export default function DashboardLayout({ sidebar, children }: { sidebar?: React.ReactNode, children?: React.ReactNode }) {
  const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -74,6 +75,7 @@ export default function DashboardLayout({ sidebar, children }: { sidebar?: React
  )}
 
  <main id="main-content" className="lg:pl-64 pt-6 h-[calc(100vh-4rem)] w-full overflow-x-hidden">{children || <Outlet />}</main>
+ <CreationActionHost />
  <MobileFAB />
  </div>
  </>

--- a/src/layouts/ProjectSidebarContainer.tsx
+++ b/src/layouts/ProjectSidebarContainer.tsx
@@ -33,11 +33,11 @@ export default function ProjectSidebarContainer({ onNavClick, selectedTaskId }: 
  };
 
  const handleNewProjectClick = () => {
- navigate('/dashboard?action=new-project');
+ navigate('/tasks?action=new-project');
  };
 
  const handleNewTemplateClick = () => {
- navigate('/dashboard?action=new-template');
+ navigate('/tasks?action=new-template');
  };
 
  return (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,22 +2,16 @@ import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import type { TaskRow, Project, TaskInsert, CreateProjectFormData } from '@/shared/db/app.types';
-import type { Database } from '@/shared/db/database.types';
-import type { CreateProjectPayload } from '@/features/projects/hooks/useProjectMutations';
+import type { TaskRow, Project } from '@/shared/db/app.types';
 import { Button } from '@/shared/ui/button';
 import { Plus, FolderKanban, Loader2, BookTemplate } from 'lucide-react';
 
 // Hooks
 import { useDashboard } from '@/features/dashboard/hooks/useDashboard';
-import useMasterLibrarySearch from '@/features/library/hooks/useMasterLibrarySearch';
-import { useCreateProject, useUpdateProjectStatus } from '@/features/projects/hooks/useProjectMutations';
-import { planter } from '@/shared/api/planterClient';
+import { useUpdateProjectStatus } from '@/features/projects/hooks/useProjectMutations';
 import { useProjectRealtime } from '@/features/projects/hooks/useProjectRealtime';
 
 // Components
-import CreateProjectModal from '@/features/dashboard/components/CreateProjectModal';
-import CreateTemplateModal from '@/features/dashboard/components/CreateTemplateModal';
 import StatsOverview from '@/features/dashboard/components/StatsOverview';
 import ProjectPipelineBoard from '@/features/dashboard/components/ProjectPipelineBoard';
 import OnboardingWizard from '@/pages/components/OnboardingWizard';
@@ -31,34 +25,7 @@ export default function Dashboard() {
     useProjectRealtime();
 
     const { state, data, actions } = useDashboard();
-    const {
-        results: projectTemplateOptions,
-        isLoading: projectTemplatesLoading,
-    } = useMasterLibrarySearch({
-        query: '',
-        enabled: state.showCreateModal,
-    });
-
-    const createProjectMutation = useCreateProject();
     const updateStatusMutation = useUpdateProjectStatus();
-
-    const handleCreateProject = async (projectData: CreateProjectFormData) => {
-        try {
-            const payload: CreateProjectPayload = {
-                title: projectData.title,
-                description: projectData.description,
-                start_date: projectData.start_date,
-                templateId: projectData.templateId ?? undefined,
-            };
-            const project = await createProjectMutation.mutateAsync(payload);
-            if (project?.id) {
-                navigate(`/project/${project.id}`);
-            }
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : t('errors.unknown');
-            toast.error(t('errors.failed_create_project'), { description: message });
-        }
-    };
 
     const handleStatusChange = async (projectId: string, newStatus: string) => {
         try {
@@ -70,38 +37,8 @@ export default function Dashboard() {
         }
     };
 
-    const handleCreateTemplate = async (data: { title: string; description: string; isPublished: boolean }) => {
-        try {
-            const userId = state.user?.id;
-            if (!userId) throw new Error(t('errors.user_must_be_logged_in'));
-
-            const template = await planter.entities.Task.create({
-                title: data.title,
-                description: data.description,
-                origin: 'template',
-                parent_task_id: null,
-                root_id: null,
-                status: 'planning',
-                creator: userId,
-                assignee_id: userId,
-                settings: { published: data.isPublished },
-            } as TaskInsert);
-            if (template?.id) {
-                // Add creator as owner so RLS allows access
-                await planter.entities.TeamMember.create({
-                    project_id: template.id,
-                    user_id: userId,
-                    role: 'owner',
-                } as Database['public']['Tables']['project_members']['Insert']);
-                toast.success(t('dashboard.template_created_toast'));
-                queryClient.invalidateQueries({ queryKey: ['projects', 'template'] });
-                navigate(`/project/${template.id}`);
-            }
-        } catch (error: unknown) {
-            const message = error instanceof Error ? error.message : t('errors.unknown');
-            toast.error(t('errors.failed_create_template'), { description: message });
-        }
-    };
+    const openProjectCreation = () => navigate('/tasks?action=new-project');
+    const openTemplateCreation = () => navigate('/tasks?action=new-template');
 
     if (state.isLoading) {
         return (
@@ -135,14 +72,14 @@ export default function Dashboard() {
                 <div className="flex items-center gap-3">
                     <Button
                         variant="secondary"
-                        onClick={() => actions.setShowTemplateModal(true)}
+                        onClick={openTemplateCreation}
                         data-testid="dashboard-new-template-btn"
                     >
                         <BookTemplate className="w-5 h-5 mr-2" />
                         {t('dashboard.new_template')}
                     </Button>
                     <Button
-                        onClick={() => actions.setShowCreateModal(true)}
+                        onClick={openProjectCreation}
                         className="bg-orange-500 hover:bg-orange-600 shadow-lg shadow-orange-500/20 "
                     >
                         <Plus className="w-5 h-5 mr-2" />
@@ -168,7 +105,7 @@ export default function Dashboard() {
                         <p className="text-muted-foreground mb-6 max-w-sm mx-auto">
                             {t('dashboard.no_projects_description')}
                         </p>
-                        <Button onClick={() => actions.setShowCreateModal(true)} className="bg-orange-500 hover:bg-orange-600">
+                        <Button onClick={openProjectCreation} className="bg-orange-500 hover:bg-orange-600">
                             <Plus className="w-5 h-5 mr-2" />
                             {t('dashboard.create_first_project')}
                         </Button>
@@ -183,27 +120,16 @@ export default function Dashboard() {
                 )}
             </div>
 
-            <CreateProjectModal
-                open={state.showCreateModal}
-                onClose={() => actions.setShowCreateModal(false)}
-                onSubmit={handleCreateProject}
-                templates={projectTemplateOptions}
-                templatesLoading={projectTemplatesLoading}
-            />
-
-            <CreateTemplateModal
-                open={state.showTemplateModal}
-                onClose={() => actions.setShowTemplateModal(false)}
-                onSubmit={handleCreateTemplate}
-            />
-
             <OnboardingWizard
                 open={!state.isLoading && data.projects.length === 0 && !state.wizardDismissed}
                 onCreateProject={async (wizardData) => {
-                    await handleCreateProject({
-                        title: wizardData.title,
-                        start_date: wizardData.due_date || '',
-                    } as CreateProjectFormData);
+                    actions.handleDismissWizard();
+                    const params = new URLSearchParams({ action: 'new-project' });
+                    const title = wizardData.title.trim();
+                    if (title) params.set('title', title);
+                    if (wizardData.due_date) params.set('start_date', wizardData.due_date);
+                    if (wizardData.template) params.set('template', wizardData.template);
+                    navigate(`/tasks?${params.toString()}`);
                 }}
                 onDismiss={actions.handleDismissWizard}
             />

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -567,6 +567,7 @@
       "project_name_placeholder": "e.g. Hope City Launch",
       "description": "Description",
       "description_placeholder": "What's the vision for this project?",
+      "launch_date": "Launch Date",
       "create_project": "Create Project",
       "loading_templates": "Loading templates…",
       "no_templates_match": "No templates match your search."

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -573,6 +573,7 @@
       "project_name_placeholder": "p. ej. Lanzamiento Hope City",
       "description": "Descripción",
       "description_placeholder": "¿Cuál es la visión de este proyecto?",
+      "launch_date": "Fecha de lanzamiento",
       "create_project": "Crear proyecto",
       "loading_templates": "Cargando plantillas…",
       "no_templates_match": "Ninguna plantilla coincide con tu búsqueda."


### PR DESCRIPTION
## Summary
- move project/template creation modals into domain-owned feature areas and host them from the authenticated layout
- route dashboard, sidebar, and mobile creation entry points through `/tasks?action=new-project` and `/tasks?action=new-template`
- add launch date input to project creation and update docs/tests for the PR C baseline

## Validation
- `npx vitest run Testing/unit/layouts/CreationActionHost.test.tsx Testing/unit/pages/Dashboard.test.tsx Testing/unit/features/dashboard/hooks/useDashboard.test.ts Testing/unit/shared/i18n/es-json.test.ts`
- `npm run typecheck:agent`
- `AGENT_MODE=true npm run verify-architecture`
- `npm run lint`
- `npx tsc --noEmit --pretty false`
- `node scripts/seed-e2e.js`
- `CI=true npm run test:e2e:release`
- `git diff --check`
- `npm test`
- `npm run build`
- `npm run db:local:test`

## Scope
PR C only. Dashboard and manual project lifecycle mutation remain for PR D.
