### PR TITLE
test: add project creation smoke coverage

### DIFF
--- a/Testing/e2e/features/dashboard/create-project.feature
+++ b/Testing/e2e/features/dashboard/create-project.feature
@@ -46,11 +46,21 @@ Feature: Create Project
     Then the template selection is visible
 
   @release
-  Scenario: Successful project creation from tasks action navigates to project page
+  Scenario: Blank project creation from tasks action imports the default scaffold
     When the user navigates to "/tasks?action=new-project"
-    And the user completes the new project modal with "E2E Project"
+    And the user completes the new project modal with "E2E Blank Scaffold"
     Then the user is redirected to a project page
-    And the project title "E2E Project" is visible
+    And the project title "E2E Blank Scaffold" is visible
+    And the blank project scaffold baseline is imported
+
+  @release
+  Scenario: Project creation from Launch Large template imports hierarchy without notes
+    When the user navigates to "/tasks?action=new-project"
+    And the user selects the "Launch Large" project template
+    And the user completes the new project modal with "E2E Launch Large Project"
+    Then the user is redirected to a project page
+    And the project title "E2E Launch Large Project" is visible
+    And the project imports the "Launch Large" template baseline without copied notes
 
   Scenario: Failed project creation shows toast error
     When the user attempts to create a project with invalid data

--- a/Testing/e2e/helpers/project-creation-db.ts
+++ b/Testing/e2e/helpers/project-creation-db.ts
@@ -29,6 +29,14 @@ function getRequiredEnv(name: string, fallback?: string) {
   return value;
 }
 
