### PR TITLE
Gate Spanish locale marketing readiness

### DIFF
--- a/Testing/unit/features/settings/components/LocaleSwitcher.test.tsx
+++ b/Testing/unit/features/settings/components/LocaleSwitcher.test.tsx
@@ -30,4 +30,17 @@ describe('LocaleSwitcher', () => {
     expect(window.localStorage.getItem('planterplan.locale')).toBe('es');
     expect(screen.getByText('Idioma')).toBeInTheDocument();
   });
+
+  it('labels Spanish as beta and review-required in the switcher', async () => {
+    renderWithProviders(<LocaleSwitcher />);
+
+    await act(async () => {
+      await i18n.changeLanguage('es');
+    });
+
+    expect(screen.getByText('Español')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    expect(screen.getByText('Revisión humana requerida antes de afirmaciones comerciales o de lanzamiento.'))
+      .toBeInTheDocument();
+  });
 });

--- a/Testing/unit/features/settings/components/LocaleSwitcher.test.tsx
+++ b/Testing/unit/features/settings/components/LocaleSwitcher.test.tsx
@@ -43,4 +43,18 @@ describe('LocaleSwitcher', () => {
     expect(screen.getByText('Revisión humana requerida antes de afirmaciones comerciales o de lanzamiento.'))
       .toBeInTheDocument();
   });
+
+  it('keeps the review-required warning visible for regional Spanish locales', async () => {
+    renderWithProviders(<LocaleSwitcher />);
+
+    await act(async () => {
+      await i18n.changeLanguage('es-MX');
+    });
+
+    expect(screen.getByText('Español')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveTextContent('Español');
+    expect(screen.getByText('Revisión humana requerida antes de afirmaciones comerciales o de lanzamiento.'))
+      .toBeInTheDocument();
+  });
 });

--- a/Testing/unit/shared/i18n/es-json.test.ts
+++ b/Testing/unit/shared/i18n/es-json.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { SUPPORTED_LOCALES } from '@/shared/i18n';
 import en from '@/shared/i18n/locales/en.json';
 import es from '@/shared/i18n/locales/es.json';
 
