### PR TITLE
PR 1: Account lifecycle deletion hardening

### DIFF
--- a/Testing/test-utils/factories.ts
+++ b/Testing/test-utils/factories.ts
@@ -154,7 +154,7 @@ export function makeCommentWithAuthor(
 ): TaskCommentWithAuthor {
   const base = makeComment(overrides as Partial<TaskCommentRow>);
   const defaultAuthor = {
-    id: base.author_id,
+    id: base.author_id ?? faker.string.uuid(),
     email: faker.internet.email(),
     user_metadata: { full_name: faker.person.fullName() },
   };

--- a/Testing/unit/features/tasks/components/TaskComments/TaskComments.test.tsx
+++ b/Testing/unit/features/tasks/components/TaskComments/TaskComments.test.tsx
@@ -250,4 +250,24 @@ describe('TaskComments (Wave 26)', () => {
         // Count chip shows live count (2 = mineLive + replyUnderDeleted), not 3.
         expect(screen.getByTestId('task-comments-count')).toHaveTextContent('2 comments');
     });
+
+    it('renders deleted-account authors as historical comments without owner affordances', () => {
+        const deletedAuthor = makeCommentWithAuthor({
+            id: 'deleted-author',
+            task_id: 'task-1',
+            parent_comment_id: null,
+            author_id: null,
+            author: null,
+            body: 'Historical comment remains',
+        });
+        mockUseTaskComments.mockReturnValue({ data: [deletedAuthor], isLoading: false });
+
+        renderSut();
+
+        const row = screen.getByTestId('comment-deleted-author');
+        expect(row).toHaveTextContent('Deleted user');
+        expect(row).toHaveTextContent('Historical comment remains');
+        expect(row.querySelector('[data-testid="comment-edit-btn"]')).toBeNull();
+        expect(row.querySelector('[data-testid="comment-delete-btn"]')).toBeNull();
+    });
 });

--- a/Testing/unit/shared/db/schema-source.test.ts
+++ b/Testing/unit/shared/db/schema-source.test.ts
@@ -126,6 +126,22 @@ describe('docs/db/schema.sql source of truth', () => {
   expect(completionSql).not.toContain('NEW.status := CASE');
  });
 
