### PR TITLE
feat: add inert business calendars

### DIFF
--- a/Testing/unit/shared/lib/date-engine/business-calendar.test.ts
+++ b/Testing/unit/shared/lib/date-engine/business-calendar.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
     calendarDayBusinessCalendar,
     defaultBusinessCalendar,
+    usFederalObservedBusinessCalendar,
+    weekdayBusinessCalendar,
     type BusinessCalendar,
 } from '@/shared/lib/date-engine/business-calendar';
 import { toIsoDate } from '@/shared/lib/date-engine';
@@ -45,5 +47,33 @@ describe('business-calendar abstraction', () => {
         const calendar: BusinessCalendar = calendarDayBusinessCalendar;
 
         expect(calendar.id).toBe('calendar-day');
+    });
+
+    it('adds weekday business days without changing the default calendar', () => {
+        expect(defaultBusinessCalendar.id).toBe('calendar-day');
+        expect(weekdayBusinessCalendar.id).toBe('weekday');
+        expect(weekdayBusinessCalendar.isBusinessDay('2026-01-02')).toBe(true);
+        expect(weekdayBusinessCalendar.isBusinessDay('2026-01-03')).toBe(false);
+
+        expect(toIsoDate(weekdayBusinessCalendar.addBusinessDays('2026-01-02', 0))).toBe('2026-01-02');
+        expect(toIsoDate(weekdayBusinessCalendar.addBusinessDays('2026-01-02', 1))).toBe('2026-01-05');
+        expect(toIsoDate(weekdayBusinessCalendar.addBusinessDays('2026-01-05', -1))).toBe('2026-01-02');
+        expect(weekdayBusinessCalendar.diffInBusinessDays('2026-01-05', '2026-01-02')).toBe(1);
+        expect(weekdayBusinessCalendar.diffInBusinessDays('2026-01-02', '2026-01-05')).toBe(-1);
+    });
+
+    it('skips US federal observed holidays in the non-default calendar', () => {
+        expect(usFederalObservedBusinessCalendar.id).toBe('us-federal-observed');
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2026-07-03')).toBe(false);
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2026-07-06')).toBe(true);
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2023-01-02')).toBe(false);
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2021-12-31')).toBe(false);
+
+        expect(toIsoDate(usFederalObservedBusinessCalendar.addBusinessDays('2026-01-16', 1))).toBe('2026-01-20');
+        expect(toIsoDate(usFederalObservedBusinessCalendar.addBusinessDays('2026-07-02', 1))).toBe('2026-07-06');
+        expect(toIsoDate(usFederalObservedBusinessCalendar.addBusinessDays('2026-12-24', 1))).toBe('2026-12-28');
+        expect(toIsoDate(usFederalObservedBusinessCalendar.addBusinessDays('2027-01-04', -1))).toBe('2026-12-31');
+        expect(usFederalObservedBusinessCalendar.diffInBusinessDays('2026-01-20', '2026-01-16')).toBe(1);
+        expect(usFederalObservedBusinessCalendar.diffInBusinessDays('2026-07-06', '2026-07-02')).toBe(1);
     });
 });