+/**
+ * Read-only local E2E database probe.
+ *
+ * Authorization model: signs in as the seeded primary test user with the local
+ * publishable anon key, then performs SELECT-only assertions under normal RLS.
+ * It never uses service-role credentials and never mutates task rows; production
+ * app code remains routed through `planterClient`.
+ */
 async function getE2EClient() {
   if (!e2eClientPromise) {
     e2eClientPromise = (async () => {
@@ -104,7 +112,14 @@ export async function fetchTemplateRows(templateTitle: string) {
   };
 }
 
-export function countLeafTasks(rows: TaskProbeRow[], projectId: string) {
+/**
+ * Counts canonical project leaf tasks below phases and milestones.
+ *
+ * PlanterPlan stores projects as root task trees:
+ * Project -> Phase -> Milestone -> Task. This is separate from the UI subtask
+ * constraint that prevents a leaf task from having nested subtasks.
+ */
+export function countMilestoneLeafTasks(rows: TaskProbeRow[], projectId: string) {
   const phaseIds = new Set(rows.filter((row) => row.parent_task_id === projectId).map((row) => row.id));
   const milestoneIds = new Set(
     rows

--- a/Testing/e2e/helpers/project-creation-db.ts
+++ b/Testing/e2e/helpers/project-creation-db.ts
@@ -1,0 +1,126 @@
+import { expect, type Page } from '@playwright/test';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { TEST_USER } from '../fixtures/test-data';
+
+const LOCAL_SUPABASE_URL = 'http://127.0.0.1:54321';
+const TASK_PROBE_SELECT = 'id,title,root_id,parent_task_id,origin,notes,settings,cloned_from_task_id,position';
+
+type JsonRecord = Record<string, unknown>;
+
+export interface TaskProbeRow {
+  id: string;
+  title: string;
+  root_id: string | null;
+  parent_task_id: string | null;
+  origin: string | null;
+  notes: string | null;
+  settings: JsonRecord | null;
+  cloned_from_task_id: string | null;
+  position: number | null;
+}
+
+let e2eClientPromise: Promise<SupabaseClient> | null = null;
+
+function getRequiredEnv(name: string, fallback?: string) {
+  const value = process.env[name] ?? fallback;
+  if (!value) {
+    throw new Error(`Missing ${name} for project creation E2E verification.`);
+  }
+  return value;
+}
+
+async function getE2EClient() {
+  if (!e2eClientPromise) {
+    e2eClientPromise = (async () => {
+      const client = createClient(
+        getRequiredEnv('VITE_SUPABASE_URL', LOCAL_SUPABASE_URL),
+        getRequiredEnv('VITE_SUPABASE_ANON_KEY'),
+        {
+          auth: {
+            autoRefreshToken: false,
+            persistSession: false,
+          },
+        },
+      );
+      const { error } = await client.auth.signInWithPassword({
+        email: process.env.VITE_TEST_EMAIL ?? TEST_USER.email,
+        password: process.env.VITE_TEST_PASSWORD ?? TEST_USER.password,
+      });
+      if (error) {
+        throw new Error(`Project creation E2E database sign-in failed: ${error.message}`);
+      }
+      return client;
+    })();
+  }
+  return e2eClientPromise;
+}
+
+export function getProjectIdFromUrl(page: Page) {
+  const match = /\/project\/([^/?#]+)/.exec(new URL(page.url()).pathname);
+  if (!match?.[1]) {
+    throw new Error(`Expected project URL, received ${page.url()}`);
+  }
+  return match[1];
+}
+
+export async function fetchProjectRows(projectId: string) {
+  const client = await getE2EClient();
+  const { data, error } = await client
+    .from('tasks')
+    .select(TASK_PROBE_SELECT)
+    .or(`id.eq.${projectId},root_id.eq.${projectId}`)
+    .order('position', { ascending: true });
+
+  if (error) throw new Error(`Failed to fetch project rows: ${error.message}`);
+  return (data ?? []) as TaskProbeRow[];
+}
+
+export async function fetchTemplateRows(templateTitle: string) {
+  const client = await getE2EClient();
+  const { data: root, error: rootError } = await client
+    .from('tasks')
+    .select(TASK_PROBE_SELECT)
+    .eq('origin', 'template')
+    .eq('title', templateTitle)
+    .is('parent_task_id', null)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (rootError) throw new Error(`Failed to fetch template root: ${rootError.message}`);
+  if (!root) throw new Error(`Template root "${templateTitle}" was not found.`);
+
+  const templateRoot = root as TaskProbeRow;
+  const { data: rows, error: rowsError } = await client
+    .from('tasks')
+    .select(TASK_PROBE_SELECT)
+    .or(`id.eq.${templateRoot.id},root_id.eq.${templateRoot.id}`)
+    .order('position', { ascending: true });
+
+  if (rowsError) throw new Error(`Failed to fetch template rows: ${rowsError.message}`);
+  return {
+    root: templateRoot,
+    rows: (rows ?? []) as TaskProbeRow[],
+  };
+}
+
+export function countLeafTasks(rows: TaskProbeRow[], projectId: string) {
+  const phaseIds = new Set(rows.filter((row) => row.parent_task_id === projectId).map((row) => row.id));
+  const milestoneIds = new Set(
+    rows
+      .filter((row) => row.parent_task_id !== null && phaseIds.has(row.parent_task_id))
+      .map((row) => row.id),
+  );
+  return rows.filter((row) => row.parent_task_id !== null && milestoneIds.has(row.parent_task_id)).length;
+}
+
+export function getSettingString(row: TaskProbeRow | undefined, key: string) {
+  const value = row?.settings?.[key];
+  return typeof value === 'string' ? value : null;
+}
+
+export async function waitForProjectRowCount(projectId: string, expectedCount: number) {
+  await expect.poll(async () => (await fetchProjectRows(projectId)).length, {
+    timeout: 15000,
+  }).toBe(expectedCount);
+}

--- a/Testing/e2e/steps/dashboard.steps.ts
+++ b/Testing/e2e/steps/dashboard.steps.ts
@@ -2,7 +2,7 @@ import { createBdd } from 'playwright-bdd';
 import { expect, type Page } from '@playwright/test';
 import { DashboardPage } from '../pages/DashboardPage';
 import {
-  countLeafTasks,
+  countMilestoneLeafTasks,
   fetchProjectRows,
   fetchTemplateRows,
   getProjectIdFromUrl,
@@ -188,7 +188,7 @@ Then('the blank project scaffold baseline is imported', async ({ page }) => {
 
   const rows = await fetchProjectRows(projectId);
   expect(rows.filter((row) => row.parent_task_id === projectId)).toHaveLength(6);
-  expect(countLeafTasks(rows, projectId)).toBe(26);
+  expect(countMilestoneLeafTasks(rows, projectId)).toBe(26);
   expect(rows.some((row) => row.title === 'Discovery')).toBeTruthy();
   expect(rows.some((row) => row.title === 'Personal Assessment')).toBeTruthy();
   expect(rows.some((row) => row.title === 'Review and complete assessment')).toBeTruthy();

--- a/Testing/e2e/steps/dashboard.steps.ts
+++ b/Testing/e2e/steps/dashboard.steps.ts
@@ -1,6 +1,14 @@
 import { createBdd } from 'playwright-bdd';
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { DashboardPage } from '../pages/DashboardPage';
+import {
+  countLeafTasks,
+  fetchProjectRows,
+  fetchTemplateRows,
+  getProjectIdFromUrl,
+  getSettingString,
+  waitForProjectRowCount,
+} from '../helpers/project-creation-db';
 
 const { Given, When, Then } = createBdd();
 
@@ -44,7 +52,7 @@ When('the user completes the new project modal with {string}', async ({ page }, 
   await completeNewProjectModal(page, name);
 });
 
-async function completeNewProjectModal(page: import('@playwright/test').Page, name: string) {
+async function completeNewProjectModal(page: Page, name: string) {
   await page.locator('[role="dialog"]').waitFor();
   // Select scratch or default template
   const continueBtn = page.getByRole('button', { name: /continue/i });
@@ -55,6 +63,15 @@ async function completeNewProjectModal(page: import('@playwright/test').Page, na
   await page.getByRole('button', { name: /create project/i }).click();
   await page.waitForURL(/\/project\//);
 }
+
+When('the user selects the {string} project template', async ({ page }, templateName: string) => {
+  const dialog = page.locator('[role="dialog"]');
+  await expect(dialog).toBeVisible();
+  const templateCard = dialog.locator('[data-testid="template-card"]').filter({ hasText: templateName }).first();
+  await expect(templateCard).toBeVisible({ timeout: 10000 });
+  await templateCard.click();
+  await expect(templateCard).toHaveAttribute('data-selected', 'true');
+});
 
 When('the user creates a new template {string}', async ({ page }, name: string) => {
   await page.goto('/tasks?action=new-template');
@@ -163,6 +180,44 @@ Then('the user is redirected to a project page', async ({ page }) => {
 
 Then('the project title {string} is visible', async ({ page }, title: string) => {
   await expect(page.getByRole('heading', { level: 1, name: title })).toBeVisible();
+});
+
+Then('the blank project scaffold baseline is imported', async ({ page }) => {
+  const projectId = getProjectIdFromUrl(page);
+  await waitForProjectRowCount(projectId, 51);
+
+  const rows = await fetchProjectRows(projectId);
+  expect(rows.filter((row) => row.parent_task_id === projectId)).toHaveLength(6);
+  expect(countLeafTasks(rows, projectId)).toBe(26);
+  expect(rows.some((row) => row.title === 'Discovery')).toBeTruthy();
+  expect(rows.some((row) => row.title === 'Personal Assessment')).toBeTruthy();
+  expect(rows.some((row) => row.title === 'Review and complete assessment')).toBeTruthy();
+
+  await expect(page.getByText('Discovery', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('Personal Assessment', { exact: true })).toBeVisible();
+  await expect(page.getByText('Review and complete assessment', { exact: true })).toBeVisible();
+});
+
+Then('the project imports the {string} template baseline without copied notes', async ({ page }, templateTitle: string) => {
+  const projectId = getProjectIdFromUrl(page);
+  const template = await fetchTemplateRows(templateTitle);
+
+  await waitForProjectRowCount(projectId, template.rows.length);
+
+  const rows = await fetchProjectRows(projectId);
+  const root = rows.find((row) => row.id === projectId);
+  expect(root?.origin).toBe('instance');
+  expect(getSettingString(root, 'spawnedFromTemplate')).toBe(template.root.id);
+  expect(rows.filter((row) => row.cloned_from_task_id !== null)).toHaveLength(template.rows.length);
+  expect(rows.filter((row) => row.parent_task_id === projectId)).toHaveLength(6);
+  expect(rows.some((row) => row.title === 'Phase 1: Discovery')).toBeTruthy();
+  expect(rows.some((row) => row.title === 'Assessment')).toBeTruthy();
+  expect(rows.some((row) => row.title === 'Complete planter assessment')).toBeTruthy();
+  expect(rows.filter((row) => (row.notes ?? '').trim().length > 0)).toEqual([]);
+
+  await expect(page.getByText('Phase 1: Discovery', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('Assessment', { exact: true })).toBeVisible();
+  await expect(page.getByText('Complete planter assessment', { exact: true })).toBeVisible();
 });
 
 Then('{string} appears in the sidebar templates section', async ({ page }, name: string) => {

--- a/Testing/unit/features/projects/components/CreateProjectModal.test.tsx
+++ b/Testing/unit/features/projects/components/CreateProjectModal.test.tsx
@@ -74,4 +74,37 @@ describe('CreateProjectModal', () => {
             }));
         });
     });
+
+    it('omits templateId when the default scaffold remains selected', async () => {
+        const onClose = vi.fn();
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+        render(
+            <CreateProjectModal
+                open
+                onClose={onClose}
+                onSubmit={onSubmit}
+                templates={[launchTemplate]}
+            />,
+        );
+
+        const defaultCard = screen
+            .getAllByTestId('template-card')
+            .find((card) => card.getAttribute('data-template-id') === '__default__');
+        expect(defaultCard).toBeDefined();
+        fireEvent.click(defaultCard as HTMLElement);
+        expect(defaultCard).toHaveAttribute('data-selected', 'true');
+
+        fireEvent.click(screen.getByRole('button', { name: /continue to details/i }));
+        fireEvent.change(screen.getByLabelText(/project name/i), {
+            target: { value: 'Blank Scaffold Project' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /create project/i }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(expect.not.objectContaining({
+                templateId: expect.any(String),
+            }));
+        });
+    });
 });

--- a/Testing/unit/features/projects/hooks/useProjectMutations.test.ts
+++ b/Testing/unit/features/projects/hooks/useProjectMutations.test.ts
@@ -93,6 +93,7 @@ describe('useCreateProject', () => {
     await act(async () => {
       await result.current.mutateAsync({
         title: 'From Template',
+        description: 'Cloned project description',
         templateId: 'tmpl-1',
         start_date: '2026-01-01',
       });
@@ -103,7 +104,12 @@ describe('useCreateProject', () => {
       null,
       'instance',
       'user-1',
-      expect.objectContaining({ title: 'From Template' }),
+      {
+        title: 'From Template',
+        description: 'Cloned project description',
+        start_date: '2026-01-01',
+        due_date: '2026-01-01',
+      },
     );
     expect(mockProjectCreate).not.toHaveBeenCalled();
   });

--- a/src/features/projects/components/CreateProjectModal.tsx
+++ b/src/features/projects/components/CreateProjectModal.tsx
@@ -258,6 +258,9 @@ export default function CreateProjectModal({
                                     {/* Default scaffold option */}
                                     {!searchQuery && (
                                         <div
+                                            data-testid="template-card"
+                                            data-template-id={DEFAULT_SCAFFOLD_ID}
+                                            data-selected={formData.templateId === DEFAULT_SCAFFOLD_ID ? 'true' : 'false'}
                                             onClick={() => handleTemplateSelect(DEFAULT_SCAFFOLD_ID)}
                                             className={cn(
                                                 'group cursor-pointer p-4 rounded-xl border-2 transition-all duration-300 flex items-center gap-4',
@@ -298,6 +301,10 @@ export default function CreateProjectModal({
                                         filteredTemplates.map((template) => (
                                             <div
                                                 key={template.id}
+                                                data-testid="template-card"
+                                                data-template-id={template.id}
+                                                data-template-seed-key={getTemplateSeedKey(template.settings) ?? undefined}
+                                                data-selected={formData.templateId === template.id ? 'true' : 'false'}
                                                 onClick={() => handleTemplateSelect(template.id)}
                                                 className={cn(
                                                     'group cursor-pointer p-4 rounded-xl border-2 transition-all duration-300 flex items-center gap-4',


### PR DESCRIPTION
## Summary
- add stable project-template card selectors used by E2E smoke tests
- characterize default scaffold creation through unit and release E2E coverage
- add release E2E coverage for Launch Large template project creation, cloned hierarchy counts, spawned template stamp, and blank cloned notes

## Validation
- npx vitest --run Testing/unit/features/projects/components/CreateProjectModal.test.tsx Testing/unit/features/projects/hooks/useProjectMutations.test.ts
- AGENT_MODE=true npm run verify-architecture
- npm run lint
- npm run typecheck:agent
- npx tsc --noEmit --pretty false
- npm run db:local:test
- npm test
- npm run test:e2e:release
- npm run build