### PR TITLE
Harden service worker push handling

### DIFF
--- a/Testing/unit/features/settings/hooks/usePushSubscription.test.tsx
+++ b/Testing/unit/features/settings/hooks/usePushSubscription.test.tsx
@@ -142,6 +142,30 @@ describe('usePushSubscription (Wave 30)', () => {
         expect(result.current.subscription).toBeNull();
     });
 
+    it('subscribe: service worker registration failure is contained', async () => {
+        notif.requestPermission.mockImplementation(async () => {
+            notif.setPermission('granted');
+            return 'granted' as NotificationPermission;
+        });
+        sw.register.mockRejectedValue(new Error('registration failed'));
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const { result } = renderHook(() => usePushSubscription());
+        await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+        await act(async () => {
+            await result.current.subscribe();
+        });
+
+        expect(sw.register).toHaveBeenCalledWith('/sw.js');
+        expect(sw.pushManager.subscribe).not.toHaveBeenCalled();
+        expect(mockCreate).not.toHaveBeenCalled();
+        expect(result.current.subscription).toBeNull();
+        expect(result.current.isSubscribing).toBe(false);
+        expect(errSpy).toHaveBeenCalledWith('[usePushSubscription] subscribe failed', expect.any(Error));
+        errSpy.mockRestore();
+    });
+
     it('unsubscribe: calls DELETE + clears local state', async () => {
         const row = makePushSubscription({
             user_id: 'user-abc',

--- a/Testing/unit/public/sw.test.ts
+++ b/Testing/unit/public/sw.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+
+type ServiceWorkerHandler = (event: Record<string, unknown>) => void;
+
+function loadWorker() {
+    const listeners = new Map<string, ServiceWorkerHandler>();
+    const showNotification = vi.fn().mockResolvedValue(undefined);
+    const openWindow = vi.fn().mockResolvedValue(undefined);
+    const worker = {
+        location: { origin: 'https://planter.test' },
+        skipWaiting: vi.fn(),
+        clients: {
+            claim: vi.fn(),
+            openWindow,
+        },
+        registration: {
+            showNotification,
+        },
+        addEventListener: vi.fn((eventName: string, handler: ServiceWorkerHandler) => {
+            listeners.set(eventName, handler);
+        }),
+    };
+
+    const source = readFileSync(resolve(process.cwd(), 'public/sw.js'), 'utf8');
+    vm.runInNewContext(source, { self: worker, URL });
+
+    return { listeners, showNotification, openWindow, worker };
+}
+
+function makeWaitEvent(extra: Record<string, unknown>) {
+    const waits: Promise<unknown>[] = [];
+    return {
+        event: {
+            ...extra,
+            waitUntil: vi.fn((promise: Promise<unknown>) => {
+                waits.push(Promise.resolve(promise));
+            }),
+        },
+        waits,
+    };
+}
+
+describe('public/sw.js', () => {
+    it('keeps the worker contract to lifecycle and push handlers only', () => {
+        const { listeners } = loadWorker();
+
+        expect([...listeners.keys()].sort()).toEqual(['activate', 'install', 'notificationclick', 'push']);
+        expect(listeners.has('fetch')).toBe(false);
+    });
+
+    it('sanitizes push notification URL and icon fields to same-origin paths', async () => {
+        const { listeners, showNotification } = loadWorker();
+        const { event, waits } = makeWaitEvent({
+            data: {
+                json: () => ({
+                    title: 'Task updated',
+                    body: 'Open the task',
+                    url: 'https://evil.example/project/p1',
+                    icon: 'javascript:alert(1)',
+                    tag: 123,
+                }),
+                text: () => 'fallback text',
+            },
+        });
+
+        listeners.get('push')?.(event);
+        await Promise.all(waits);
+
+        expect(showNotification).toHaveBeenCalledWith('Task updated', {
+            body: 'Open the task',
+            icon: '/icon-192.png',
+            tag: undefined,
+            data: { url: '/' },
+        });
+    });
+
+    it('preserves same-origin absolute notification URLs as paths', async () => {
+        const { listeners, showNotification } = loadWorker();
+        const { event, waits } = makeWaitEvent({
+            data: {
+                json: () => ({
+                    title: 'Mention',
+                    url: 'https://planter.test/project/p1?tab=tasks#comment-1',
+                }),
+                text: () => '',
+            },
+        });
+
+        listeners.get('push')?.(event);
+        await Promise.all(waits);
+
+        expect(showNotification).toHaveBeenCalledWith('Mention', expect.objectContaining({
+            data: { url: '/project/p1?tab=tasks#comment-1' },
+        }));
+    });
+
+    it('falls back to text payloads when push JSON parsing fails', async () => {
+        const { listeners, showNotification } = loadWorker();
+        const { event, waits } = makeWaitEvent({
+            data: {
+                json: () => {
+                    throw new Error('invalid json');
+                },
+                text: () => 'Raw push body',
+            },
+        });
+
+        listeners.get('push')?.(event);
+        await Promise.all(waits);
+
+        expect(showNotification).toHaveBeenCalledWith('PlanterPlan', expect.objectContaining({
+            body: 'Raw push body',
+            data: { url: '/' },
+        }));
+    });
+
+    it('opens only sanitized same-origin paths from notification clicks', async () => {
+        const { listeners, openWindow } = loadWorker();
+        const close = vi.fn();
+        const { event, waits } = makeWaitEvent({
+            notification: {
+                close,
+                data: { url: 'javascript:alert(1)' },
+            },
+        });
+
+        listeners.get('notificationclick')?.(event);
+        await Promise.all(waits);
+
+        expect(close).toHaveBeenCalled();
+        expect(openWindow).toHaveBeenCalledWith('/');
+    });
+});

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -145,7 +145,7 @@ and project identifiers in every `mention_pending` payload.
 
 **Active. No wave assigned.** `public/sw.js` (Wave 30 Task 2 push handler) is the only non-TypeScript file in the application tree. The styleguide calls for TS-only across `src/`; the service worker carves out one documented exception because the TS → worker build path hasn't landed yet. The PWA / workbox track that would have subsumed this file was descoped during the post-Wave-31 roadmap renumber, so there is no active plan to subsume it — the exception stays documented until a future workbox (or equivalent) rewrite is scheduled.
 
-Do not grow `sw.js`. The current handler implements `install` / `activate` / `push` / `notificationclick` and is the complete contract. Any additional SW responsibility (offline queue, asset precache) waits for the TS rewrite.
+Do not grow `sw.js` beyond lifecycle + push responsibilities. The current handler implements `install` / `activate` / `push` / `notificationclick`, intentionally omits `fetch`/cache handling to avoid stale cache poisoning, normalizes malformed push payloads, and sanitizes notification click targets to same-origin paths. Any additional SW responsibility (offline queue, asset precache) waits for the TS rewrite.
 
 ### `task_comments.author_id ON DELETE RESTRICT` blocks account deletion
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,22 +1,55 @@
 /**
  * PlanterPlan service worker — push notification handler.
  *
- * EXCEPTION: this is the only non-TypeScript file in src/. TS conversion is
- * not currently scheduled (the former Wave 32 PWA/workbox track was descoped).
- * Tracked in docs/dev-notes.md.
+ * EXCEPTION: this is the only non-TypeScript file shipped by the app. TS
+ * conversion is not currently scheduled (the former Wave 32 PWA/workbox track
+ * was descoped). Tracked in docs/dev-notes.md.
+ *
+ * This worker intentionally has no `fetch` handler and no cache storage logic:
+ * it must not precache app assets or serve stale UI while the PWA stack is
+ * descoped. Keep the contract to install/activate/push/notificationclick.
  */
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', () => self.clients.claim());
 
-self.addEventListener('push', (event) => {
-  if (!event.data) return;
+function safeText(value, fallback = '') {
+  return typeof value === 'string' && value.trim().length > 0 ? value : fallback;
+}
+
+function safePath(value, fallback = '/') {
+  const fallbackPath = fallback.startsWith('/') ? fallback : '/';
+  if (typeof value !== 'string' || value.trim().length === 0) return fallbackPath;
+  try {
+    const url = new URL(value, self.location.origin);
+    if (url.origin !== self.location.origin) return fallbackPath;
+    return `${url.pathname}${url.search}${url.hash}` || fallbackPath;
+  } catch {
+    return fallbackPath;
+  }
+}
+
+function parsePushPayload(data) {
   let payload;
   try {
-    payload = event.data.json();
+    payload = data.json();
   } catch {
-    payload = { title: 'PlanterPlan', body: event.data.text() };
+    payload = { body: data.text() };
   }
-  const { title = 'PlanterPlan', body = '', url = '/', icon = '/icon-192.png', tag } = payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    payload = { body: data.text() };
+  }
+  return {
+    title: safeText(payload.title, 'PlanterPlan'),
+    body: safeText(payload.body),
+    icon: safePath(payload.icon, '/icon-192.png'),
+    tag: typeof payload.tag === 'string' && payload.tag.trim().length > 0 ? payload.tag : undefined,
+    url: safePath(payload.url),
+  };
+}
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+  const { title, body, url, icon, tag } = parsePushPayload(event.data);
   event.waitUntil(
     self.registration.showNotification(title, { body, icon, tag, data: { url } }),
   );
@@ -24,6 +57,6 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = event.notification.data?.url || '/';
+  const url = safePath(event.notification.data?.url);
   event.waitUntil(self.clients.openWindow(url));
 });


### PR DESCRIPTION
## Findings addressed
- Hardened `public/sw.js` against malformed push payloads and unsafe notification click targets.
- Preserved the intentional no-cache/no-fetch service worker contract to avoid stale cache poisoning while the broader PWA stack remains descoped.
- Added regression coverage for graceful client behavior when service worker registration fails.

## Files changed
- `public/sw.js`
- `Testing/unit/public/sw.test.ts`
- `Testing/unit/features/settings/hooks/usePushSubscription.test.tsx`
- `docs/dev-notes.md`

## Data/security impact
- No schema, RLS, API, token, or credential changes.
- Push notification URLs and icons are now normalized to same-origin paths before display/click handling; external, `javascript:`, blank, primitive, or malformed values fall back safely.
- The service worker still has no `fetch` handler or cache storage logic, so this PR does not introduce offline caching behavior.

## Tests added/updated
- Added VM-based unit coverage for `public/sw.js` lifecycle/push/click behavior.
- Added a push subscription hook regression proving service worker registration failure is contained without creating a subscription row.
- Build verification includes `test -f build/sw.js` to prove the public worker is still emitted.

## Commands run and results
- `npm test -- Testing/unit/public/sw.test.ts Testing/unit/features/settings/hooks/usePushSubscription.test.tsx` — pass, 2 files / 12 tests.
- `npm run verify-architecture` — pass.
- `npm run lint` — pass with 6 existing warnings.
- `npm test` — pass, 123 files / 1034 tests.
- `npm run build` — pass; existing large chunk warning remains.
- `test -f build/sw.js` — pass.
- `npm run db:local:test` — pass, 12 files / 135 tests.
- `npm run test:e2e:release` — pass, 5 tests.
- `git diff --check` — pass.

## Rollback/migration notes
- No migration or backfill required.
- Rollback is a normal code revert; it would restore prior push payload handling and remove the added regression tests.