--- a/Testing/unit/shared/lib/date-engine/parity.test.ts
+++ b/Testing/unit/shared/lib/date-engine/parity.test.ts
@@ -9,6 +9,8 @@ import {
 } from '@/shared/lib/date-engine';
 import {
     calendarDayBusinessCalendar as appBusinessCalendar,
+    usFederalObservedBusinessCalendar as appUsFederalObservedBusinessCalendar,
+    weekdayBusinessCalendar as appWeekdayBusinessCalendar,
 } from '@/shared/lib/date-engine/business-calendar';
 import {
     addDaysToIsoDate,
@@ -20,6 +22,8 @@ import {
 } from '../../../../../supabase/functions/_shared/date';
 import {
     calendarDayBusinessCalendar as edgeBusinessCalendar,
+    usFederalObservedBusinessCalendar as edgeUsFederalObservedBusinessCalendar,
+    weekdayBusinessCalendar as edgeWeekdayBusinessCalendar,
 } from '../../../../../supabase/functions/_shared/business-calendar';
 
 describe('date-engine app/edge parity characterization', () => {
@@ -72,5 +76,54 @@ describe('date-engine app/edge parity characterization', () => {
         expect(appBusinessCalendar.isBusinessDay('2026-01-03')).toBe(
             edgeBusinessCalendar.isBusinessDay('2026-01-03'),
         );
+    });
+
+    it('keeps app and edge behavior aligned for inert weekday and holiday calendars', () => {
+        const cases = [
+            {
+                app: appWeekdayBusinessCalendar,
+                edge: edgeWeekdayBusinessCalendar,
+                start: '2026-01-02',
+                amount: 1,
+                diffLater: '2026-01-05',
+                diffEarlier: '2026-01-02',
+                included: '2026-01-05',
+                excluded: '2026-01-03',
+            },
+            {
+                app: appUsFederalObservedBusinessCalendar,
+                edge: edgeUsFederalObservedBusinessCalendar,
+                start: '2026-07-02',
+                amount: 1,
+                diffLater: '2026-07-06',
+                diffEarlier: '2026-07-02',
+                included: '2026-07-06',
+                excluded: '2026-07-03',
+            },
+        ];
+
+        for (const testCase of cases) {
+            expect(toIsoDate(testCase.app.addBusinessDays(testCase.start, testCase.amount))).toBe(
+                testCase.edge.addBusinessDays(testCase.start, testCase.amount),
+            );
+            expect(toIsoDate(testCase.app.addBusinessDays(testCase.diffLater, -1))).toBe(
+                testCase.edge.addBusinessDays(testCase.diffLater, -1),
+            );
+            expect(toIsoDate(testCase.app.addBusinessDays(testCase.start, 0))).toBe(
+                testCase.edge.addBusinessDays(testCase.start, 0),
+            );
+            expect(testCase.app.diffInBusinessDays(testCase.diffLater, testCase.diffEarlier)).toBe(
+                testCase.edge.diffInBusinessDays(testCase.diffLater, testCase.diffEarlier),
+            );
+            expect(testCase.app.diffInBusinessDays(testCase.diffEarlier, testCase.diffLater)).toBe(
+                testCase.edge.diffInBusinessDays(testCase.diffEarlier, testCase.diffLater),
+            );
+            expect(testCase.app.isBusinessDay(testCase.included)).toBe(
+                testCase.edge.isBusinessDay(testCase.included),
+            );
+            expect(testCase.app.isBusinessDay(testCase.excluded)).toBe(
+                testCase.edge.isBusinessDay(testCase.excluded),
+            );
+        }
     });
 });

--- a/Testing/unit/supabase/functions/_shared/business-calendar.test.ts
+++ b/Testing/unit/supabase/functions/_shared/business-calendar.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
     calendarDayBusinessCalendar,
     defaultBusinessCalendar,
+    usFederalObservedBusinessCalendar,
+    weekdayBusinessCalendar,
     type BusinessCalendar,
 } from '../../../../../supabase/functions/_shared/business-calendar';
 
@@ -36,5 +38,33 @@ describe('edge business-calendar abstraction', () => {
         const calendar: BusinessCalendar = calendarDayBusinessCalendar;
 
         expect(calendar.id).toBe('calendar-day');
+    });
+
+    it('adds weekday business days without changing the default edge calendar', () => {
+        expect(defaultBusinessCalendar.id).toBe('calendar-day');
+        expect(weekdayBusinessCalendar.id).toBe('weekday');
+        expect(weekdayBusinessCalendar.isBusinessDay('2026-01-02')).toBe(true);
+        expect(weekdayBusinessCalendar.isBusinessDay('2026-01-03')).toBe(false);
+
+        expect(weekdayBusinessCalendar.addBusinessDays('2026-01-02', 0)).toBe('2026-01-02');
+        expect(weekdayBusinessCalendar.addBusinessDays('2026-01-02', 1)).toBe('2026-01-05');
+        expect(weekdayBusinessCalendar.addBusinessDays('2026-01-05', -1)).toBe('2026-01-02');
+        expect(weekdayBusinessCalendar.diffInBusinessDays('2026-01-05', '2026-01-02')).toBe(1);
+        expect(weekdayBusinessCalendar.diffInBusinessDays('2026-01-02', '2026-01-05')).toBe(-1);
+    });
+
+    it('skips US federal observed holidays in the non-default edge calendar', () => {
+        expect(usFederalObservedBusinessCalendar.id).toBe('us-federal-observed');
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2026-07-03')).toBe(false);
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2026-07-06')).toBe(true);
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2023-01-02')).toBe(false);
+        expect(usFederalObservedBusinessCalendar.isBusinessDay('2021-12-31')).toBe(false);
+
+        expect(usFederalObservedBusinessCalendar.addBusinessDays('2026-01-16', 1)).toBe('2026-01-20');
+        expect(usFederalObservedBusinessCalendar.addBusinessDays('2026-07-02', 1)).toBe('2026-07-06');
+        expect(usFederalObservedBusinessCalendar.addBusinessDays('2026-12-24', 1)).toBe('2026-12-28');
+        expect(usFederalObservedBusinessCalendar.addBusinessDays('2027-01-04', -1)).toBe('2026-12-31');
+        expect(usFederalObservedBusinessCalendar.diffInBusinessDays('2026-01-20', '2026-01-16')).toBe(1);
+        expect(usFederalObservedBusinessCalendar.diffInBusinessDays('2026-07-06', '2026-07-02')).toBe(1);
     });
 });

--- a/docs/architecture/date-engine-business-calendar-adr.md
+++ b/docs/architecture/date-engine-business-calendar-adr.md
@@ -6,8 +6,9 @@ characterization net. PR I1 added the app/edge business-calendar interfaces
 with calendar-day behavior. PR I2 routes active scheduling and urgency callers
 through the seam without changing behavior. The 2026-05-05 release-hardening
 plan keeps this custom-engine direction and selects `us-federal-observed` as
