### PR TITLE
Default Tasks page to all work

### DIFF
--- a/Testing/unit/pages/TasksPage.test.tsx
+++ b/Testing/unit/pages/TasksPage.test.tsx
@@ -94,6 +94,7 @@ vi.mock('@/shared/api/planterClient', () => {
         {
             id: 't-2',
             title: 'Write welcome letter',
+            description: 'Draft the first-time guest follow-up copy',
             parent_task_id: 'm-launch',
             root_id: 'p-alpha',
             origin: 'instance',
@@ -195,9 +196,21 @@ function renderTasksPage() {
     );
 }
 
-describe('TasksPage — PM-1 priority view + details dialog', () => {
+describe('TasksPage — global tasks view + details dialog', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        if (!HTMLElement.prototype.hasPointerCapture) {
+            HTMLElement.prototype.hasPointerCapture = vi.fn(() => false);
+        }
+        if (!HTMLElement.prototype.setPointerCapture) {
+            HTMLElement.prototype.setPointerCapture = vi.fn();
+        }
+        if (!HTMLElement.prototype.releasePointerCapture) {
+            HTMLElement.prototype.releasePointerCapture = vi.fn();
+        }
+        if (!HTMLElement.prototype.scrollIntoView) {
+            HTMLElement.prototype.scrollIntoView = vi.fn();
+        }
     });
 
     it('does not render the details panel until a task is clicked', async () => {
@@ -206,8 +219,25 @@ describe('TasksPage — PM-1 priority view + details dialog', () => {
         expect(screen.queryByTestId('tasks-page-details-panel')).not.toBeInTheDocument();
     });
 
-    it('defaults to the grouped priority view and hides empty or non-qualifying rows', async () => {
+    it('defaults to all actionable work and excludes root project rows', async () => {
         renderTasksPage();
+
+        expect(await screen.findByRole('heading', { name: 'All Tasks' })).toBeInTheDocument();
+        expect(screen.getByText('Showing 7 of 7 work items')).toBeInTheDocument();
+        expect(screen.getByText('Empty Milestone')).toBeInTheDocument();
+        expect(screen.getByText('Future hidden task')).toBeInTheDocument();
+        expect(screen.getByLabelText('Sort order')).toBeInTheDocument();
+        expect(screen.queryByTestId('task-row-p-alpha')).not.toBeInTheDocument();
+    });
+
+    it('keeps priority available as an explicit quick filter', async () => {
+        const user = userEvent.setup();
+        renderTasksPage();
+
+        await screen.findByRole('heading', { name: 'All Tasks' });
+
+        await user.click(screen.getByRole('combobox', { name: 'Task view' }));
+        await user.click(await screen.findByRole('option', { name: 'Priority' }));
 
         expect(await screen.findByRole('heading', { name: 'Priority' })).toBeInTheDocument();
         expect(screen.getByTestId('priority-task-group-milestone-m-launch')).toBeInTheDocument();
@@ -215,6 +245,27 @@ describe('TasksPage — PM-1 priority view + details dialog', () => {
         expect(screen.queryByText('Empty Milestone')).not.toBeInTheDocument();
         expect(screen.queryByText('Future hidden task')).not.toBeInTheDocument();
         expect(screen.queryByLabelText('Sort order')).not.toBeInTheDocument();
+    });
+
+    it('searches title, description, and project context inside the RLS-visible task list', async () => {
+        const user = userEvent.setup();
+        renderTasksPage();
+
+        await screen.findByText('Buy a domain');
+        const search = screen.getByRole('searchbox', { name: 'Search tasks and projects' });
+
+        await user.type(search, 'guest follow-up');
+        expect(await screen.findByText('Write welcome letter')).toBeInTheDocument();
+        expect(screen.queryByText('Buy a domain')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Clear task search' }));
+        await user.type(search, 'Alpha Project');
+        expect(await screen.findByText('Buy a domain')).toBeInTheDocument();
+        expect(screen.getByText('Future hidden task')).toBeInTheDocument();
+
+        await user.clear(search);
+        await user.type(search, 'does-not-exist');
+        expect(await screen.findByText('No tasks match your search and filters.')).toBeInTheDocument();
     });
 
     it('opens the details dialog with the clicked task', async () => {

--- a/Testing/unit/shared/db/schema-source.test.ts
+++ b/Testing/unit/shared/db/schema-source.test.ts
@@ -150,6 +150,20 @@ describe('docs/db/schema.sql source of truth', () => {
   );
  });
 
+ it('keeps task reads scoped to every project member role', () => {
+  const selectPolicyStart = schema.indexOf('CREATE POLICY "Enable read access for all users" ON "public"."tasks" FOR SELECT');
+  const selectPolicyEnd = schema.indexOf('CREATE POLICY "Enable update for coaches on coaching tasks"', selectPolicyStart);
+  const selectPolicySql = schema.slice(selectPolicyStart, selectPolicyEnd);
+
+  expect(selectPolicyStart).toBeGreaterThanOrEqual(0);
+  expect(selectPolicyEnd).toBeGreaterThan(selectPolicyStart);
+  expect(selectPolicySql).toContain('"public"."has_project_role"(COALESCE("root_id", "id")');
+  for (const role of ['owner', 'editor', 'coach', 'viewer', 'limited']) {
+   expect(selectPolicySql).toContain(`'${role}'::"text"`);
+  }
+  expect(selectPolicySql).toContain('"public"."is_admin"');
+ });
+
  it('keeps ICS token revocation one-way below the UI', () => {
   const sql = functionSql('enforce_ics_feed_token_update_scope');
 

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -9,8 +9,9 @@ import { planter } from '@/shared/api/planterClient';
 import { STALE_TIMES } from '@/shared/lib/react-query-config';
 import TaskItem from '@/features/tasks/components/TaskItem';
 import TaskDetailsPanel from '@/features/tasks/components/TaskDetailsPanel';
-import { Loader2, List, LayoutGrid, X } from 'lucide-react';
+import { Loader2, List, LayoutGrid, Search, X } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
+import { Input } from '@/shared/ui/input';
 import ProjectBoardView from '@/features/tasks/components/board/ProjectBoardView';
 import { useAuth } from '@/shared/contexts/AuthContext';
 import { useTeam } from '@/features/people/hooks/useTeam';
@@ -62,11 +63,12 @@ export default function TasksPage() {
        const invalidateTasks = useCallback(() => queryClient.invalidateQueries({ queryKey: ['tasks'] }), [queryClient]);
 
        const [viewMode, setViewMode] = useState('list');
-       const [filter, setFilter] = useState<TaskFilterKey>('priority');
+       const [filter, setFilter] = useState<TaskFilterKey>('all_tasks');
        const [sort, setSort] = useState<TaskSortKey>('chronological');
        const [selectedTask, setSelectedTask] = useState<TaskRow | null>(null);
        const [dueStart, setDueStart] = useState<string>('');
        const [dueEnd, setDueEnd] = useState<string>('');
+       const [searchQuery, setSearchQuery] = useState<string>('');
        const dueDateRange = useMemo<DueDateRange>(
               () => ({ start: dueStart || null, end: dueEnd || null }),
               [dueStart, dueEnd],
@@ -201,14 +203,6 @@ export default function TasksPage() {
               ? canDeleteTaskForRole(selectedMembershipRole, selectedTaskForPanel)
               : false;
 
-       const visibleTasks = useTaskFilters({ tasks, filter, sort: effectiveSort, dueDateRange, currentUserId });
-       const priorityGroups = useMemo(
-              () => filter === 'priority' && viewMode === 'list'
-                     ? buildPriorityTaskGroups({ tasks, candidateTasks: visibleTasks })
-                     : [],
-              [filter, tasks, viewMode, visibleTasks],
-       );
-
        // Wave 33: map of root-task-id → project title, used to reveal each task's
        // parent-project name in a hover tooltip on the row. Projects live in the
        // same `tasks` list (roots have `parent_task_id === null`).
@@ -221,6 +215,34 @@ export default function TasksPage() {
               }
               return map;
        }, [tasks]);
+       const actionableTaskCount = useMemo(
+              () => tasks.filter((task) => task.origin === 'instance' && task.parent_task_id !== null).length,
+              [tasks],
+       );
+       const filteredTasks = useTaskFilters({ tasks, filter, sort: effectiveSort, dueDateRange, currentUserId });
+       const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+       const visibleTasks = useMemo(() => {
+              if (!normalizedSearchQuery) return filteredTasks;
+
+              return filteredTasks.filter((task) => {
+                     const projectTitle = task.root_id ? projectTitleByRootId.get(task.root_id) : null;
+                     const haystack = [
+                            task.title,
+                            task.description,
+                            projectTitle,
+                     ]
+                            .filter((value): value is string => typeof value === 'string' && value.length > 0)
+                            .join(' ')
+                            .toLowerCase();
+                     return haystack.includes(normalizedSearchQuery);
+              });
+       }, [filteredTasks, normalizedSearchQuery, projectTitleByRootId]);
+       const priorityGroups = useMemo(
+              () => filter === 'priority' && viewMode === 'list'
+                     ? buildPriorityTaskGroups({ tasks, candidateTasks: visibleTasks })
+                     : [],
+              [filter, tasks, viewMode, visibleTasks],
+       );
 
        const sensors = useSensors(
               useSensor(PointerSensor, {
@@ -289,9 +311,38 @@ export default function TasksPage() {
                                                  <div>
                                                         <h1 className="text-3xl font-bold text-slate-900 tracking-tight">{t(`tasks.filters.labels.${filter}`)}</h1>
                                                         <p className="text-muted-foreground mt-1">{t('tasks.page_subtitle')}</p>
+                                                        <p className="mt-2 text-sm text-muted-foreground" aria-live="polite">
+                                                               {t('tasks.result_count', { shown: visibleTasks.length, total: actionableTaskCount })}
+                                                        </p>
                                                  </div>
 
                                                  <div className="flex flex-wrap items-center gap-3">
+                                                        <div className="flex flex-col gap-1">
+                                                               <label htmlFor="task-search" className="text-xs font-medium text-muted-foreground">{t('tasks.search_label')}</label>
+                                                               <div className="relative">
+                                                                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+                                                                      <Input
+                                                                             id="task-search"
+                                                                             type="search"
+                                                                             value={searchQuery}
+                                                                             onChange={(event) => setSearchQuery(event.target.value)}
+                                                                             placeholder={t('tasks.search_placeholder')}
+                                                                             aria-label={t('tasks.search_aria')}
+                                                                             className="w-[220px] bg-card pl-9 pr-9"
+                                                                      />
+                                                                      {searchQuery && (
+                                                                             <button
+                                                                                    type="button"
+                                                                                    onClick={() => setSearchQuery('')}
+                                                                                    className="absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:text-card-foreground"
+                                                                                    aria-label={t('tasks.clear_search')}
+                                                                             >
+                                                                                    <X className="h-4 w-4" aria-hidden="true" />
+                                                                             </button>
+                                                                      )}
+                                                               </div>
+                                                        </div>
+
                                                         <div className="flex flex-col gap-1">
                                                                <label htmlFor="task-filter" className="text-xs font-medium text-muted-foreground">{t('tasks.view_label')}</label>
                                                                <Select value={filter} onValueChange={(v) => setFilter(v as TaskFilterKey)}>
@@ -387,7 +438,11 @@ export default function TasksPage() {
                                           <div className="h-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-8 w-full">
                                                  {visibleTasks.length === 0 ? (
                                                         <div className="bg-card rounded-xl border border-border shadow-sm p-12 text-center">
-                                                               <p className="text-muted-foreground">{t(`tasks.filters.empty.${filter}`)}</p>
+                                                               <p className="text-muted-foreground">
+                                                                      {normalizedSearchQuery
+                                                                             ? t('tasks.search_empty')
+                                                                             : t(`tasks.filters.empty.${filter}`)}
+                                                               </p>
                                                         </div>
                                                  ) : (
                                                         viewMode === 'list' ? (

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -328,7 +328,7 @@ export default function TasksPage() {
                                                                              onChange={(event) => setSearchQuery(event.target.value)}
                                                                              placeholder={t('tasks.search_placeholder')}
                                                                              aria-label={t('tasks.search_aria')}
-                                                                             className="w-[220px] bg-card pl-9 pr-9"
+                                                                             className="w-56 bg-card pl-9 pr-9"
                                                                       />
                                                                       {searchQuery && (
                                                                              <button

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -41,7 +41,7 @@
     "enter_email": "Enter email"
   },
   "nav": {
-    "my_tasks": "My Tasks",
+    "my_tasks": "Tasks",
     "reports": "Reports",
     "team": "Team",
     "projects": "Projects",
@@ -103,8 +103,8 @@
     "unexpected_error": "An unexpected error occurred"
   },
   "tasks": {
-    "page_title": "My Tasks",
-    "page_subtitle": "Review and manage your assignments across all projects",
+    "page_title": "Tasks",
+    "page_subtitle": "Review and manage work across all projects",
     "delete_confirm_title": "Delete \"{{title}}\"?",
     "delete_confirm_description": "This also deletes every subtask under it. This action cannot be undone.",
     "delete_success": "Task deleted",
@@ -136,6 +136,12 @@
     "status_for_aria": "Status for {{title}}",
     "title_with_project_aria": "{{title}} — {{project}}",
     "view_label": "View",
+    "search_label": "Search",
+    "search_placeholder": "Search tasks or projects…",
+    "search_aria": "Search tasks and projects",
+    "search_empty": "No tasks match your search and filters.",
+    "clear_search": "Clear task search",
+    "result_count": "Showing {{shown}} of {{total}} work items",
     "view_list": "List View",
     "view_board": "Board View",
     "view_aria": "Task view",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -47,7 +47,7 @@
     "enter_email": "Introduce el correo electrónico"
   },
   "nav": {
-    "my_tasks": "Mis tareas",
+    "my_tasks": "Tareas",
     "reports": "Informes",
     "team": "Equipo",
     "projects": "Proyectos",
@@ -109,8 +109,8 @@
     "unexpected_error": "Se produjo un error inesperado"
   },
   "tasks": {
-    "page_title": "Mis tareas",
-    "page_subtitle": "Revisa y gestiona tus asignaciones en todos los proyectos",
+    "page_title": "Tareas",
+    "page_subtitle": "Revisa y gestiona el trabajo en todos los proyectos",
     "delete_confirm_title": "¿Eliminar \"{{title}}\"?",
     "delete_confirm_description": "Esto también elimina todas las subtareas asociadas. Esta acción no se puede deshacer.",
     "delete_success": "Tarea eliminada",
@@ -142,6 +142,12 @@
     "status_for_aria": "Estado de {{title}}",
     "title_with_project_aria": "{{title}} — {{project}}",
     "view_label": "Vista",
+    "search_label": "Buscar",
+    "search_placeholder": "Buscar tareas o proyectos…",
+    "search_aria": "Buscar tareas y proyectos",
+    "search_empty": "Ninguna tarea coincide con tu búsqueda y filtros.",
+    "clear_search": "Borrar búsqueda de tareas",
+    "result_count": "Mostrando {{shown}} de {{total}} elementos de trabajo",
     "view_list": "Vista de lista",
     "view_board": "Vista de tablero",
     "view_aria": "Vista de tareas",


### PR DESCRIPTION
## Findings addressed
- `/tasks` defaulted to the Priority filter, which intentionally hid non-priority work and made the global task surface look incomplete.
- The global task surface had no task/project search or visible count to explain filtered subsets.
- Added a schema-source regression assertion that task SELECT remains scoped to all project member roles/admins, so the UI continues to rely on RLS-visible source data rather than privileged reads.

## Files changed
- `src/pages/TasksPage.tsx`
- `src/shared/i18n/locales/en.json`
- `src/shared/i18n/locales/es.json`
- `Testing/unit/pages/TasksPage.test.tsx`
- `Testing/unit/shared/db/schema-source.test.ts`

## Data/security impact
- No schema or data migration.
- No permission broadening. The UI still reads through `planter.entities.Task.list()` under existing Supabase RLS.
- Added a regression test that the task SELECT policy keeps owner/editor/coach/viewer/limited/admin visibility paths represented in `docs/db/schema.sql`.

## Tests added/updated
- Updated TasksPage tests for All Tasks default behavior, Priority as explicit filter, title/description/project-context search, root-project exclusion, and existing due-date filtering/details behavior.
- Added schema-source test coverage for task RLS read roles.
- Existing i18n key parity test covers new English/Spanish task strings.

## Commands run and results
- `npm test -- Testing/unit/pages/TasksPage.test.tsx` — passed, 12 tests.
- `npm test -- Testing/unit/shared/db/schema-source.test.ts` — passed, 18 tests.
- `npm test -- Testing/unit/shared/i18n/es-json.test.ts` — passed, 6 tests.
- `npm run verify-architecture` — passed.
- `npm run lint` — passed with 4 pre-existing Fast Refresh warnings in `AuthContext.tsx` and `confirm-dialog.tsx`.
- `npm test` — passed, 125 files / 1044 tests. Vitest still prints the existing intentional AuthContext negative-test error while passing.
- `npm run build` — passed. Vite reports the existing large chunk warning.
- `npm run db:local:test` — passed, 12 pgTAP files / 135 tests.
- `npm run test:e2e:release` — passed, 8 Playwright release tests.

## Rollback/migration notes
- Rollback is a normal revert of this commit.
- No database rollback required.