@@ -32,6 +33,18 @@ describe('es.json', () => {
     expect(meta.review_required_before_marketing).toBe(true);
     expect(typeof meta.status).toBe('string');
     expect(typeof meta.translated_against_en_version).toBe('string');
+  });
+
+  it('keeps Spanish runtime metadata gated until human review clears marketing readiness', () => {
+    const meta = (es as JsonObject)._meta as JsonObject;
+    const spanishLocale = SUPPORTED_LOCALES.find((locale) => locale.code === 'es');
+
+    expect(spanishLocale).toMatchObject({
+      code: 'es',
+      launchStatus: 'review_required',
+      marketingReady: false,
+      reviewRequiredBeforeMarketing: meta.review_required_before_marketing,
+    });
   });
 
   it('no empty string values outside _meta', () => {

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -6,7 +6,7 @@
 
 ## Locale catalog (Wave 31)
 * `en` — baseline, hand-authored.
-* `es` — proof of pipeline; machine-translated; **human review pending** (see `docs/dev-notes.md`).
+* `es` — proof of pipeline; machine-translated; **human review pending** (see `docs/dev-notes.md`). `SUPPORTED_LOCALES` marks it `launchStatus: 'review_required'`, `marketingReady: false`, and the Settings locale switcher labels it beta/review-required until that review flag is cleared.
 
 ## File layout
 * `src/shared/i18n/index.ts` — i18next init + supported-locale list.
@@ -29,6 +29,6 @@ Settings → Profile → LocaleSwitcher. Persisted to `localStorage.planterplan.
 ## Adding a new locale (post-Wave-31 translator workflow)
 1. Copy `en.json` to `XX.json` (XX = ISO 639-1 code).
 2. Translate; preserve interpolation (`{{count}}`) and pluralization keys (`_one`/`_other`).
-3. Append `{ code: 'XX', label: 'Native Label' }` to `SUPPORTED_LOCALES` in `src/shared/i18n/index.ts`.
+3. Append the locale to `SUPPORTED_LOCALES` in `src/shared/i18n/index.ts`, including launch metadata (`launchStatus`, `marketingReady`, `reviewRequiredBeforeMarketing`).
 4. Import + add to `resources` in the same file.
 5. Validation test (`Testing/unit/shared/i18n/XX-json.test.ts`) — copy from `es-json.test.ts`.

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -74,7 +74,7 @@ The Wave 32 plan originally scoped a third task: "project due date does not pers
 
 ### Spanish translation is machine-translated
 
-**Active (Wave 31).** `src/shared/i18n/locales/es.json` was produced by a machine-translation pass from `en.json` at commit `63c77d8`. The file's `_meta.review_required_before_marketing: true` flag is enforced by `Testing/unit/shared/i18n/es-json.test.ts`. Quality is "good enough for an internal beta" but has not been reviewed by a native Spanish speaker. **Do not market "Spanish support" on the marketing site or app store listing until a human-review pass lands.** The pipeline itself (i18next + module augmentation + locale switcher + Intl formatters) is production-ready — future locales become a translator-only workflow per `docs/architecture/i18n.md` §"Adding a new locale."
+**Active (Wave 31).** `src/shared/i18n/locales/es.json` was produced by a machine-translation pass from `en.json` at commit `63c77d8`. The file's `_meta.review_required_before_marketing: true` flag is enforced by `Testing/unit/shared/i18n/es-json.test.ts`, reflected in `SUPPORTED_LOCALES`, and surfaced in the Settings locale switcher as beta/review-required. Quality is "good enough for an internal beta" but has not been reviewed by a native Spanish speaker. **Do not market "Spanish support" on the marketing site or app store listing until a human-review pass lands.** The pipeline itself (i18next + module augmentation + locale switcher + Intl formatters) is production-ready — future locales become a translator-only workflow per `docs/architecture/i18n.md` §"Adding a new locale."
 
 ### String-extraction completion
 

--- a/src/features/settings/components/LocaleSwitcher.tsx
+++ b/src/features/settings/components/LocaleSwitcher.tsx
@@ -10,15 +10,16 @@ import { SUPPORTED_LOCALES } from '@/shared/i18n';
 
 export function LocaleSwitcher() {
   const { i18n, t } = useTranslation();
+  const activeLocaleCode = (i18n.resolvedLanguage ?? i18n.language).split('-')[0];
   const selectedLocale =
-    SUPPORTED_LOCALES.find((locale) => locale.code === i18n.language) ?? SUPPORTED_LOCALES[0];
+    SUPPORTED_LOCALES.find((locale) => locale.code === activeLocaleCode) ?? SUPPORTED_LOCALES[0];
 
   return (
-    <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:gap-3">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-3">
       <label className="pt-2 text-slate-700">{t('settings.profile.locale_label')}</label>
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col gap-3">
         <Select
-          value={i18n.language}
+          value={selectedLocale.code}
           onValueChange={(code) => void i18n.changeLanguage(code)}
         >
           <SelectTrigger className="w-56">
@@ -30,7 +31,7 @@ export function LocaleSwitcher() {
                 <span className="flex min-w-0 items-center gap-2">
                   <span>{locale.label}</span>
                   {locale.reviewRequiredBeforeMarketing ? (
-                    <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-800">
+                    <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-xs font-medium uppercase text-amber-800">
                       {t('settings.profile.locale_beta_badge')}
                     </span>
                   ) : null}

--- a/src/features/settings/components/LocaleSwitcher.tsx
+++ b/src/features/settings/components/LocaleSwitcher.tsx
@@ -10,24 +10,41 @@ import { SUPPORTED_LOCALES } from '@/shared/i18n';
 
 export function LocaleSwitcher() {
   const { i18n, t } = useTranslation();
+  const selectedLocale =
+    SUPPORTED_LOCALES.find((locale) => locale.code === i18n.language) ?? SUPPORTED_LOCALES[0];
+
   return (
-    <div className="flex items-center gap-3">
-      <label className="text-slate-700">{t('settings.profile.locale_label')}</label>
-      <Select
-        value={i18n.language}
-        onValueChange={(code) => void i18n.changeLanguage(code)}
-      >
-        <SelectTrigger className="w-48">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {SUPPORTED_LOCALES.map((l) => (
-            <SelectItem key={l.code} value={l.code}>
-              {l.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+    <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:gap-3">
+      <label className="pt-2 text-slate-700">{t('settings.profile.locale_label')}</label>
+      <div className="flex flex-col gap-1">
+        <Select
+          value={i18n.language}
+          onValueChange={(code) => void i18n.changeLanguage(code)}
+        >
+          <SelectTrigger className="w-56">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SUPPORTED_LOCALES.map((locale) => (
+              <SelectItem key={locale.code} value={locale.code}>
+                <span className="flex min-w-0 items-center gap-2">
+                  <span>{locale.label}</span>
+                  {locale.reviewRequiredBeforeMarketing ? (
+                    <span className="rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-800">
+                      {t('settings.profile.locale_beta_badge')}
+                    </span>
+                  ) : null}
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {selectedLocale.reviewRequiredBeforeMarketing ? (
+          <p className="max-w-56 text-xs leading-5 text-amber-700">
+            {t('settings.profile.locale_review_required_note')}
+          </p>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -4,6 +4,25 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import en from './locales/en.json';
 import es from './locales/es.json';
 
+export const SUPPORTED_LOCALES = [
+  {
+    code: 'en' as const,
+    label: 'English',
+    launchStatus: 'ready',
+    marketingReady: true,
+    reviewRequiredBeforeMarketing: false,
+  },
+  {
+    code: 'es' as const,
+    label: 'Español',
+    launchStatus: 'review_required',
+    marketingReady: false,
+    reviewRequiredBeforeMarketing: es._meta.review_required_before_marketing === true,
+  },
+] as const;
+
+export const SUPPORTED_LOCALE_CODES = SUPPORTED_LOCALES.map((locale) => locale.code);
+
 // Namespaces live as top-level keys inside the one translation bundle so
 // callers can write `t('domain.section.element')` with a single dotted path.
 // en-json.test.ts / es-json.test.ts assert each of these exists in en/es.json.
@@ -29,7 +48,7 @@ void i18n
   .use(initReactI18next)
   .init({
     fallbackLng: 'en',
-    supportedLngs: ['en', 'es'],
+    supportedLngs: SUPPORTED_LOCALE_CODES,
     interpolation: { escapeValue: false },
     resources: {
       en: { translation: en },
@@ -43,8 +62,3 @@ void i18n
   });
 
 export { i18n };
-
-export const SUPPORTED_LOCALES = [
-  { code: 'en' as const, label: 'English' },
-  { code: 'es' as const, label: 'Español' },
-];

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -606,6 +606,8 @@
       "organization_placeholder": "e.g. Hope City Church",
       "language_heading": "Language",
       "locale_label": "Language",
+      "locale_beta_badge": "Beta",
+      "locale_review_required_note": "Human review required before marketing or launch claims.",
       "email_preferences_heading": "Email Preferences",
       "weekly_digest": "Weekly Digest",
       "weekly_digest_description": "Get a summary of your tasks every Monday"

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -612,6 +612,8 @@
       "organization_placeholder": "p. ej. Iglesia Hope City",
       "language_heading": "Idioma",
       "locale_label": "Idioma",
+      "locale_beta_badge": "Beta",
+      "locale_review_required_note": "Revisión humana requerida antes de afirmaciones comerciales o de lanzamiento.",
       "email_preferences_heading": "Preferencias de correo electrónico",
       "weekly_digest": "Resumen semanal",
       "weekly_digest_description": "Recibe un resumen de tus tareas cada lunes"


### PR DESCRIPTION
## Findings addressed
- Preserved the Spanish `_meta.review_required_before_marketing=true` gate and made it visible in runtime locale metadata.
- Labeled Spanish as beta/review-required in the Settings locale switcher so the app does not imply launch-ready Spanish localization.
- Updated i18n architecture/dev notes to document the launch metadata requirement for supported locales.
- Addressed bot review feedback in `289acdb3`: regional locale resolution, select value normalization, standard badge text sizing, and comfortable spacing.

## Files changed
- `src/shared/i18n/index.ts`
- `src/features/settings/components/LocaleSwitcher.tsx`
- `src/shared/i18n/locales/en.json`
- `src/shared/i18n/locales/es.json`
- `Testing/unit/shared/i18n/es-json.test.ts`
- `Testing/unit/features/settings/components/LocaleSwitcher.test.tsx`
- `docs/architecture/i18n.md`
- `docs/dev-notes.md`

## Data/security impact
- No database, RLS, auth, API, token, or credential changes.
- Runtime locale metadata now marks Spanish `launchStatus: 'review_required'`, `marketingReady: false`, and mirrors the `es.json` review-required flag.
- User-facing Settings UI now shows Spanish as beta/review-required while the human-review flag remains set, including regional Spanish locales such as `es-MX`.

## Tests added/updated
- Added metadata coverage tying `SUPPORTED_LOCALES` Spanish readiness state to `es.json`.
- Added LocaleSwitcher coverage proving the Spanish beta badge and review-required note render.
- Added a regional Spanish regression proving `es-MX` still shows the review-required warning and selects the base Spanish locale.
- Existing en/es key parity remains in place for the new localized strings.

## Commands run and results
- `npm test -- Testing/unit/shared/i18n/es-json.test.ts Testing/unit/features/settings/components/LocaleSwitcher.test.tsx Testing/unit/shared/i18n/en-json.test.ts` — pass, 3 files / 14 tests after review fixes.
- `npm run verify-architecture` — pass after review fixes.
- `npm run lint` — pass with 6 existing warnings after review fixes.
- `npm test` — pass, 123 files / 1037 tests after review fixes.
- `npm run build` — pass after review fixes; existing large chunk warning remains.
- `npm run db:local:test` — pass before review fixes, 12 files / 135 tests; review fix was UI-only.
- `npm run test:e2e:release` — pass, 5 tests after review fixes.
- `git diff --check` — pass after review fixes.
- `rg -n "Spanish support|market-ready|market ready|marketing.*Spanish|Spanish.*marketing|launch-ready.*Spanish|Spanish.*launch-ready|review_required_before_marketing|marketingReady|reviewRequiredBeforeMarketing|launchStatus" docs src Testing -S` — pass; hits are the intentional guardrails/docs/tests.

## Rollback/migration notes
- No migration or backfill required.
- Rollback is a normal code revert; it would remove the runtime/display gate but leave the existing `es.json` metadata intact on main before this PR.