-the Alpha default calendar for date-kind scheduling once the inert calendar
-implementations and parity tests land.
+the Alpha default calendar for date-kind scheduling. PR R4 adds inert
+`weekday` and `us-federal-observed` implementations plus app/edge parity tests;
+`calendar-day` remains the runtime default until the behavior-switch PR lands.
 
 ## Context
 PlanterPlan currently centralizes app date math in `src/shared/lib/date-engine`.
@@ -138,11 +139,26 @@ PR I2 adds tests that lock:
 * nightly-sync due-soon thresholds preserve UTC time-of-day while routing the
   date portion through the edge business-calendar seam.
 
+## PR R4 Implementation
+PR R4 adds non-default app and Edge calendars without changing runtime callers:
+
+* `weekday`: skips Saturday and Sunday.
+* `us-federal-observed`: skips Saturday and Sunday plus nationwide US federal
+  observed holidays. This includes fixed-date observed rules, MLK Day,
+  Washington's Birthday, Memorial Day, Juneteenth from 2021 onward,
+  Independence Day, Labor Day, Columbus Day, Veterans Day, Thanksgiving, and
+  Christmas. It does not include DC-specific Inauguration Day.
+
+PR R4 tests positive, negative, and zero offsets; weekend boundaries; year
+boundaries; and observed holidays that land on weekends. App and Edge tests keep
+the implementations aligned while `defaultBusinessCalendar` remains
+`calendar-day`.
+
 ## PR R4/R5 Requirements
-PR R4 must add `weekday` and `us-federal-observed` without changing runtime
-defaults. App and Edge implementations must agree for date-only inputs,
-negative offsets, zero offsets, weekend boundaries, year boundaries, and
-observed-holiday cases where the legal holiday falls on a weekend.
+PR R4 added `weekday` and `us-federal-observed` without changing runtime
+defaults. App and Edge implementations agree for date-only inputs, negative
+offsets, zero offsets, weekend boundaries, year boundaries, and observed-holiday
+cases where the legal holiday falls on a weekend.
 
 PR R5 may change behavior only after PR R4 lands. It must switch date-kind
 scheduling and urgency callers to the `us-federal-observed` calendar while

--- a/docs/architecture/date-engine.md
+++ b/docs/architecture/date-engine.md
@@ -23,7 +23,7 @@ Calculated dynamically based on system time vs. Task End Dates:
 * **Template Exclusion:** The Date Engine is entirely disabled for Library Templates. Template tasks use `duration` and `days from start until due`.
 * **Checkpoint projects (Wave 29):** `recalculateProjectDates` and `deriveUrgencyForProject` short-circuit when the project root carries `settings.project_kind === 'checkpoint'`; nightly-sync skips urgency transitions for those roots; due dates render as informational only. `isCheckpointProject` is lock-step with `supabase/functions/_shared/date.ts`.
 * **Wave 31:** display-time date formatting uses `formatDateLocalized` from `src/shared/i18n/formatters.ts` (Intl `DateTimeFormat` / `RelativeTimeFormat` with per-locale caches). Internal math stays UTC-anchored ISO strings here in `date-engine/index.ts` — `compareDateAsc`, `isBeforeDate`, `formatDisplayDate`, cascade/rollup calculations, etc. Don't conflate the two: calling `formatDateLocalized` in a comparator silently breaks sort stability across locales; calling `formatDisplayDate` in JSX silently renders the wrong language.
-* **Business-calendar seam (PR I1/I2):** `src/shared/lib/date-engine/business-calendar.ts` and `supabase/functions/_shared/business-calendar.ts` expose app/edge `BusinessCalendar` interfaces. The default implementation is `calendar-day`, which intentionally treats every valid date including weekends as a business day. App schedule offsets, global project shifts, display urgency, ICS all-day `DTEND`, and nightly-sync due-soon cutoffs route through the seam without changing current calendar-day behavior.
+* **Business-calendar seam (PR I1/I2/R4):** `src/shared/lib/date-engine/business-calendar.ts` and `supabase/functions/_shared/business-calendar.ts` expose app/edge `BusinessCalendar` interfaces. The default implementation is `calendar-day`, which intentionally treats every valid date including weekends as a business day. Non-default `weekday` and `us-federal-observed` calendars exist behind the seam for the next behavior slice. App schedule offsets, global project shifts, display urgency, ICS all-day `DTEND`, and nightly-sync due-soon cutoffs route through the seam without changing current calendar-day behavior.
 
 ## Integration Points
 * **Tasks & Subtasks:** The drag-and-drop system relies heavily on the Date Engine to recalculate bounds when items are moved.
@@ -34,11 +34,14 @@ Calculated dynamically based on system time vs. Task End Dates:
 * **Decision record (PR H/I1/I2):** `docs/architecture/date-engine-business-calendar-adr.md` records the accepted direction: keep `date-fns` inside the app date-engine layer, add a custom business-calendar seam, and route app/edge scheduling callers through it before any weekend/holiday behavior change.
 
 ## Known Gaps / Technical Debt
