### PR TITLE
Remove dead launch task controls

### DIFF
--- a/Testing/unit/features/tasks/components/TaskItem.dueBadge.test.tsx
+++ b/Testing/unit/features/tasks/components/TaskItem.dueBadge.test.tsx
@@ -168,4 +168,13 @@ describe('TaskItem due-date badge (Wave 33)', () => {
 
         expect(screen.queryByRole('button', { name: /add subtask under parent task/i })).not.toBeInTheDocument();
     });
+
+    it('hides row action controls when no backed handlers are provided', () => {
+        const task = makeTask({ id: 'actions-hidden', title: 'Actionless task', origin: 'instance' }) as TaskItemData;
+        renderTaskItem(task);
+
+        expect(screen.queryByRole('button', { name: /edit actionless task/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /add subtask under actionless task/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /invite member to actionless task/i })).not.toBeInTheDocument();
+    });
 });

--- a/Testing/unit/pages/TasksPage.test.tsx
+++ b/Testing/unit/pages/TasksPage.test.tsx
@@ -230,6 +230,16 @@ describe('TasksPage — PM-1 priority view + details dialog', () => {
         expect(screen.getByTestId('tasks-page-details-panel-title')).toHaveTextContent('Buy a domain');
     });
 
+    it('does not expose no-op row action controls on the unified tasks list', async () => {
+        renderTasksPage();
+
+        await screen.findByTestId('task-row-t-1');
+
+        expect(screen.queryByRole('button', { name: /edit buy a domain/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /add subtask under buy a domain/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /invite member to buy a domain/i })).not.toBeInTheDocument();
+    });
+
     it('opens the details dialog from the keyboard', async () => {
         const user = userEvent.setup();
         renderTasksPage();

--- a/Testing/unit/shared/i18n/en-json.test.ts
+++ b/Testing/unit/shared/i18n/en-json.test.ts
@@ -44,19 +44,14 @@ describe('en.json', () => {
     walk(en as JsonObject);
   });
 
-  it('does not expose launch-visible coming soon copy', () => {
-    const walk = (obj: JsonObject, path: string[] = []): void => {
-      for (const [k, v] of Object.entries(obj)) {
-        const keyPath = [...path, k].join('.');
-        expect(k.toLowerCase(), keyPath).not.toContain('coming_soon');
-        if (typeof v === 'string') {
-          expect(v.toLowerCase(), keyPath).not.toContain('coming soon');
-        } else if (v && typeof v === 'object' && !Array.isArray(v)) {
-          walk(v as JsonObject, [...path, k]);
-        }
-      }
-    };
-    walk(en as JsonObject);
+  it('does not expose stale Gantt coming soon copy', () => {
+    const root = en as JsonObject;
+    const projectGantt = (root.projects as JsonObject).gantt as JsonObject;
+    const routeGantt = root.gantt as JsonObject;
+
+    expect(projectGantt).not.toHaveProperty('pdf_coming_soon');
+    expect(JSON.stringify(projectGantt).toLowerCase()).not.toContain('coming soon');
+    expect(JSON.stringify(routeGantt).toLowerCase()).not.toContain('coming soon');
   });
 
   it('every plural `_one` key has a matching `_other` sibling', () => {

--- a/Testing/unit/shared/i18n/en-json.test.ts
+++ b/Testing/unit/shared/i18n/en-json.test.ts
@@ -44,6 +44,21 @@ describe('en.json', () => {
     walk(en as JsonObject);
   });
 
+  it('does not expose launch-visible coming soon copy', () => {
+    const walk = (obj: JsonObject, path: string[] = []): void => {
+      for (const [k, v] of Object.entries(obj)) {
+        const keyPath = [...path, k].join('.');
+        expect(k.toLowerCase(), keyPath).not.toContain('coming_soon');
+        if (typeof v === 'string') {
+          expect(v.toLowerCase(), keyPath).not.toContain('coming soon');
+        } else if (v && typeof v === 'object' && !Array.isArray(v)) {
+          walk(v as JsonObject, [...path, k]);
+        }
+      }
+    };
+    walk(en as JsonObject);
+  });
+
   it('every plural `_one` key has a matching `_other` sibling', () => {
     const walk = (obj: JsonObject): void => {
       const keys = Object.keys(obj);

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -155,6 +155,6 @@ The right fix is cross-cutting, not local: when the admin / account-deletion flo
 
 Flagging at the Wave 26 level so the admin-flow plan doesn't miss `task_comments` when it audits the FK surface.
 
-### Gantt PDF export deferred
+### Gantt PDF export
 
-**Active. Target: Wave 34 (Admin Management).** The gantt toolbar in `src/features/gantt/components/ProjectGantt.tsx` renders a disabled "Export PDF" button with a `title="PDF export coming soon"` tooltip. Deferred because Wave 28 intentionally ships the core timeline render + drag-shift only; print/PDF export pairs better with the Wave 34 admin reporting surface (same user flow as report scheduling). No technical blocker — wire to `window.print()` with a gantt-only print stylesheet when Wave 34 lands, or use a headless-browser export from a Deno edge function if output fidelity matters.
+**Resolved (PR 10).** The gantt toolbar in `src/features/gantt/components/ProjectGantt.tsx` renders an enabled "Export PDF" button wired to `window.print()`. The accessible label instructs users to choose "Save as PDF" in the browser print dialog. The old disabled "coming soon" copy has been removed from runtime localization strings.

--- a/src/features/tasks/components/TaskItem.tsx
+++ b/src/features/tasks/components/TaskItem.tsx
@@ -387,9 +387,9 @@ const TaskItem = ({
 
  <TaskControlButtons
  task={task}
- onEdit={() => onEdit?.(task)}
- onAddChild={() => onAddChildTask?.(task)}
- onInvite={() => onInviteMember?.(task)}
+ onEdit={onEdit ? () => onEdit(task) : undefined}
+ onAddChild={onAddChildTask ? () => onAddChildTask(task) : undefined}
+ onInvite={onInviteMember ? () => onInviteMember(task) : undefined}
  onDelete={onDeleteTask || undefined}
  canHaveChildren={canHaveChildren}
  />

--- a/src/features/tasks/components/TaskItem.tsx
+++ b/src/features/tasks/components/TaskItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import RoleIndicator from '@/shared/ui/RoleIndicator';
 import { SortableContext, useSortable } from '@dnd-kit/sortable';
@@ -181,6 +181,15 @@ const TaskItem = ({
  const isLocked = !!task.is_locked;
  const canUpdateThisStatus = canUpdateStatusForTask ? canUpdateStatusForTask(task) : canUpdateStatus !== false;
  const statusDisabled = !onStatusChange || !canUpdateThisStatus;
+ const handleEditAction = useCallback(() => {
+ onEdit?.(task);
+ }, [onEdit, task]);
+ const handleAddChildAction = useCallback(() => {
+ onAddChildTask?.(task);
+ }, [onAddChildTask, task]);
+ const handleInviteAction = useCallback(() => {
+ onInviteMember?.(task);
+ }, [onInviteMember, task]);
 
  // Wave 27: peers currently focused on this task (self-hidden, cap 3).
  // Memoize so DnD reorders / parent re-renders don't re-filter per row.
@@ -387,9 +396,9 @@ const TaskItem = ({
 
  <TaskControlButtons
  task={task}
- onEdit={onEdit ? () => onEdit(task) : undefined}
- onAddChild={onAddChildTask ? () => onAddChildTask(task) : undefined}
- onInvite={onInviteMember ? () => onInviteMember(task) : undefined}
+ onEdit={onEdit ? handleEditAction : undefined}
+ onAddChild={onAddChildTask ? handleAddChildAction : undefined}
+ onInvite={onInviteMember ? handleInviteAction : undefined}
  onDelete={onDeleteTask || undefined}
  canHaveChildren={canHaveChildren}
  />

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -112,7 +112,6 @@ export default function TasksPage() {
        const handleStatusChange = useCallback((id: string, status: string) => {
               updateTask(id, { status });
        }, [updateTask]);
-       const handleNoop = useCallback(() => { }, []);
        const handleTaskClick = useCallback((task: TaskRow) => {
               setSelectedTask(task);
        }, []);
@@ -432,8 +431,6 @@ export default function TasksPage() {
                                                                                                                               hideExpansion={true}
                                                                                                                               disableDrag={true}
                                                                                                                               onTaskClick={handleTaskClick}
-                                                                                                                              onAddChildTask={handleNoop}
-                                                                                                                              onInviteMember={handleNoop}
                                                                                                                               selectedTaskId={selectedTaskId}
                                                                                                                               parentProjectTitle={group.projectTitle}
                                                                                                                        />
@@ -458,8 +455,6 @@ export default function TasksPage() {
                                                                                                          hideExpansion={true}
                                                                                                          disableDrag={true}
                                                                                                          onTaskClick={handleTaskClick}
-                                                                                                         onAddChildTask={handleNoop}
-                                                                                                         onInviteMember={handleNoop}
                                                                                                          selectedTaskId={selectedTaskId}
                                                                                                          parentProjectTitle={projectTitle}
                                                                                                   />

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -348,8 +348,7 @@
       "no_active_projects": "No active projects yet.",
       "project_picker_label": "Project",
       "select_project": "Select a project…",
-      "untitled_project": "(untitled project)",
-      "pdf_coming_soon": "PDF export coming soon"
+      "untitled_project": "(untitled project)"
     },
     "form": {
       "title_label": "Project Title",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -354,8 +354,7 @@
       "no_active_projects": "Aún no hay proyectos activos.",
       "project_picker_label": "Proyecto",
       "select_project": "Selecciona un proyecto…",
-      "untitled_project": "(proyecto sin título)",
-      "pdf_coming_soon": "Exportación a PDF próximamente"
+      "untitled_project": "(proyecto sin título)"
     },
     "form": {
       "title_label": "Título del proyecto",


### PR DESCRIPTION
## Findings addressed
- Removed no-op row action controls from launch-visible task rows when no backed handler exists.
- Cleaned the unified `/tasks` list so row edit/add-subtask/invite buttons are absent instead of rendering as inert icons.
- Verified Gantt PDF export is already functional via `window.print()` and removed stale runtime “coming soon” localization keys.

## Files changed
- `src/features/tasks/components/TaskItem.tsx`
- `src/pages/TasksPage.tsx`
- `src/shared/i18n/locales/en.json`
- `src/shared/i18n/locales/es.json`
- `Testing/unit/features/tasks/components/TaskItem.dueBadge.test.tsx`
- `Testing/unit/pages/TasksPage.test.tsx`
- `Testing/unit/shared/i18n/en-json.test.ts`
- `docs/dev-notes.md`

## Data/security impact
- No schema, API, RLS, or permission changes.
- UI now mirrors actual available behavior: action icons only render when a real handler is wired.
- Existing project/member invite functionality remains available through backed project-level surfaces.

## Tests added/updated
- Added TaskItem coverage proving edit/add-subtask/invite row controls are hidden without backed handlers.
- Added TasksPage coverage proving the unified tasks list does not expose no-op row action controls.
- Added i18n guard against runtime “coming soon” copy.
- Existing ProjectGantt unit coverage continues to prove Export PDF calls `window.print()`.

## Commands run and results
- `npm test -- Testing/unit/pages/TasksPage.test.tsx Testing/unit/features/tasks/components/TaskItem.dueBadge.test.tsx Testing/unit/features/gantt/components/ProjectGantt.test.tsx Testing/unit/shared/i18n/en-json.test.ts Testing/unit/shared/i18n/es-json.test.ts` — passed, 5 files / 35 tests.
- `npm run verify-architecture` — passed.
- `npm run lint` — passed with the existing 6 warnings and 0 errors.
- `npm test` — passed, 122 files / 1028 tests.
- `npm run build` — passed; existing large chunk warning remains.
- `npm run db:local:test` — passed, 12 files / 135 pgTAP tests.
- `npm run test:e2e:release` — passed, 5 Playwright release tests.
- `git diff --check` — passed.
- `rg -n "coming soon|coming_soon" src -S` — no matches.

## Rollback/migration notes
- No migration or data backfill. Rollback is a standard revert of this UI/test/docs cleanup.