+ it('keeps account lifecycle user references anonymizing instead of restricting auth deletion', () => {
+  expect(schema).toContain('"author_id" "uuid",');
+  expect(schema).toContain(
+   'ADD CONSTRAINT "task_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE SET NULL;',
+  );
+  expect(schema).toContain(
+   'ADD CONSTRAINT "tasks_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "auth"."users"("id") ON DELETE SET NULL;',
+  );
+  expect(schema).toContain(
+   'ADD CONSTRAINT "tasks_creator_fkey" FOREIGN KEY ("creator") REFERENCES "auth"."users"("id") ON DELETE SET NULL;',
+  );
+  expect(schema).not.toContain(
+   'ADD CONSTRAINT "task_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;',
+  );
+ });
+
  it('keeps has_permission aligned to role ownership instead of creatorship', () => {
   const functionStart = schema.indexOf('CREATE OR REPLACE FUNCTION "public"."has_permission"(');
   const functionEnd = schema.indexOf('ALTER FUNCTION "public"."has_permission"(');

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -2116,7 +2116,7 @@ CREATE TABLE IF NOT EXISTS "public"."task_comments" (
     "task_id" "uuid" NOT NULL,
     "root_id" "uuid" NOT NULL,
     "parent_comment_id" "uuid",
-    "author_id" "uuid" NOT NULL,
+    "author_id" "uuid",
     "body" "text" NOT NULL,
     "mentions" "text"[] DEFAULT ARRAY[]::"text"[] NOT NULL,
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
@@ -2696,7 +2696,7 @@ ALTER TABLE ONLY "public"."rag_chunks"
 
 
 ALTER TABLE ONLY "public"."task_comments"
-    ADD CONSTRAINT "task_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;
+    ADD CONSTRAINT "task_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE SET NULL;
 
 
 
@@ -2736,7 +2736,7 @@ ALTER TABLE ONLY "public"."task_resources"
 
 
 ALTER TABLE ONLY "public"."tasks"
-    ADD CONSTRAINT "tasks_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "auth"."users"("id");
+    ADD CONSTRAINT "tasks_assignee_id_fkey" FOREIGN KEY ("assignee_id") REFERENCES "auth"."users"("id") ON DELETE SET NULL;
 
 
 
@@ -2746,7 +2746,7 @@ ALTER TABLE ONLY "public"."tasks"
 
 
 ALTER TABLE ONLY "public"."tasks"
-    ADD CONSTRAINT "tasks_creator_fkey" FOREIGN KEY ("creator") REFERENCES "auth"."users"("id");
+    ADD CONSTRAINT "tasks_creator_fkey" FOREIGN KEY ("creator") REFERENCES "auth"."users"("id") ON DELETE SET NULL;
 
 
 

--- a/src/features/tasks/components/TaskComments/CommentItem.tsx
+++ b/src/features/tasks/components/TaskComments/CommentItem.tsx
@@ -36,7 +36,7 @@ export function CommentItem({
 }: CommentItemProps) {
     const { t } = useTranslation();
     const [mode, setMode] = useState<'view' | 'edit' | 'reply'>('view');
-    const isOwn = Boolean(currentUserId && comment.author_id && comment.author_id === currentUserId);
+    const isOwn = currentUserId !== null && comment.author_id === currentUserId;
     const isDeleted = comment.deleted_at !== null;
     const fullName =
         typeof comment.author?.user_metadata?.full_name === 'string'

--- a/src/features/tasks/components/TaskComments/CommentItem.tsx
+++ b/src/features/tasks/components/TaskComments/CommentItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Pencil, Trash2, Reply } from 'lucide-react';
 import { Avatar, AvatarFallback } from '@/shared/ui/avatar';
 import { Button } from '@/shared/ui/button';
@@ -33,14 +34,19 @@ export function CommentItem({
     onEdit,
     onDelete,
 }: CommentItemProps) {
+    const { t } = useTranslation();
     const [mode, setMode] = useState<'view' | 'edit' | 'reply'>('view');
-    const isOwn = comment.author_id === currentUserId;
+    const isOwn = Boolean(currentUserId && comment.author_id && comment.author_id === currentUserId);
     const isDeleted = comment.deleted_at !== null;
     const fullName =
         typeof comment.author?.user_metadata?.full_name === 'string'
             ? comment.author.user_metadata.full_name
             : null;
-    const displayName = fullName || comment.author?.email || 'Unknown';
+    const displayName = fullName || comment.author?.email || (
+        comment.author_id === null
+            ? t('tasks.comments.deleted_author')
+            : t('common.unknown_name')
+    );
 
     // Tombstone render — preserves thread lineage for replies without leaking
     // the original body (softDelete blanks it server-side; optimistic update
@@ -126,7 +132,7 @@ export function CommentItem({
                             data-testid="comment-reply-btn"
                             className="h-7 px-2 text-xs text-slate-500 hover:text-slate-900"
                         >
-                            <Reply className="h-3 w-3 mr-1" /> Reply
+                            <Reply className="h-3 w-3 mr-1" /> {t('tasks.comments.reply_button')}
                         </Button>
                         {isOwn && (
                             <>
@@ -138,7 +144,7 @@ export function CommentItem({
                                     data-testid="comment-edit-btn"
                                     className="h-7 px-2 text-xs text-slate-500 hover:text-slate-900"
                                 >
-                                    <Pencil className="h-3 w-3 mr-1" /> Edit
+                                    <Pencil className="h-3 w-3 mr-1" /> {t('common.edit')}
                                 </Button>
                                 <Button
                                     type="button"
@@ -148,7 +154,7 @@ export function CommentItem({
                                     data-testid="comment-delete-btn"
                                     className="h-7 px-2 text-xs text-slate-500 hover:text-rose-600"
                                 >
-                                    <Trash2 className="h-3 w-3 mr-1" /> Delete
+                                    <Trash2 className="h-3 w-3 mr-1" /> {t('common.delete')}
                                 </Button>
                             </>
                         )}

--- a/src/shared/db/database.types.ts
+++ b/src/shared/db/database.types.ts
@@ -519,7 +519,7 @@ export type Database = {
       }
       task_comments: {
         Row: {
-          author_id: string
+          author_id: string | null
           body: string
           created_at: string
           deleted_at: string | null
@@ -532,7 +532,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
-          author_id: string
+          author_id?: string | null
           body: string
           created_at?: string
           deleted_at?: string | null
@@ -545,7 +545,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
-          author_id?: string
+          author_id?: string | null
           body?: string
           created_at?: string
           deleted_at?: string | null

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -198,6 +198,10 @@
       "blocked": "Blocked",
       "completed": "Completed"
     },
+    "comments": {
+      "deleted_author": "Deleted user",
+      "reply_button": "Reply"
+    },
     "detail": {
       "select_task": "Select a task to view details",
       "purpose_heading": "Purpose (The Why)",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -204,6 +204,10 @@
       "blocked": "Bloqueada",
       "completed": "Completada"
     },
+    "comments": {
+      "deleted_author": "Usuario eliminado",
+      "reply_button": "Responder"
+    },
     "detail": {
       "select_task": "Selecciona una tarea para ver los detalles",
       "purpose_heading": "Propósito (El porqué)",

--- a/supabase/migrations/20260506000000_account_lifecycle_user_delete_fks.sql
+++ b/supabase/migrations/20260506000000_account_lifecycle_user_delete_fks.sql
@@ -1,0 +1,44 @@
+-- PR 1: account lifecycle hardening.
+--
+-- Historical project content should survive auth.users deletion for audit and
+-- collaboration continuity. Private per-user rows already cascade elsewhere;
+-- authored/assigned task history is anonymized by nulling user references.
+
+ALTER TABLE public.task_comments
+  DROP CONSTRAINT IF EXISTS task_comments_author_id_fkey;
+
+ALTER TABLE public.tasks
+  DROP CONSTRAINT IF EXISTS tasks_assignee_id_fkey;
+
+ALTER TABLE public.tasks
+  DROP CONSTRAINT IF EXISTS tasks_creator_fkey;
+
+ALTER TABLE public.task_comments
+  ALTER COLUMN author_id DROP NOT NULL;
+
+ALTER TABLE ONLY public.task_comments
+  ADD CONSTRAINT task_comments_author_id_fkey
+  FOREIGN KEY (author_id)
+  REFERENCES auth.users(id)
+  ON DELETE SET NULL;
+
+ALTER TABLE ONLY public.tasks
+  ADD CONSTRAINT tasks_assignee_id_fkey
+  FOREIGN KEY (assignee_id)
+  REFERENCES auth.users(id)
+  ON DELETE SET NULL;
+
+ALTER TABLE ONLY public.tasks
+  ADD CONSTRAINT tasks_creator_fkey
+  FOREIGN KEY (creator)
+  REFERENCES auth.users(id)
+  ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.task_comments.author_id IS
+  'Nullable after account lifecycle hardening: auth.users deletion preserves historical comments with author_id set null.';
+
+COMMENT ON CONSTRAINT tasks_creator_fkey ON public.tasks IS
+  'ON DELETE SET NULL preserves historical project/task rows when an auth user is deleted.';
+
+COMMENT ON CONSTRAINT tasks_assignee_id_fkey ON public.tasks IS
+  'ON DELETE SET NULL preserves task history while clearing deleted-user assignments.';

--- a/supabase/tests/pgtap_account_lifecycle.sql
+++ b/supabase/tests/pgtap_account_lifecycle.sql
@@ -1,0 +1,167 @@
+BEGIN;
+
+SELECT plan(12);
+
+TRUNCATE TABLE
+    public.activity_log,
+    public.notification_log,
+    public.push_subscriptions,
+    public.ics_feed_tokens,
+    public.notification_preferences,
+    public.task_comments,
+    public.project_members,
+    public.tasks
+CASCADE;
+
+DELETE FROM auth.users
+WHERE email IN (
+    'lifecycle-owner@example.com',
+    'lifecycle-deleted@example.com',
+    'lifecycle-other@example.com'
+);
+
+INSERT INTO auth.users (id, email) VALUES
+    ('00000000-0000-0000-0000-000000000401', 'lifecycle-owner@example.com'),
+    ('00000000-0000-0000-0000-000000000402', 'lifecycle-deleted@example.com'),
+    ('00000000-0000-0000-0000-000000000403', 'lifecycle-other@example.com');
+
+INSERT INTO public.tasks (id, title, status, creator, assignee_id, root_id, origin)
+VALUES (
+    '11111111-1111-1111-1111-111111111401',
+    'Lifecycle Project',
+    'not_started',
+    '00000000-0000-0000-0000-000000000401',
+    '00000000-0000-0000-0000-000000000402',
+    '11111111-1111-1111-1111-111111111401',
+    'instance'
+);
+
+INSERT INTO public.tasks (id, root_id, parent_task_id, title, status, creator, assignee_id, origin)
+VALUES (
+    '22222222-2222-2222-2222-222222222401',
+    '11111111-1111-1111-1111-111111111401',
+    '11111111-1111-1111-1111-111111111401',
+    'Deleted user authored task',
+    'todo',
+    '00000000-0000-0000-0000-000000000402',
+    '00000000-0000-0000-0000-000000000402',
+    'instance'
+);
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+    ('11111111-1111-1111-1111-111111111401', '00000000-0000-0000-0000-000000000401', 'owner'),
+    ('11111111-1111-1111-1111-111111111401', '00000000-0000-0000-0000-000000000402', 'editor');
+
+INSERT INTO public.task_comments (id, task_id, author_id, body)
+VALUES (
+    '33333333-3333-3333-3333-333333333401',
+    '22222222-2222-2222-2222-222222222401',
+    '00000000-0000-0000-0000-000000000402',
+    'Historical comment survives account deletion'
+);
+
+INSERT INTO public.push_subscriptions (id, user_id, endpoint, p256dh, auth)
+VALUES (
+    '44444444-4444-4444-4444-444444444401',
+    '00000000-0000-0000-0000-000000000402',
+    'https://push.example/lifecycle',
+    'p256dh-lifecycle',
+    'auth-lifecycle'
+);
+
+INSERT INTO public.ics_feed_tokens (id, user_id, token, label)
+VALUES (
+    '55555555-5555-5555-5555-555555555401',
+    '00000000-0000-0000-0000-000000000402',
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    'Lifecycle token'
+);
+
+INSERT INTO public.notification_log (id, user_id, channel, event_type, payload)
+VALUES (
+    '66666666-6666-6666-6666-666666666401',
+    '00000000-0000-0000-0000-000000000402',
+    'email',
+    'mention_pending',
+    '{}'::jsonb
+);
+
+SELECT lives_ok(
+    $$ DELETE FROM auth.users WHERE id = '00000000-0000-0000-0000-000000000402' $$,
+    'auth user deletion succeeds when the user authored comments, created tasks, assignments, memberships, and private rows'
+);
+
+SELECT is(
+    (SELECT author_id::text FROM public.task_comments WHERE id = '33333333-3333-3333-3333-333333333401'),
+    NULL::text,
+    'historical comments survive with author_id nulled'
+);
+
+SELECT is(
+    (SELECT creator::text FROM public.tasks WHERE id = '22222222-2222-2222-2222-222222222401'),
+    NULL::text,
+    'historical tasks survive with creator nulled'
+);
+
+SELECT is(
+    (SELECT assignee_id::text FROM public.tasks WHERE id = '22222222-2222-2222-2222-222222222401'),
+    NULL::text,
+    'historical task assignments are cleared when the assigned user is deleted'
+);
+
+SELECT is(
+    (SELECT assignee_id::text FROM public.tasks WHERE id = '11111111-1111-1111-1111-111111111401'),
+    NULL::text,
+    'root task assignment references are cleared when the assigned user is deleted'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.project_members WHERE user_id = '00000000-0000-0000-0000-000000000402'),
+    0::bigint,
+    'deleted users are removed from project memberships by cascade'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.notification_preferences WHERE user_id = '00000000-0000-0000-0000-000000000402'),
+    0::bigint,
+    'deleted users lose notification preferences by cascade'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.push_subscriptions WHERE user_id = '00000000-0000-0000-0000-000000000402'),
+    0::bigint,
+    'deleted users lose push subscriptions by cascade'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.ics_feed_tokens WHERE user_id = '00000000-0000-0000-0000-000000000402'),
+    0::bigint,
+    'deleted users lose ICS feed tokens by cascade'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.notification_log WHERE user_id = '00000000-0000-0000-0000-000000000402'),
+    0::bigint,
+    'deleted users lose private notification log rows by cascade'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000403', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000403"}', true);
+
+SELECT throws_like(
+    $$ DELETE FROM auth.users WHERE id = '00000000-0000-0000-0000-000000000401' $$,
+    '%permission denied%',
+    'authenticated users cannot delete arbitrary auth.users rows'
+);
+
+SET LOCAL ROLE postgres;
+
+SELECT is(
+    (SELECT count(*) FROM auth.users WHERE id = '00000000-0000-0000-0000-000000000401'),
+    1::bigint,
+    'failed arbitrary auth.users delete leaves the target account intact'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Findings addressed
- Removes account deletion blockers caused by historical authored content referencing auth.users through task_comments.author_id, tasks.creator, and tasks.assignee_id.
- Keeps historical comments/tasks auditable by anonymizing deleted users with ON DELETE SET NULL.
- Preserves existing private user-owned row cascades for memberships, notification preferences/logs, push subscriptions, ICS feed tokens, and admin rows.
- Prevents deleted/null authors from being treated as the current user in comment UI affordances.

## Files changed
- supabase/migrations/20260506000000_account_lifecycle_user_delete_fks.sql
- supabase/tests/pgtap_account_lifecycle.sql
- docs/db/schema.sql
- src/shared/db/database.types.ts
- src/shared/db/app.types.ts: unchanged because it derives comment row nullability from generated database types.
- src/features/tasks/components/TaskComments/CommentItem.tsx
- Testing/unit/features/tasks/components/TaskComments/TaskComments.test.tsx
- Testing/unit/shared/db/schema-source.test.ts
- Testing/test-utils/factories.ts
- src/shared/i18n/locales/en.json
- src/shared/i18n/locales/es.json

## Data/security impact
- task_comments.author_id is now nullable and SET NULL on auth user deletion.
- tasks.creator and tasks.assignee_id now SET NULL on auth user deletion.
- Memberships and private per-user rows continue to cascade on auth user deletion.
- Authenticated clients still cannot delete arbitrary auth.users rows; pgTAP covers the denied direct-delete path.
- No secrets, service-role keys, or production credentials are exposed.

## Tests added/updated
- Added pgTAP lifecycle regression proving deletion of an auth user succeeds with authored comments, created/assigned tasks, memberships, notification preferences/logs, push subscriptions, and ICS tokens.
- Added pgTAP denial test proving an authenticated user cannot directly delete another auth.users row.
- Added schema-source unit regression for the FK directions/nullability.
- Added comment rendering regression for author_id=null/author=null historical comments.
- Updated test factories for nullable author_id.

## Commands run and results
- npm test -- Testing/unit/features/tasks/components/TaskComments/TaskComments.test.tsx Testing/unit/shared/db/schema-source.test.ts Testing/unit/shared/i18n/es-json.test.ts: PASS, 3 files / 24 tests.
- npm run verify-architecture: PASS.
- npm run lint: PASS with existing warnings only, 0 errors.
- npm test: PASS, 115 files / 976 tests.
- npm run db:local:test: PASS, 4 pgTAP files / 43 tests.
- npm run build: PASS.
- npm run test:e2e:release: PASS, 5 tests.

## Rollback/migration notes
- Rollback is possible by dropping the three replacement FK constraints and recreating the previous RESTRICT/no-action constraints.
- Before restoring NOT NULL or restrictive author constraints, production data would need a backfill for any comments/tasks already anonymized by user deletion; otherwise rollback would fail or reintroduce deletion blockers.
- The migration is intentionally non-destructive: it relaxes FK delete behavior and nullability but does not delete historical task/comment rows.