-* Algorithms for auto-adjusting dates currently lack logic for skipping weekends and regional holidays.
+* Runtime scheduling still defaults to `calendar-day`; weekend and holiday
+  skipping is implemented only in inert `weekday` / `us-federal-observed`
+  calendars until the product-approved behavior switch lands.
 * **User-testing tranche direction (PR H, PR I+):** PR H added the decision
   record and characterization tests. PR I1 added the app/edge business-calendar
   seam with no runtime behavior change. PR I2 routes active app/edge scheduling
-  callers through that seam while keeping calendar-day behavior. Later PR I
-  slices must preserve UTC/date-only semantics, checkpoint-project exclusions,
-  template exclusions, task hierarchy rollups, and `nightly-sync` / edge utility
-  parity before any product-approved weekend/holiday behavior change.
+  callers through that seam while keeping calendar-day behavior. PR R4 adds
+  inert weekday/holiday calendars. Later PR slices must preserve UTC/date-only
+  semantics, checkpoint-project exclusions, template exclusions, task hierarchy
+  rollups, and `nightly-sync` / edge utility parity before any product-approved
+  weekend/holiday behavior change.

--- a/docs/architecture/user-testing-baseline.md
+++ b/docs/architecture/user-testing-baseline.md
@@ -79,8 +79,8 @@ coverage before changing behavior.
   utilities before changing behavior.
 * Alpha date-kind scheduling will use a custom `us-federal-observed` business
   calendar after the inert app/edge calendar implementations and parity tests
-  land. `calendar-day` remains the compatibility behavior until that behavior
-  switch PR merges.
+  land. PR R4 adds those inert calendars. `calendar-day` remains the
+  compatibility behavior until that behavior switch PR merges.
 
 ## Current Implementation Gaps
 
@@ -92,7 +92,7 @@ coverage before changing behavior.
 | Coaching flag | PR F exposes `settings.is_coaching_task` editing only on template forms and strips instance form payloads. | Instances preserve inherited behavior read-only. | Done PR F |
 | Strategy flag | PR F exposes `settings.is_strategy_template` editing only on template forms and strips instance form payloads. | Instances preserve inherited behavior read-only. | Done PR F |
 | Template clone | PR G clears template notes when cloning/importing into project instances and preserves only approved inherited metadata (`project_kind`, coaching, and strategy flags). | Instance clones receive blank notes while preserving approved metadata. | Done PR G |
-| Date engine | PR H documents the selected business-calendar direction and characterizes app/edge UTC parity plus the `date-fns` boundary. PR I1 adds app/edge business-calendar interfaces with current calendar-day behavior. PR I2 routes active app schedule offsets, project shifts, display urgency, ICS `DTEND`, and nightly-sync due-soon cutoffs through the seam without changing behavior. | Add `weekday` and `us-federal-observed` calendars behind the seam, then switch date-kind scheduling after parity and characterization tests. | Done PR H/I1/I2; Planned PR R4/R5 |
+| Date engine | PR H documents the selected business-calendar direction and characterizes app/edge UTC parity plus the `date-fns` boundary. PR I1 adds app/edge business-calendar interfaces with current calendar-day behavior. PR I2 routes active app schedule offsets, project shifts, display urgency, ICS `DTEND`, and nightly-sync due-soon cutoffs through the seam without changing behavior. PR R4 adds inert `weekday` and `us-federal-observed` app/edge calendars. | Switch date-kind scheduling after parity and characterization tests. | Done PR H/I1/I2/R4; Planned PR R5 |
 
 ## Remaining PR Sequence
 

--- a/src/shared/lib/date-engine/business-calendar.ts
+++ b/src/shared/lib/date-engine/business-calendar.ts
@@ -3,13 +3,14 @@ import { addDays, differenceInCalendarDays, isValid, parseISO } from 'date-fns';
 /**
  * Business-calendar abstraction for PlanterPlan scheduling.
  *
- * PR I1 intentionally preserves current calendar-day behavior: every valid
- * date is treated as a business day, so Friday + 1 business day is Saturday.
- * Weekend and holiday skipping must be added behind this seam in a later PR
- * after product rules and edge parity are explicit.
+ * The default calendar intentionally preserves current calendar-day behavior:
+ * every valid date is treated as a business day, so Friday + 1 business day is
+ * Saturday. PR R4 adds non-default weekday and US federal observed calendars
+ * behind this seam; PR R5 owns any runtime default or scheduling behavior
+ * switch.
  */
 
-export type BusinessCalendarId = 'calendar-day';
+export type BusinessCalendarId = 'calendar-day' | 'weekday' | 'us-federal-observed';
 export type BusinessCalendarDateInput = string | Date;
 
 export interface BusinessCalendar {
@@ -41,6 +42,7 @@ export interface BusinessCalendar {
 
 const DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const usFederalObservedHolidayCache = new Map<number, Set<string>>();
 
 const parseDateOnlyParts = (input: string): [number, number, number] | null => {
  const match = DATE_ONLY_RE.exec(input);
@@ -74,6 +76,81 @@ const addUtcDateOnlyDays = (input: string, amount: number): Date | null => {
  return new Date(Date.UTC(year, month - 1, day + amount));
 };
 
+const toUtcDateOnly = (date: Date): string => {
+ const year = date.getUTCFullYear();
+ const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+ const day = String(date.getUTCDate()).padStart(2, '0');
+ return `${year}-${month}-${day}`;
+};
+
+const fromUtcDateOnlyParts = (year: number, month: number, day: number): string => (
+ toUtcDateOnly(new Date(Date.UTC(year, month - 1, day)))
+);
+
+const isWeekendUtc = (date: Date): boolean => {
+ const day = date.getUTCDay();
+ return day === 0 || day === 6;
+};
+
+const addDaysUtc = (date: Date, amount: number): Date => (
+ new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + amount))
+);
+
+const nthWeekdayOfMonth = (year: number, month: number, weekday: number, occurrence: number): string => {
+ const first = new Date(Date.UTC(year, month - 1, 1));
+ const offset = (weekday - first.getUTCDay() + 7) % 7;
+ return fromUtcDateOnlyParts(year, month, 1 + offset + (occurrence - 1) * 7);
+};
+
+const lastWeekdayOfMonth = (year: number, month: number, weekday: number): string => {
+ const last = new Date(Date.UTC(year, month, 0));
+ const offset = (last.getUTCDay() - weekday + 7) % 7;
+ return fromUtcDateOnlyParts(year, month, last.getUTCDate() - offset);
+};
+
+const observedFixedHoliday = (year: number, month: number, day: number): string => {
+ const holiday = new Date(Date.UTC(year, month - 1, day));
+ const weekday = holiday.getUTCDay();
+ if (weekday === 6) return toUtcDateOnly(addDaysUtc(holiday, -1));
+ if (weekday === 0) return toUtcDateOnly(addDaysUtc(holiday, 1));
+ return toUtcDateOnly(holiday);
+};
+
+const getUsFederalObservedHolidaysForYear = (year: number): Set<string> => {
+ const cached = usFederalObservedHolidayCache.get(year);
+ if (cached) return cached;
+
+ const holidays = new Set<string>([
+  observedFixedHoliday(year, 1, 1),
+  nthWeekdayOfMonth(year, 1, 1, 3),
+  nthWeekdayOfMonth(year, 2, 1, 3),
+  lastWeekdayOfMonth(year, 5, 1),
+  observedFixedHoliday(year, 7, 4),
+  nthWeekdayOfMonth(year, 9, 1, 1),
+  nthWeekdayOfMonth(year, 10, 1, 2),
+  observedFixedHoliday(year, 11, 11),
+  nthWeekdayOfMonth(year, 11, 4, 4),
+  observedFixedHoliday(year, 12, 25),
+ ]);
+
+ if (year >= 2021) {
+  holidays.add(observedFixedHoliday(year, 6, 19));
+ }
+
+ usFederalObservedHolidayCache.set(year, holidays);
+ return holidays;
+};
+
+const isUsFederalObservedHoliday = (date: Date): boolean => {
+ const isoDate = toUtcDateOnly(date);
+ const year = date.getUTCFullYear();
+ return (
+  getUsFederalObservedHolidaysForYear(year - 1).has(isoDate) ||
+  getUsFederalObservedHolidaysForYear(year).has(isoDate) ||
+  getUsFederalObservedHolidaysForYear(year + 1).has(isoDate)
+ );
+};
+
 /**
  * Resolves a business-calendar input to a Date.
  * @param input - Date input to resolve.
@@ -87,6 +164,80 @@ const resolveBusinessDate = (input: BusinessCalendarDateInput | null | undefined
  }
  const date = typeof input === 'string' ? parseISO(input) : input;
  return isValid(date) ? date : null;
+};
+
+const createSkippingBusinessCalendar = (
+ id: Exclude<BusinessCalendarId, 'calendar-day'>,
+ isExcludedDate: (date: Date) => boolean,
+): BusinessCalendar => {
+ const isIncluded = (date: Date): boolean => !isExcludedDate(date);
+
+ return {
+  id,
+
+  isBusinessDay(date) {
+   const resolved = resolveBusinessDate(date);
+   return resolved !== null && isIncluded(resolved);
+  },
+
+  addBusinessDays(date, amount) {
+   const resolved = resolveBusinessDate(date);
+   if (!resolved) return null;
+   if (amount === 0) {
+    return new Date(Date.UTC(
+     resolved.getUTCFullYear(),
+     resolved.getUTCMonth(),
+     resolved.getUTCDate(),
+    ));
+   }
+
+   const direction = amount > 0 ? 1 : -1;
+   let remaining = Math.abs(amount);
+   let cursor = new Date(Date.UTC(
+    resolved.getUTCFullYear(),
+    resolved.getUTCMonth(),
+    resolved.getUTCDate(),
+   ));
+
+   while (remaining > 0) {
+    cursor = addDaysUtc(cursor, direction);
+    if (isIncluded(cursor)) remaining -= 1;
+   }
+
+   return cursor;
+  },
+
+  diffInBusinessDays(later, earlier) {
+   const resolvedLater = resolveBusinessDate(later);
+   const resolvedEarlier = resolveBusinessDate(earlier);
+   if (!resolvedLater || !resolvedEarlier) return null;
+
+   const laterDate = new Date(Date.UTC(
+    resolvedLater.getUTCFullYear(),
+    resolvedLater.getUTCMonth(),
+    resolvedLater.getUTCDate(),
+   ));
+   const earlierDate = new Date(Date.UTC(
+    resolvedEarlier.getUTCFullYear(),
+    resolvedEarlier.getUTCMonth(),
+    resolvedEarlier.getUTCDate(),
+   ));
+   const laterMs = laterDate.getTime();
+   const earlierMs = earlierDate.getTime();
+   if (laterMs === earlierMs) return 0;
+
+   const direction = laterMs > earlierMs ? 1 : -1;
+   let cursor = earlierDate;
+   let count = 0;
+
+   while (cursor.getTime() !== laterMs) {
+    cursor = addDaysUtc(cursor, direction);
+    if (isIncluded(cursor)) count += direction;
+   }
+
+   return count;
+  },
+ };
 };
 
 export const calendarDayBusinessCalendar: BusinessCalendar = {
@@ -123,5 +274,15 @@ export const calendarDayBusinessCalendar: BusinessCalendar = {
   return differenceInCalendarDays(resolvedLater, resolvedEarlier);
  },
 };
+
+export const weekdayBusinessCalendar: BusinessCalendar = createSkippingBusinessCalendar(
+ 'weekday',
+ isWeekendUtc,
+);
+
+export const usFederalObservedBusinessCalendar: BusinessCalendar = createSkippingBusinessCalendar(
+ 'us-federal-observed',
+ (date) => isWeekendUtc(date) || isUsFederalObservedHoliday(date),
+);
 
 export const defaultBusinessCalendar = calendarDayBusinessCalendar;

--- a/src/shared/lib/date-engine/business-calendar.ts
+++ b/src/shared/lib/date-engine/business-calendar.ts
@@ -76,6 +76,11 @@ const addUtcDateOnlyDays = (input: string, amount: number): Date | null => {
  return new Date(Date.UTC(year, month - 1, day + amount));
 };
 
+/**
+ * Formats a date as a UTC `YYYY-MM-DD` string.
+ * @param date - Date to format.
+ * @returns UTC date-only string.
+ */
 const toUtcDateOnly = (date: Date): string => {
  const year = date.getUTCFullYear();
  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
@@ -83,31 +88,71 @@ const toUtcDateOnly = (date: Date): string => {
  return `${year}-${month}-${day}`;
 };
 
+/**
+ * Builds a UTC date-only string from numeric date parts.
+ * @param year - UTC year.
+ * @param month - One-based UTC month.
+ * @param day - UTC day of month.
+ * @returns UTC date-only string.
+ */
 const fromUtcDateOnlyParts = (year: number, month: number, day: number): string => (
  toUtcDateOnly(new Date(Date.UTC(year, month - 1, day)))
 );
 
+/**
+ * Checks whether a date falls on Saturday or Sunday in UTC.
+ * @param date - Date to inspect.
+ * @returns True when the UTC weekday is Saturday or Sunday.
+ */
 const isWeekendUtc = (date: Date): boolean => {
  const day = date.getUTCDay();
  return day === 0 || day === 6;
 };
 
+/**
+ * Adds calendar days using UTC date-only semantics.
+ * @param date - Date to shift.
+ * @param amount - Number of calendar days to add; negative subtracts.
+ * @returns Shifted UTC date.
+ */
 const addDaysUtc = (date: Date, amount: number): Date => (
  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + amount))
 );
 
+/**
+ * Finds the Nth weekday in a UTC month.
+ * @param year - UTC year.
+ * @param month - One-based UTC month.
+ * @param weekday - UTC weekday, where 0 is Sunday.
+ * @param occurrence - One-based occurrence to find.
+ * @returns UTC date-only string for the matched weekday.
+ */
 const nthWeekdayOfMonth = (year: number, month: number, weekday: number, occurrence: number): string => {
  const first = new Date(Date.UTC(year, month - 1, 1));
  const offset = (weekday - first.getUTCDay() + 7) % 7;
  return fromUtcDateOnlyParts(year, month, 1 + offset + (occurrence - 1) * 7);
 };
 
+/**
+ * Finds the last matching weekday in a UTC month.
+ * @param year - UTC year.
+ * @param month - One-based UTC month.
+ * @param weekday - UTC weekday, where 0 is Sunday.
+ * @returns UTC date-only string for the matched weekday.
+ */
 const lastWeekdayOfMonth = (year: number, month: number, weekday: number): string => {
  const last = new Date(Date.UTC(year, month, 0));
  const offset = (last.getUTCDay() - weekday + 7) % 7;
  return fromUtcDateOnlyParts(year, month, last.getUTCDate() - offset);
 };
 
+/**
+ * Applies US federal observed-date rules to a fixed-date holiday.
+ * @param year - Legal holiday year.
+ * @param month - One-based legal holiday month.
+ * @param day - Legal holiday day of month.
+ * @returns Observed UTC date-only string.
+ */
 const observedFixedHoliday = (year: number, month: number, day: number): string => {
  const holiday = new Date(Date.UTC(year, month - 1, day));
  const weekday = holiday.getUTCDay();
@@ -116,6 +161,11 @@ const observedFixedHoliday = (year: number, month: number, day: number): string 
  return toUtcDateOnly(holiday);
 };
 
+/**
+ * Builds and caches nationwide US federal observed holidays for one year.
+ * @param year - Calendar year whose legal holidays should be generated.
+ * @returns Set of observed UTC date-only strings.
+ */
 const getUsFederalObservedHolidaysForYear = (year: number): Set<string> => {
  const cached = usFederalObservedHolidayCache.get(year);
  if (cached) return cached;
@@ -141,6 +191,11 @@ const getUsFederalObservedHolidaysForYear = (year: number): Set<string> => {
  return holidays;
 };
 
+/**
+ * Checks whether a date is a nationwide US federal observed holiday.
+ * @param date - Date to inspect.
+ * @returns True when the UTC date matches an observed holiday.
+ */
 const isUsFederalObservedHoliday = (date: Date): boolean => {
  const isoDate = toUtcDateOnly(date);
  const year = date.getUTCFullYear();
@@ -166,6 +221,12 @@ const resolveBusinessDate = (input: BusinessCalendarDateInput | null | undefined
  return isValid(date) ? date : null;
 };
 
+/**
+ * Creates a business calendar that skips dates rejected by a predicate.
+ * @param id - Stable business-calendar identifier.
+ * @param isExcludedDate - Predicate returning true for skipped UTC dates.
+ * @returns BusinessCalendar implementation.
+ */
 const createSkippingBusinessCalendar = (
  id: Exclude<BusinessCalendarId, 'calendar-day'>,
  isExcludedDate: (date: Date) => boolean,

--- a/supabase/functions/_shared/business-calendar.ts
+++ b/supabase/functions/_shared/business-calendar.ts
@@ -4,10 +4,11 @@ import {
     toUtcIsoDate,
 } from './date.ts'
 
-// Deno mirror of the frontend business-calendar seam. PR I1 intentionally
-// preserves calendar-day behavior: every valid date is a business day.
+// Deno mirror of the frontend business-calendar seam. The default preserves
+// calendar-day behavior; non-default weekday and US federal observed calendars
+// stay inert until a scheduling caller explicitly opts in.
 
-export type BusinessCalendarId = 'calendar-day'
+export type BusinessCalendarId = 'calendar-day' | 'weekday' | 'us-federal-observed'
 
 export interface BusinessCalendar {
     readonly id: BusinessCalendarId
@@ -37,6 +38,78 @@ export interface BusinessCalendar {
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000
+const usFederalObservedHolidayCache = new Map<number, Set<string>>()
+
+const addUtcDays = (isoDate: string, amount: number): string | null => addDaysToIsoDate(isoDate, amount)
+
+const isWeekendUtc = (isoDate: string): boolean => {
+    const midnightMs = dateStringToUtcMidnightMs(isoDate)
+    if (midnightMs === null) return false
+    const day = new Date(midnightMs).getUTCDay()
+    return day === 0 || day === 6
+}
+
+const isoDateFromParts = (year: number, month: number, day: number): string => (
+    toUtcIsoDate(new Date(Date.UTC(year, month - 1, day)))
+)
+
+const nthWeekdayOfMonth = (year: number, month: number, weekday: number, occurrence: number): string => {
+    const first = new Date(Date.UTC(year, month - 1, 1))
+    const offset = (weekday - first.getUTCDay() + 7) % 7
+    return isoDateFromParts(year, month, 1 + offset + (occurrence - 1) * 7)
+}
+
+const lastWeekdayOfMonth = (year: number, month: number, weekday: number): string => {
+    const last = new Date(Date.UTC(year, month, 0))
+    const offset = (last.getUTCDay() - weekday + 7) % 7
+    return isoDateFromParts(year, month, last.getUTCDate() - offset)
+}
+
+const observedFixedHoliday = (year: number, month: number, day: number): string => {
+    const holiday = new Date(Date.UTC(year, month - 1, day))
+    const weekday = holiday.getUTCDay()
+    if (weekday === 6) return toUtcIsoDate(new Date(Date.UTC(year, month - 1, day - 1)))
+    if (weekday === 0) return toUtcIsoDate(new Date(Date.UTC(year, month - 1, day + 1)))
+    return toUtcIsoDate(holiday)
+}
+
+const getUsFederalObservedHolidaysForYear = (year: number): Set<string> => {
+    const cached = usFederalObservedHolidayCache.get(year)
+    if (cached) return cached
+
+    const holidays = new Set<string>([
+        observedFixedHoliday(year, 1, 1),
+        nthWeekdayOfMonth(year, 1, 1, 3),
+        nthWeekdayOfMonth(year, 2, 1, 3),
+        lastWeekdayOfMonth(year, 5, 1),
+        observedFixedHoliday(year, 7, 4),
+        nthWeekdayOfMonth(year, 9, 1, 1),
+        nthWeekdayOfMonth(year, 10, 1, 2),
+        observedFixedHoliday(year, 11, 11),
+        nthWeekdayOfMonth(year, 11, 4, 4),
+        observedFixedHoliday(year, 12, 25),
+    ])
+
+    if (year >= 2021) {
+        holidays.add(observedFixedHoliday(year, 6, 19))
+    }
+
+    usFederalObservedHolidayCache.set(year, holidays)
+    return holidays
+}
+
+const isUsFederalObservedHoliday = (isoDate: string): boolean => {
+    const midnightMs = dateStringToUtcMidnightMs(isoDate)
+    if (midnightMs === null) return false
+    const date = new Date(midnightMs)
+    const normalized = toUtcIsoDate(date)
+    const year = date.getUTCFullYear()
+    return (
+        getUsFederalObservedHolidaysForYear(year - 1).has(normalized) ||
+        getUsFederalObservedHolidaysForYear(year).has(normalized) ||
+        getUsFederalObservedHolidaysForYear(year + 1).has(normalized)
+    )
+}
 
 /**
  * Normalizes an ISO date/timestamp to a UTC YYYY-MM-DD date.
@@ -47,6 +120,65 @@ const normalizeToUtcIsoDate = (raw: string | null | undefined): string | null =>
     const midnightMs = dateStringToUtcMidnightMs(raw ?? null)
     if (midnightMs === null) return null
     return toUtcIsoDate(new Date(midnightMs))
+}
+
+const createSkippingBusinessCalendar = (
+    id: Exclude<BusinessCalendarId, 'calendar-day'>,
+    isExcludedDate: (isoDate: string) => boolean,
+): BusinessCalendar => {
+    const isIncluded = (isoDate: string): boolean => !isExcludedDate(isoDate)
+
+    return {
+        id,
+
+        isBusinessDay(isoDate) {
+            const normalized = normalizeToUtcIsoDate(isoDate)
+            return normalized !== null && isIncluded(normalized)
+        },
+
+        addBusinessDays(isoDate, amount) {
+            const normalized = normalizeToUtcIsoDate(isoDate)
+            if (!normalized) return null
+            if (amount === 0) return normalized
+
+            const direction = amount > 0 ? 1 : -1
+            let remaining = Math.abs(amount)
+            let cursor = normalized
+
+            while (remaining > 0) {
+                const next = addUtcDays(cursor, direction)
+                if (!next) return null
+                cursor = next
+                if (isIncluded(cursor)) remaining -= 1
+            }
+
+            return cursor
+        },
+
+        diffInBusinessDays(later, earlier) {
+            const laterDate = normalizeToUtcIsoDate(later)
+            const earlierDate = normalizeToUtcIsoDate(earlier)
+            if (!laterDate || !earlierDate) return null
+
+            const laterMs = dateStringToUtcMidnightMs(laterDate)
+            const earlierMs = dateStringToUtcMidnightMs(earlierDate)
+            if (laterMs === null || earlierMs === null) return null
+            if (laterMs === earlierMs) return 0
+
+            const direction = laterMs > earlierMs ? 1 : -1
+            let cursor = earlierDate
+            let count = 0
+
+            while (cursor !== laterDate) {
+                const next = addUtcDays(cursor, direction)
+                if (!next) return null
+                cursor = next
+                if (isIncluded(cursor)) count += direction
+            }
+
+            return count
+        },
+    }
 }
 
 export const calendarDayBusinessCalendar: BusinessCalendar = {
@@ -69,5 +201,15 @@ export const calendarDayBusinessCalendar: BusinessCalendar = {
         return Math.round((laterMs - earlierMs) / MS_PER_DAY)
     },
 }
+
+export const weekdayBusinessCalendar: BusinessCalendar = createSkippingBusinessCalendar(
+    'weekday',
+    isWeekendUtc,
+)
+
+export const usFederalObservedBusinessCalendar: BusinessCalendar = createSkippingBusinessCalendar(
+    'us-federal-observed',
+    (isoDate) => isWeekendUtc(isoDate) || isUsFederalObservedHoliday(isoDate),
+)
 
 export const defaultBusinessCalendar = calendarDayBusinessCalendar


### PR DESCRIPTION
## Summary
- add non-default `weekday` and `us-federal-observed` app business calendars while keeping `defaultBusinessCalendar` on `calendar-day`
- mirror the inert calendars in Supabase Edge shared utilities
- add app, edge, and parity tests for weekday skipping, US federal observed holidays, negative offsets, zero offsets, weekend/year boundaries, and observed weekend holidays
- update date-engine ADR and architecture docs for the R4 slice

## Validation
- npx vitest --run Testing/unit/shared/lib/date-engine/business-calendar.test.ts Testing/unit/supabase/functions/_shared/business-calendar.test.ts Testing/unit/shared/lib/date-engine/parity.test.ts
- AGENT_MODE=true npm run verify-architecture
- npm run lint
- npm run typecheck:agent
- npx tsc --noEmit --pretty false
- npm test
- npm run build
- git diff --check

## Notes
- Runtime scheduling remains on `calendar-day`; PR R5 owns the behavior switch.