### PR TITLE
Complete minimal team roster route

### DIFF
--- a/Testing/e2e/features/release/critical-regressions.feature
+++ b/Testing/e2e/features/release/critical-regressions.feature
@@ -5,6 +5,8 @@ Feature: Release critical regression coverage
 
   Scenario: Completion cascade, rollups, phase unlock, and write guardrails
     Given a release regression project tree exists
+    When the signed-in release user opens the team roster route
+    Then the team roster route shows the project member profile
     When the user completes a parent task with an open subtask through the UI
     Then the parent, child, rollup, and dependent phase states are persisted correctly
     When invalid release hierarchy and date-envelope writes are attempted through Supabase

--- a/Testing/e2e/steps/release-regressions.steps.ts
+++ b/Testing/e2e/steps/release-regressions.steps.ts
@@ -302,6 +302,19 @@ Given('a release regression project tree exists', async ({ page }) => {
   stateByPage.set(page, { owner, ids });
 });
 
+When('the signed-in release user opens the team roster route', async ({ page }) => {
+  const state = requireState(page);
+  await page.goto(`/team?project=${state.ids.projectId}`);
+});
+
+Then('the team roster route shows the project member profile', async ({ page }) => {
+  const state = requireState(page);
+  await expect(page.getByRole('heading', { name: new RegExp(`Release Regression Project .* Team`) })).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.locator('[data-testid="team-member-card"]').filter({ hasText: state.owner.email }).first(),
+  ).toBeVisible();
+});
+
 When('the user completes a parent task with an open subtask through the UI', async ({ page }) => {
   const state = requireState(page);
   await page.goto(`/project/${state.ids.projectId}`);

--- a/Testing/unit/app/App.routing.test.tsx
+++ b/Testing/unit/app/App.routing.test.tsx
@@ -32,6 +32,10 @@ vi.mock('@/pages/ResetPassword', () => ({
   default: () => <div data-testid="reset-password-page" />,
 }));
 
+vi.mock('@/pages/Team', () => ({
+  default: () => <div data-testid="team-page" />,
+}));
+
 import App from '@/app/App';
 
 describe('App routing', () => {
@@ -54,5 +58,13 @@ describe('App routing', () => {
     render(<App />);
 
     expect(await screen.findByTestId('reset-password-page')).toBeInTheDocument();
+  });
+
+  it('serves /team as an authenticated roster route', async () => {
+    window.history.pushState({}, '', '/team?project=proj-1');
+
+    render(<App />);
+
+    expect(await screen.findByTestId('team-page')).toBeInTheDocument();
   });
 });

--- a/Testing/unit/features/people/hooks/useTeam.test.ts
+++ b/Testing/unit/features/people/hooks/useTeam.test.ts
@@ -5,19 +5,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ---- Mocks ----
 const mockProjectGet = vi.fn();
-const mockTeamMemberFilter = vi.fn();
-const mockTeamMemberList = vi.fn();
-const mockTeamMemberCreate = vi.fn();
+const mockListTeamMembersWithProfiles = vi.fn();
+const mockInviteMemberByEmail = vi.fn();
 const mockTeamMemberDelete = vi.fn();
 
 vi.mock('@/shared/api/planterClient', () => ({
   planter: {
     entities: {
-      Project: { get: (...args: unknown[]) => mockProjectGet(...args) },
+      Project: {
+        get: (...args: unknown[]) => mockProjectGet(...args),
+        inviteMemberByEmail: (...args: unknown[]) => mockInviteMemberByEmail(...args),
+      },
       TeamMember: {
-        filter: (...args: unknown[]) => mockTeamMemberFilter(...args),
-        list: (...args: unknown[]) => mockTeamMemberList(...args),
-        create: (...args: unknown[]) => mockTeamMemberCreate(...args),
+        listByProjectWithProfiles: (...args: unknown[]) => mockListTeamMembersWithProfiles(...args),
         delete: (...args: unknown[]) => mockTeamMemberDelete(...args),
       },
     },
@@ -30,6 +30,10 @@ vi.mock('@/shared/contexts/AuthContext', () => ({
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 import { useTeam } from '@/features/people/hooks/useTeam';
@@ -49,29 +53,25 @@ describe('useTeam', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProjectGet.mockResolvedValue({ id: 'p1', title: 'Test Project' });
-    mockTeamMemberFilter.mockResolvedValue([
-      { id: 'm1', project_id: 'p1', user_id: 'u1', role: 'editor' },
-    ]);
-    mockTeamMemberList.mockResolvedValue([
-      { id: 'm1', project_id: 'p1', user_id: 'u1', role: 'editor' },
-      { id: 'm2', project_id: 'p2', user_id: 'u2', role: 'viewer' },
+    mockListTeamMembersWithProfiles.mockResolvedValue([
+      { id: 'm1', project_id: 'p1', user_id: 'u1', role: 'editor', email: 'u1@example.com' },
     ]);
   });
 
-  it('fetches team members filtered by projectId', async () => {
+  it('fetches hydrated team members filtered by projectId', async () => {
     const { result } = renderHook(() => useTeam('p1'), { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockTeamMemberFilter).toHaveBeenCalledWith({ project_id: 'p1' });
+    expect(mockListTeamMembersWithProfiles).toHaveBeenCalledWith('p1');
     expect(result.current.teamMembers).toHaveLength(1);
   });
 
-  it('fetches all team members when projectId is null', async () => {
+  it('does not fetch team members when projectId is null', async () => {
     const { result } = renderHook(() => useTeam(null), { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(mockTeamMemberList).toHaveBeenCalled();
-    expect(result.current.teamMembers).toHaveLength(2);
+    expect(mockListTeamMembersWithProfiles).not.toHaveBeenCalled();
+    expect(result.current.teamMembers).toEqual([]);
   });
 
   it('fetches project data when projectId is provided', async () => {
@@ -106,8 +106,8 @@ describe('useTeam', () => {
     });
   });
 
-  it('addMember injects current user id', async () => {
-    mockTeamMemberCreate.mockResolvedValue({ id: 'm3' });
+  it('addMember delegates to the owner-only email invite path', async () => {
+    mockInviteMemberByEmail.mockResolvedValue({ message: 'ok', user: { id: 'u3', email: 'new@example.com' } });
 
     const { result } = renderHook(() => useTeam('p1'), { wrapper: createWrapper() });
 
@@ -123,17 +123,12 @@ describe('useTeam', () => {
     });
 
     await waitFor(() => {
-      expect(mockTeamMemberCreate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          user_id: 'current-user-1',
-          project_id: 'p1',
-        }),
-      );
+      expect(mockInviteMemberByEmail).toHaveBeenCalledWith('p1', 'new@example.com', 'editor');
     });
   });
 
   it('defaults teamMembers to empty array', () => {
-    mockTeamMemberFilter.mockResolvedValue(undefined);
+    mockListTeamMembersWithProfiles.mockResolvedValue(undefined);
     const { result } = renderHook(() => useTeam('p1'), { wrapper: createWrapper() });
     expect(result.current.teamMembers).toEqual([]);
   });

--- a/Testing/unit/features/people/hooks/useTeam.test.ts
+++ b/Testing/unit/features/people/hooks/useTeam.test.ts
@@ -52,7 +52,7 @@ function createWrapper() {
 describe('useTeam', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockProjectGet.mockResolvedValue({ id: 'p1', title: 'Test Project' });
+    mockProjectGet.mockResolvedValue({ id: 'p1', title: 'Test Project', origin: 'instance', parent_task_id: null });
     mockListTeamMembersWithProfiles.mockResolvedValue([
       { id: 'm1', project_id: 'p1', user_id: 'u1', role: 'editor', email: 'u1@example.com' },
     ]);
@@ -88,6 +88,19 @@ describe('useTeam', () => {
 
     await new Promise(r => setTimeout(r, 50));
     expect(mockProjectGet).not.toHaveBeenCalled();
+  });
+
+  it('does not call the roster RPC for template roots', async () => {
+    mockProjectGet.mockResolvedValue({ id: 'tmpl-1', title: 'Template Root', origin: 'template', parent_task_id: null });
+
+    const { result } = renderHook(() => useTeam('tmpl-1'), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(mockProjectGet).toHaveBeenCalledWith('tmpl-1');
+    });
+
+    expect(mockListTeamMembersWithProfiles).not.toHaveBeenCalled();
+    expect(result.current.teamMembers).toEqual([]);
   });
 
   it('deleteMember calls delete and invalidates queries', async () => {

--- a/Testing/unit/features/projects/hooks/useProjectData.test.ts
+++ b/Testing/unit/features/projects/hooks/useProjectData.test.ts
@@ -6,14 +6,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // ---- Mocks ----
 const mockGetWithStats = vi.fn();
 const mockTaskFilter = vi.fn();
-const mockTeamMemberFilter = vi.fn();
+const mockListTeamMembersWithProfiles = vi.fn();
 
 vi.mock('@/shared/api/planterClient', () => ({
   planter: {
     entities: {
       Project: { getWithStats: (...args: unknown[]) => mockGetWithStats(...args) },
       Task: { filter: (...args: unknown[]) => mockTaskFilter(...args) },
-      TeamMember: { filter: (...args: unknown[]) => mockTeamMemberFilter(...args) },
+      TeamMember: { listByProjectWithProfiles: (...args: unknown[]) => mockListTeamMembersWithProfiles(...args) },
     },
   },
 }));
@@ -38,7 +38,7 @@ describe('useProjectData', () => {
     vi.clearAllMocks();
     mockGetWithStats.mockResolvedValue({ data: { id: projectId, title: 'Test Project' } });
     mockTaskFilter.mockResolvedValue([]);
-    mockTeamMemberFilter.mockResolvedValue([]);
+    mockListTeamMembersWithProfiles.mockResolvedValue([]);
   });
 
   describe('disabled states', () => {
@@ -48,7 +48,7 @@ describe('useProjectData', () => {
       expect(result.current.project).toBeUndefined();
       expect(mockGetWithStats).not.toHaveBeenCalled();
       expect(mockTaskFilter).not.toHaveBeenCalled();
-      expect(mockTeamMemberFilter).not.toHaveBeenCalled();
+      expect(mockListTeamMembersWithProfiles).not.toHaveBeenCalled();
     });
 
     it('does not fetch when projectId is undefined', () => {
@@ -89,7 +89,7 @@ describe('useProjectData', () => {
 
     it('fetches team members by project_id', async () => {
       const members = [{ id: 'm1', project_id: projectId, user_id: 'u1', role: 'editor' }];
-      mockTeamMemberFilter.mockResolvedValue(members);
+      mockListTeamMembersWithProfiles.mockResolvedValue(members);
 
       const { result } = renderHook(() => useProjectData(projectId), { wrapper: createWrapper() });
 
@@ -97,7 +97,7 @@ describe('useProjectData', () => {
         expect(result.current.teamMembers).toEqual(members);
       });
 
-      expect(mockTeamMemberFilter).toHaveBeenCalledWith({ project_id: projectId });
+      expect(mockListTeamMembersWithProfiles).toHaveBeenCalledWith(projectId);
     });
 
     it('defaults teamMembers to empty array', async () => {

--- a/Testing/unit/pages/Team.test.tsx
+++ b/Testing/unit/pages/Team.test.tsx
@@ -1,0 +1,134 @@
+import { MemoryRouter } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '@test/render-with-providers';
+import Team from '@/pages/Team';
+
+const mockProjectList = vi.fn();
+const mockProjectGet = vi.fn();
+const mockListTeamMembersWithProfiles = vi.fn();
+const mockDeleteMember = vi.fn();
+let mockUser = { id: 'owner-user', email: 'owner@example.com', role: 'viewer' };
+
+vi.mock('@/shared/api/planterClient', () => ({
+  planter: {
+    entities: {
+      Project: {
+        list: (...args: unknown[]) => mockProjectList(...args),
+        get: (...args: unknown[]) => mockProjectGet(...args),
+      },
+      TeamMember: {
+        listByProjectWithProfiles: (...args: unknown[]) => mockListTeamMembersWithProfiles(...args),
+        delete: (...args: unknown[]) => mockDeleteMember(...args),
+      },
+    },
+  },
+}));
+
+vi.mock('@/shared/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser, loading: false }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function renderTeam(initialPath = '/team?project=p1') {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Team />
+    </MemoryRouter>,
+  );
+}
+
+describe('Team page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = { id: 'owner-user', email: 'owner@example.com', role: 'viewer' };
+    mockProjectList.mockResolvedValue([{ id: 'p1', title: 'Launch Project' }]);
+    mockProjectGet.mockResolvedValue({ id: 'p1', title: 'Launch Project' });
+    mockListTeamMembersWithProfiles.mockResolvedValue([
+      {
+        id: 'm-owner',
+        project_id: 'p1',
+        user_id: 'owner-user',
+        role: 'owner',
+        joined_at: '2026-05-07T00:00:00Z',
+        email: 'owner@example.com',
+        first_name: 'Owner',
+        last_name: 'Person',
+        display_name: 'Owner Person',
+        avatar_url: null,
+      },
+      {
+        id: 'm-editor',
+        project_id: 'p1',
+        user_id: 'editor-user',
+        role: 'editor',
+        joined_at: null,
+        email: 'editor@example.com',
+        first_name: 'Ed',
+        last_name: 'Itor',
+        display_name: 'Ed Itor',
+        avatar_url: null,
+      },
+    ]);
+    mockDeleteMember.mockResolvedValue(true);
+  });
+
+  it('renders the selected project roster with hydrated names and roles', async () => {
+    renderTeam();
+
+    expect(await screen.findByRole('heading', { name: 'Launch Project Team' })).toBeInTheDocument();
+    expect(screen.getByText('Owner Person')).toBeInTheDocument();
+    expect(screen.getByText('editor@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Editor')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add member/i })).toBeInTheDocument();
+    expect(mockListTeamMembersWithProfiles).toHaveBeenCalledWith('p1');
+  });
+
+  it('shows project selection guidance when no project is selected', async () => {
+    renderTeam('/team');
+
+    expect(await screen.findByRole('heading', { name: 'Team' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Project')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Select a project' })).toBeInTheDocument();
+    expect(mockListTeamMembersWithProfiles).not.toHaveBeenCalled();
+  });
+
+  it('hides member-management actions from non-owner project members', async () => {
+    mockUser = { id: 'viewer-user', email: 'viewer@example.com', role: 'viewer' };
+    mockListTeamMembersWithProfiles.mockResolvedValue([
+      {
+        id: 'm-viewer',
+        project_id: 'p1',
+        user_id: 'viewer-user',
+        role: 'viewer',
+        joined_at: null,
+        email: 'viewer@example.com',
+        first_name: null,
+        last_name: null,
+        display_name: 'Viewer Person',
+        avatar_url: null,
+      },
+    ]);
+
+    renderTeam();
+
+    expect(await screen.findByText('Viewer Person')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add member/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+  });
+
+  it('confirms before removing another member', async () => {
+    const user = userEvent.setup();
+    renderTeam();
+
+    await screen.findByText('Ed Itor');
+    await user.click(screen.getByRole('button', { name: 'Remove Ed Itor' }));
+    await user.click(await screen.findByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => expect(mockDeleteMember).toHaveBeenCalledWith('m-editor'));
+  });
+});

--- a/Testing/unit/pages/Team.test.tsx
+++ b/Testing/unit/pages/Team.test.tsx
@@ -47,7 +47,7 @@ describe('Team page', () => {
     vi.clearAllMocks();
     mockUser = { id: 'owner-user', email: 'owner@example.com', role: 'viewer' };
     mockProjectList.mockResolvedValue([{ id: 'p1', title: 'Launch Project' }]);
-    mockProjectGet.mockResolvedValue({ id: 'p1', title: 'Launch Project' });
+    mockProjectGet.mockResolvedValue({ id: 'p1', title: 'Launch Project', origin: 'instance', parent_task_id: null });
     mockListTeamMembersWithProfiles.mockResolvedValue([
       {
         id: 'm-owner',

--- a/Testing/unit/shared/api/planterClient.test.ts
+++ b/Testing/unit/shared/api/planterClient.test.ts
@@ -289,6 +289,35 @@ describe('Project entity', () => {
     expect(mockFrom).toHaveBeenCalledWith('project_members');
     expect(chain.insert).toHaveBeenCalledWith(member);
   });
+
+  it('TeamMember.listByProjectWithProfiles() calls the profile hydration RPC', async () => {
+    mockRpc.mockResolvedValue({
+      data: [
+        {
+          id: 'm1',
+          project_id: 'proj-1',
+          user_id: 'user-2',
+          role: 'editor',
+          joined_at: '2026-05-07T00:00:00Z',
+          email: 'editor@example.com',
+          first_name: 'Ed',
+          last_name: 'Itor',
+          display_name: 'Ed Itor',
+          avatar_url: null,
+        },
+      ],
+      error: null,
+    });
+
+    const result = await planter.entities.TeamMember.listByProjectWithProfiles('proj-1');
+
+    expect(mockRpc).toHaveBeenCalledWith('list_project_members_with_profiles', { p_project_id: 'proj-1' });
+    expect(result[0]).toMatchObject({
+      id: 'm1',
+      email: 'editor@example.com',
+      display_name: 'Ed Itor',
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/Testing/unit/shared/db/schema-source.test.ts
+++ b/Testing/unit/shared/db/schema-source.test.ts
@@ -39,10 +39,26 @@ describe('docs/db/schema.sql source of truth', () => {
    'CREATE OR REPLACE FUNCTION "public"."enforce_ics_feed_token_update_scope"',
    'CREATE OR REPLACE TRIGGER "trg_enforce_ics_feed_token_update_scope"',
    'CREATE OR REPLACE FUNCTION "public"."list_task_comments_with_authors"',
+   'CREATE OR REPLACE FUNCTION "public"."list_project_members_with_profiles"',
    'CREATE INDEX "idx_tasks_cloned_from_task_id"',
   ].forEach((needle) => {
    expect(schema).toContain(needle);
   });
+ });
+
+ it('keeps team member profile hydration gated in Postgres', () => {
+  const rpcStart = schema.indexOf('CREATE OR REPLACE FUNCTION "public"."list_project_members_with_profiles"');
+  const rpcEnd = schema.indexOf('ALTER FUNCTION "public"."list_project_members_with_profiles"');
+  const rpcSql = schema.slice(rpcStart, rpcEnd);
+
+  expect(rpcStart).toBeGreaterThanOrEqual(0);
+  expect(rpcEnd).toBeGreaterThan(rpcStart);
+  expect(rpcSql).toContain('public.is_admin(v_actor_id)');
+  expect(rpcSql).toContain('FROM public.project_members pm');
+  expect(rpcSql).toContain('LEFT JOIN auth.users u ON u.id = pm.user_id');
+  expect(rpcSql).toContain('unauthorized: project membership required');
+  expect(schema).toContain('GRANT ALL ON FUNCTION "public"."list_project_members_with_profiles"("p_project_id" "uuid") TO "authenticated";');
+  expect(schema).toContain('CREATE POLICY "members_delete_policy" ON "public"."project_members" FOR DELETE USING ((("user_id" = ( SELECT "auth"."uid"() AS "uid")) OR "public"."is_admin"');
  });
 
  it('keeps only the hardened timestamptz clone_project_template overload', () => {

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -2104,6 +2104,108 @@ ALTER FUNCTION "public"."invite_user_to_project"("p_project_id" "uuid", "p_email
 COMMENT ON FUNCTION "public"."invite_user_to_project"("p_project_id" "uuid", "p_email" "text", "p_role" "text") IS 'Owner/admin-only invite RPC. Editors retain task-edit rights but cannot invite or manage project members.';
 
 
+CREATE OR REPLACE FUNCTION "public"."list_project_members_with_profiles"("p_project_id" "uuid") RETURNS TABLE("id" "uuid", "project_id" "uuid", "user_id" "uuid", "role" "text", "joined_at" timestamp with time zone, "email" "text", "first_name" "text", "last_name" "text", "display_name" "text", "avatar_url" "text")
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_authorized boolean;
+BEGIN
+  IF p_project_id IS NULL THEN
+    RAISE EXCEPTION 'project_id is required';
+  END IF;
+
+  IF v_actor_id IS NULL THEN
+    RAISE EXCEPTION 'unauthorized: authentication required';
+  END IF;
+
+  SELECT
+    public.is_admin(v_actor_id)
+    OR EXISTS (
+      SELECT 1
+      FROM public.project_members pm
+      WHERE pm.project_id = p_project_id
+        AND pm.user_id = v_actor_id
+    )
+  INTO v_authorized;
+
+  IF NOT COALESCE(v_authorized, false) THEN
+    RAISE EXCEPTION 'unauthorized: project membership required';
+  END IF;
+
+  RETURN QUERY
+  WITH hydrated AS (
+    SELECT
+      pm.id,
+      pm.project_id,
+      pm.user_id,
+      pm.role,
+      pm.joined_at,
+      u.email::text AS email,
+      COALESCE(
+        NULLIF(btrim(u.raw_user_meta_data ->> 'full_name'), ''),
+        NULLIF(btrim(u.raw_user_meta_data ->> 'name'), '')
+      ) AS full_name,
+      NULLIF(btrim(u.raw_user_meta_data ->> 'first_name'), '') AS meta_first_name,
+      NULLIF(btrim(u.raw_user_meta_data ->> 'last_name'), '') AS meta_last_name,
+      NULLIF(btrim(u.raw_user_meta_data ->> 'avatar_url'), '') AS avatar_url
+    FROM public.project_members pm
+    LEFT JOIN auth.users u ON u.id = pm.user_id
+    WHERE pm.project_id = p_project_id
+  ),
+  normalized AS (
+    SELECT
+      hydrated.id,
+      hydrated.project_id,
+      hydrated.user_id,
+      hydrated.role,
+      hydrated.joined_at,
+      hydrated.email,
+      COALESCE(
+        hydrated.meta_first_name,
+        NULLIF(split_part(COALESCE(hydrated.full_name, ''), ' ', 1), '')
+      ) AS first_name,
+      COALESCE(
+        hydrated.meta_last_name,
+        NULLIF(btrim(regexp_replace(COALESCE(hydrated.full_name, ''), '^[^[:space:]]+[[:space:]]*', '')), '')
+      ) AS last_name,
+      COALESCE(hydrated.full_name, hydrated.email, hydrated.user_id::text) AS display_name,
+      hydrated.avatar_url
+    FROM hydrated
+  )
+  SELECT
+    normalized.id,
+    normalized.project_id,
+    normalized.user_id,
+    normalized.role,
+    normalized.joined_at,
+    normalized.email,
+    normalized.first_name,
+    normalized.last_name,
+    normalized.display_name,
+    normalized.avatar_url
+  FROM normalized
+  ORDER BY
+    CASE normalized.role
+      WHEN 'owner' THEN 0
+      WHEN 'editor' THEN 1
+      WHEN 'coach' THEN 2
+      WHEN 'viewer' THEN 3
+      WHEN 'limited' THEN 4
+      ELSE 5
+    END,
+    lower(COALESCE(normalized.display_name, normalized.email, normalized.user_id::text));
+END;
+$$;
+
+
+ALTER FUNCTION "public"."list_project_members_with_profiles"("p_project_id" "uuid") OWNER TO "postgres";
+
+
+COMMENT ON FUNCTION "public"."list_project_members_with_profiles"("p_project_id" "uuid") IS 'Project-member/admin gated roster reader that hydrates safe auth.users profile fields for team UI labels.';
+
+
 CREATE OR REPLACE FUNCTION "public"."is_active_member"("p_project_id" "uuid", "p_user_id" "uuid") RETURNS boolean
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''
@@ -3562,7 +3664,7 @@ ALTER TABLE "public"."admin_users" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."ics_feed_tokens" ENABLE ROW LEVEL SECURITY;
 
 
-CREATE POLICY "members_delete_policy" ON "public"."project_members" FOR DELETE USING ((("user_id" = ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")) OR "public"."check_project_ownership_by_role"("project_id", ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))));
+CREATE POLICY "members_delete_policy" ON "public"."project_members" FOR DELETE USING ((("user_id" = ( SELECT "auth"."uid"() AS "uid")) OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid")) OR "public"."check_project_ownership_by_role"("project_id", ( SELECT "auth"."uid"() AS "uid"))));
 
 
 
@@ -3739,6 +3841,10 @@ GRANT ALL ON FUNCTION "public"."log_comment_change"() TO "authenticated";
 
 REVOKE ALL ON FUNCTION "public"."list_task_comments_with_authors"("p_task_id" "uuid", "p_comment_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."list_task_comments_with_authors"("p_task_id" "uuid", "p_comment_id" "uuid") TO "authenticated";
+
+
+REVOKE ALL ON FUNCTION "public"."list_project_members_with_profiles"("p_project_id" "uuid") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."list_project_members_with_profiles"("p_project_id" "uuid") TO "authenticated";
 
 
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,6 +19,7 @@ import ResetPassword from '@/pages/ResetPassword';
 // lazy for the same reason.
 const Reports = lazy(() => import('@/pages/Reports'));
 const Gantt = lazy(() => import('@/pages/Gantt'));
+const Team = lazy(() => import('@/pages/Team'));
 const AdminLayout = lazy(() => import('@/pages/admin/AdminLayout'));
 const AdminHome = lazy(() => import('@/pages/admin/AdminHome'));
 const AdminUsers = lazy(() => import('@/pages/admin/AdminUsers'));
@@ -56,6 +57,10 @@ export default function App() {
  <Route path="Project/:projectId" element={<Project />} />
  <Route path="Project" element={<Project />} />
  <Route path="tasks" element={<TasksPage />} />
+ <Route
+ path="team"
+ element={<Suspense fallback={<div className="p-6 text-sm text-slate-600">Loading team…</div>}><Team /></Suspense>}
+ />
  <Route path="daily" element={<Navigate to="/tasks" replace />} />
  <Route path="settings" element={<Settings />} />
  <Route

--- a/src/features/people/hooks/useTeam.ts
+++ b/src/features/people/hooks/useTeam.ts
@@ -1,64 +1,58 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { planter } from '@/shared/api/planterClient';
 import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
 
-import type { Task as ProjectRow, TeamMemberRow } from '@/shared/db/app.types';
-import type { Database } from '@/shared/db/database.types';
-import { useAuth } from '@/shared/contexts/AuthContext';
+import type { Task as ProjectRow, TeamMemberWithProfile } from '@/shared/db/app.types';
 
 export function useTeam(projectId: string | null) {
     const queryClient = useQueryClient();
+    const { t } = useTranslation();
 
-    const { user: currentUser } = useAuth();
-
-    const { data: project } = useQuery<ProjectRow>({
-        queryKey: ['project', projectId],
+    const { data: project, isLoading: isLoadingProject, error: projectError } = useQuery<ProjectRow>({
+        queryKey: ['teamProject', projectId],
         queryFn: () => planter.entities.Project.get(projectId!).then(res => res as ProjectRow),
         enabled: !!projectId,
     });
 
-    const { data: teamMembers = [], isLoading } = useQuery<TeamMemberRow[]>({
-        queryKey: ['teamMembers', projectId || 'all'],
-        queryFn: () => {
-            if (projectId) {
-                return planter.entities.TeamMember.filter({ project_id: projectId });
-            } else {
-                // Fetch all members from all projects the user has access to
-                return planter.entities.TeamMember.list();
-            }
-        },
+    const { data: teamMembers = [], isLoading: isLoadingMembers, error: teamError } = useQuery<TeamMemberWithProfile[]>({
+        queryKey: ['teamMembers', projectId],
+        queryFn: () => planter.entities.TeamMember.listByProjectWithProfiles(projectId!),
+        enabled: !!projectId,
     });
 
     const deleteMemberMutation = useMutation({
         mutationFn: (id: string) => planter.entities.TeamMember.delete(id),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['teamMembers', projectId || 'all'] });
-            toast.success('Member removed successfully');
+            queryClient.invalidateQueries({ queryKey: ['teamMembers', projectId] });
+            toast.success(t('projects.team_page.remove_success'));
+        },
+        onError: (error: Error) => {
+            toast.error(t('projects.team_page.remove_failed'), { description: error.message });
         },
     });
 
-    const addMemberMutation = useMutation({
+    const inviteMemberMutation = useMutation({
         mutationFn: (data: { project_id: string | null, name: string, email: string, role: string }) => {
-            if (!currentUser?.id) throw new Error('User not authenticated');
-            return planter.entities.TeamMember.create({
-                user_id: currentUser.id,
-                project_id: data.project_id!,
-                role: data.role,
-            } as Database['public']['Tables']['project_members']['Insert']);
+            const targetProjectId = data.project_id ?? projectId;
+            if (!targetProjectId) throw new Error(t('projects.team_page.project_required'));
+            return planter.entities.Project.inviteMemberByEmail(targetProjectId, data.email, data.role);
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['teamMembers', projectId || 'all'] });
-            toast.success('Member added successfully');
+            queryClient.invalidateQueries({ queryKey: ['teamMembers', projectId] });
+            toast.success(t('projects.invite_modal.success'));
         },
     });
 
     return {
         project,
         teamMembers,
-        isLoading,
+        isLoading: isLoadingProject || isLoadingMembers,
+        error: (projectError as Error | null) ?? (teamError as Error | null) ?? null,
         mutations: {
             deleteMember: deleteMemberMutation,
-            addMember: addMemberMutation,
+            addMember: inviteMemberMutation,
+            inviteMember: inviteMemberMutation,
         }
     };
 }

--- a/src/features/people/hooks/useTeam.ts
+++ b/src/features/people/hooks/useTeam.ts
@@ -9,16 +9,18 @@ export function useTeam(projectId: string | null) {
     const queryClient = useQueryClient();
     const { t } = useTranslation();
 
-    const { data: project, isLoading: isLoadingProject, error: projectError } = useQuery<ProjectRow>({
+    const { data: project, isLoading: isLoadingProject, error: projectError } = useQuery<ProjectRow | null>({
         queryKey: ['teamProject', projectId],
-        queryFn: () => planter.entities.Project.get(projectId!).then(res => res as ProjectRow),
+        queryFn: () => planter.entities.Project.get(projectId!).then(res => res as ProjectRow | null),
         enabled: !!projectId,
     });
+
+    const isInstanceProjectRoot = project?.origin === 'instance' && project.parent_task_id === null;
 
     const { data: teamMembers = [], isLoading: isLoadingMembers, error: teamError } = useQuery<TeamMemberWithProfile[]>({
         queryKey: ['teamMembers', projectId],
         queryFn: () => planter.entities.TeamMember.listByProjectWithProfiles(projectId!),
-        enabled: !!projectId,
+        enabled: !!projectId && isInstanceProjectRoot,
     });
 
     const deleteMemberMutation = useMutation({

--- a/src/features/projects/hooks/useProjectData.ts
+++ b/src/features/projects/hooks/useProjectData.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { planter } from '@/shared/api/planterClient';
 import { STALE_TIMES } from '@/shared/lib/react-query-config';
-import type { HierarchyTask, Project, TeamMemberRow } from '@/shared/db/app.types';
+import type { HierarchyTask, Project, TeamMemberWithProfile } from '@/shared/db/app.types';
 
 interface UseProjectDataReturn {
     project: Project | undefined;
@@ -13,7 +13,7 @@ interface UseProjectDataReturn {
     phases: HierarchyTask[];
     milestones: HierarchyTask[];
     tasks: HierarchyTask[];
-    teamMembers: TeamMemberRow[];
+    teamMembers: TeamMemberWithProfile[];
     /** Manually retry the failed project-metadata query (used by the error-card CTA). */
     refetchProject: () => void;
 }
@@ -73,9 +73,9 @@ export function useProjectData(projectId: string | null | undefined): UseProject
     }, [projectHierarchy, projectId]);
 
     // 3. Fetch Team Members
-    const { data: teamMembers = [] } = useQuery<TeamMemberRow[]>({
+    const { data: teamMembers = [] } = useQuery<TeamMemberWithProfile[]>({
         queryKey: ['teamMembers', projectId],
-        queryFn: () => planter.entities.TeamMember.filter({ project_id: projectId! }),
+        queryFn: () => planter.entities.TeamMember.listByProjectWithProfiles(projectId!),
         enabled: !!projectId,
         staleTime: STALE_TIMES.medium,
     });

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -156,7 +156,7 @@ export default function Team() {
                 )}
 
                 {!isLoading && !error && !selectedProjectId && (
-                    <div className="rounded-md border border-dashed border-border bg-card p-8 text-center">
+                    <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
                         <Users className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
                         <h2 className="mt-4 text-lg font-semibold text-foreground">{t('projects.team_page.select_heading')}</h2>
                         <p className="mt-2 text-sm text-muted-foreground">{t('projects.team_page.select_description')}</p>
@@ -164,7 +164,7 @@ export default function Team() {
                 )}
 
                 {!isLoading && !error && selectedProjectId && teamMembers.length === 0 && (
-                    <div className="rounded-md border border-dashed border-border bg-card p-8 text-center">
+                    <div className="rounded-lg border border-dashed border-border bg-card p-8 text-center">
                         <Users className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
                         <h2 className="mt-4 text-lg font-semibold text-foreground">{t('projects.team_page.empty_heading')}</h2>
                         <p className="mt-2 text-sm text-muted-foreground">{t('projects.team_page.empty_description')}</p>
@@ -188,7 +188,7 @@ export default function Team() {
                                 <article
                                     key={member.id}
                                     data-testid="team-member-card"
-                                    className="rounded-md border bg-card p-4 shadow-sm"
+                                    className="rounded-lg border bg-card p-4 shadow-sm"
                                 >
                                     <div className="flex items-start gap-3">
                                         <Avatar className="h-11 w-11">

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -1,0 +1,254 @@
+import { useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2, Mail, Trash2, UserPlus, Users } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { planter } from '@/shared/api/planterClient';
+import { useAuth } from '@/shared/contexts/AuthContext';
+import { STALE_TIMES } from '@/shared/lib/react-query-config';
+import { formatDateLocalized } from '@/shared/i18n/formatters';
+import { ROLES } from '@/shared/constants';
+import { Button } from '@/shared/ui/button';
+import { Badge } from '@/shared/ui/badge';
+import { Label } from '@/shared/ui/label';
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
+import { useConfirm } from '@/shared/ui/confirm-dialog';
+import InviteMemberModal from '@/features/projects/components/InviteMemberModal';
+import { useTeam } from '@/features/people/hooks/useTeam';
+import { canManageProjectMembers } from '@/features/projects/lib/project-member-permissions';
+import type { Project, TeamMemberWithProfile } from '@/shared/db/app.types';
+
+function memberName(member: TeamMemberWithProfile, fallback: string) {
+    const joinedName = [member.first_name, member.last_name].filter(Boolean).join(' ').trim();
+    return member.display_name || joinedName || member.email || fallback;
+}
+
+function memberInitials(name: string) {
+    const initials = name
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map(part => part[0]?.toUpperCase())
+        .join('');
+    return initials || '?';
+}
+
+export default function Team() {
+    const { t } = useTranslation();
+    const { user } = useAuth();
+    const queryClient = useQueryClient();
+    const confirm = useConfirm();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const selectedProjectId = searchParams.get('project');
+    const [showInviteModal, setShowInviteModal] = useState(false);
+
+    const {
+        data: projects = [],
+        isLoading: loadingProjects,
+        error: projectsError,
+    } = useQuery<Project[]>({
+        queryKey: ['teamPageProjects', user?.id],
+        queryFn: () => planter.entities.Project.list(),
+        enabled: !!user,
+        staleTime: STALE_TIMES.medium,
+    });
+
+    const {
+        project,
+        teamMembers,
+        isLoading: loadingTeam,
+        error: teamError,
+        mutations,
+    } = useTeam(selectedProjectId);
+
+    const selectedProject = useMemo(
+        () => project ?? projects.find(candidate => candidate.id === selectedProjectId),
+        [project, projects, selectedProjectId],
+    );
+
+    const currentMember = teamMembers.find(member => member.user_id === user?.id);
+    const effectiveRole = user?.role === ROLES.ADMIN ? ROLES.ADMIN : currentMember?.role;
+    const canManageMembers = canManageProjectMembers(effectiveRole);
+    const isLoading = loadingProjects || (Boolean(selectedProjectId) && loadingTeam);
+    const error = projectsError ?? teamError;
+
+    const handleProjectChange = (projectId: string) => {
+        if (projectId) {
+            setSearchParams({ project: projectId });
+        } else {
+            setSearchParams({});
+        }
+    };
+
+    const handleRemoveMember = async (member: TeamMemberWithProfile) => {
+        const name = memberName(member, t('projects.team_page.unknown_member'));
+        const ok = await confirm({
+            title: t('projects.team_page.remove_confirm_title', { name }),
+            description: t('projects.team_page.remove_confirm_description'),
+            confirmText: t('common.remove'),
+            destructive: true,
+        });
+        if (!ok) return;
+        mutations.deleteMember.mutate(member.id);
+    };
+
+    return (
+        <div className="min-h-full bg-background">
+            <div className="border-b bg-card">
+                <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8">
+                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div className="min-w-0">
+                            <div className="flex items-center gap-3">
+                                <div className="flex h-10 w-10 items-center justify-center rounded-md bg-brand-50 text-brand-700">
+                                    <Users className="h-5 w-5" aria-hidden="true" />
+                                </div>
+                                <div>
+                                    <h1 className="text-2xl font-semibold text-foreground">
+                                        {selectedProject?.title
+                                            ? t('projects.team_page.title_with_project', { project: selectedProject.title })
+                                            : t('projects.team_page.title')}
+                                    </h1>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                        {t('projects.team_page.subtitle')}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        {selectedProject && canManageMembers && (
+                            <Button onClick={() => setShowInviteModal(true)}>
+                                <UserPlus className="h-4 w-4" aria-hidden="true" />
+                                {t('projects.team_page.add_member')}
+                            </Button>
+                        )}
+                    </div>
+
+                    <div className="max-w-md space-y-2">
+                        <Label htmlFor="team-project-select">{t('projects.team_page.project_label')}</Label>
+                        <select
+                            id="team-project-select"
+                            value={selectedProjectId ?? ''}
+                            onChange={event => handleProjectChange(event.target.value)}
+                            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        >
+                            <option value="">{t('projects.team_page.project_placeholder')}</option>
+                            {projects.map(candidate => (
+                                <option key={candidate.id} value={candidate.id}>
+                                    {candidate.title || t('projects.team_page.untitled_project')}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
+            </div>
+
+            <main className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+                {isLoading && (
+                    <div className="flex items-center justify-center py-16">
+                        <Loader2 data-testid="loading-spinner" className="h-8 w-8 animate-spin text-brand-600" />
+                    </div>
+                )}
+
+                {!isLoading && error && (
+                    <div role="alert" className="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+                        {error.message}
+                    </div>
+                )}
+
+                {!isLoading && !error && !selectedProjectId && (
+                    <div className="rounded-md border border-dashed border-border bg-card p-8 text-center">
+                        <Users className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
+                        <h2 className="mt-4 text-lg font-semibold text-foreground">{t('projects.team_page.select_heading')}</h2>
+                        <p className="mt-2 text-sm text-muted-foreground">{t('projects.team_page.select_description')}</p>
+                    </div>
+                )}
+
+                {!isLoading && !error && selectedProjectId && teamMembers.length === 0 && (
+                    <div className="rounded-md border border-dashed border-border bg-card p-8 text-center">
+                        <Users className="mx-auto h-10 w-10 text-muted-foreground" aria-hidden="true" />
+                        <h2 className="mt-4 text-lg font-semibold text-foreground">{t('projects.team_page.empty_heading')}</h2>
+                        <p className="mt-2 text-sm text-muted-foreground">{t('projects.team_page.empty_description')}</p>
+                        {canManageMembers && (
+                            <Button className="mt-5" onClick={() => setShowInviteModal(true)}>
+                                <UserPlus className="h-4 w-4" aria-hidden="true" />
+                                {t('projects.team_page.add_first_member')}
+                            </Button>
+                        )}
+                    </div>
+                )}
+
+                {!isLoading && !error && teamMembers.length > 0 && (
+                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                        {teamMembers.map(member => {
+                            const name = memberName(member, t('projects.team_page.unknown_member'));
+                            const email = member.email ?? t('projects.team_page.email_unavailable');
+                            const canRemoveMember = canManageMembers && member.user_id !== user?.id;
+
+                            return (
+                                <article
+                                    key={member.id}
+                                    data-testid="team-member-card"
+                                    className="rounded-md border bg-card p-4 shadow-sm"
+                                >
+                                    <div className="flex items-start gap-3">
+                                        <Avatar className="h-11 w-11">
+                                            {member.avatar_url && <AvatarImage src={member.avatar_url} alt={name} />}
+                                            <AvatarFallback>{memberInitials(name)}</AvatarFallback>
+                                        </Avatar>
+                                        <div className="min-w-0 flex-1">
+                                            <div className="flex items-start justify-between gap-3">
+                                                <div className="min-w-0">
+                                                    <h2 className="truncate text-base font-semibold text-foreground">{name}</h2>
+                                                    <div className="mt-1 flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
+                                                        <Mail className="h-4 w-4 shrink-0" aria-hidden="true" />
+                                                        <span className="truncate">{email}</span>
+                                                    </div>
+                                                </div>
+                                                <Badge variant="outline" className="shrink-0 capitalize">
+                                                    {t(`projects.team_page.roles.${member.role}` as const, { defaultValue: member.role })}
+                                                </Badge>
+                                            </div>
+
+                                            <div className="mt-4 flex items-center justify-between gap-3">
+                                                <span className="text-xs text-muted-foreground">
+                                                    {member.joined_at
+                                                        ? t('projects.team_page.joined_known', {
+                                                            date: formatDateLocalized(member.joined_at, 'short'),
+                                                        })
+                                                        : t('projects.team_page.joined_unknown')}
+                                                </span>
+                                                {canRemoveMember && (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-destructive hover:text-destructive"
+                                                        onClick={() => void handleRemoveMember(member)}
+                                                        aria-label={t('projects.team_page.remove_member_aria', { name })}
+                                                    >
+                                                        <Trash2 className="h-4 w-4" aria-hidden="true" />
+                                                        {t('common.remove')}
+                                                    </Button>
+                                                )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </article>
+                            );
+                        })}
+                    </div>
+                )}
+            </main>
+
+            {showInviteModal && selectedProject && (
+                <InviteMemberModal
+                    project={{ id: selectedProject.id, title: selectedProject.title }}
+                    onClose={() => setShowInviteModal(false)}
+                    onInviteSuccess={() => {
+                        queryClient.invalidateQueries({ queryKey: ['teamMembers', selectedProject.id] });
+                    }}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/shared/api/planterClient.ts
+++ b/src/shared/api/planterClient.ts
@@ -210,6 +210,12 @@ function commentRowWithoutHydratedAuthor(row: TaskCommentRow): TaskCommentWithAu
     return { ...row, author: null };
 }
 
+/**
+ * Normalize a hydrated project-member row into the client DTO shape.
+ *
+ * @param row - Raw row returned by the profile-hydration RPC.
+ * @returns A team member DTO with safe display fields for the roster UI.
+ */
 function normalizeTeamMemberWithProfile(row: ListProjectMembersWithProfilesRow): TeamMemberWithProfile {
     return {
         id: row.id,
@@ -330,6 +336,12 @@ interface TaskResourceEntityClient extends EntityClient<TaskResourceRow, Databas
 }
 
 interface TeamMemberEntityClient extends EntityClient<TeamMemberRow, Database['public']['Tables']['project_members']['Insert'], Database['public']['Tables']['project_members']['Update']> {
+    /**
+     * Fetches the project roster hydrated with safe auth profile fields.
+     *
+     * @param projectId - The project root task ID.
+     * @returns Hydrated team member rows visible to the current user.
+     */
     listByProjectWithProfiles: (projectId: string) => Promise<TeamMemberWithProfile[]>;
 }
 
@@ -1265,6 +1277,13 @@ export const planter: PlanterClient = {
         })(),
         TeamMember: {
             ...createEntityClient<TeamMemberRow, Database['public']['Tables']['project_members']['Insert'], Database['public']['Tables']['project_members']['Update']>('project_members'),
+            /**
+             * Fetches the project roster hydrated with safe auth profile fields.
+             * The SECURITY DEFINER RPC gates access to project members and global admins.
+             *
+             * @param projectId - The project root task ID.
+             * @returns Hydrated team member rows visible to the current user.
+             */
             listByProjectWithProfiles: async (projectId: string): Promise<TeamMemberWithProfile[]> => {
                 return retry(async () => {
                     const { data, error } = await supabase

--- a/src/shared/api/planterClient.ts
+++ b/src/shared/api/planterClient.ts
@@ -14,6 +14,7 @@ import type {
     TaskRelationshipRow,
     PersonRow,
     TeamMemberRow,
+    TeamMemberWithProfile,
     ProjectInviteResult,
     UserMetadata,
     TaskCommentInsert,
@@ -65,6 +66,8 @@ export class PlanterError extends Error {
 
 type ListTaskCommentsWithAuthorsRow =
     Database['public']['Functions']['list_task_comments_with_authors']['Returns'][number];
+type ListProjectMembersWithProfilesRow =
+    Database['public']['Functions']['list_project_members_with_profiles']['Returns'][number];
 
 /**
  * Narrow an unknown value to a plain object record before reading hydrated DTO
@@ -207,6 +210,21 @@ function commentRowWithoutHydratedAuthor(row: TaskCommentRow): TaskCommentWithAu
     return { ...row, author: null };
 }
 
+function normalizeTeamMemberWithProfile(row: ListProjectMembersWithProfilesRow): TeamMemberWithProfile {
+    return {
+        id: row.id,
+        project_id: row.project_id,
+        user_id: row.user_id,
+        role: row.role,
+        joined_at: row.joined_at,
+        email: row.email,
+        first_name: row.first_name,
+        last_name: row.last_name,
+        display_name: row.display_name,
+        avatar_url: row.avatar_url,
+    };
+}
+
 export interface PlanterClient {
     auth: {
         me: () => Promise<AuthUser | null>;
@@ -228,7 +246,7 @@ export interface PlanterClient {
             listAllVisibleTemplates: (viewerId?: string) => Promise<Task[]>;
         };
         TaskResource: TaskResourceEntityClient;
-        TeamMember: EntityClient<TeamMemberRow, Database['public']['Tables']['project_members']['Insert'], Database['public']['Tables']['project_members']['Update']>;
+        TeamMember: TeamMemberEntityClient;
         Person: EntityClient<PersonRow, Database['public']['Tables']['people']['Insert'], Database['public']['Tables']['people']['Update']>;
         TaskComment: TaskCommentEntityClient;
         ActivityLog: ActivityLogEntityClient;
@@ -309,6 +327,10 @@ interface EntityClient<T, TInsert, TUpdate> {
 interface TaskResourceEntityClient extends EntityClient<TaskResourceRow, Database['public']['Tables']['task_resources']['Insert'], Database['public']['Tables']['task_resources']['Update']> {
     setPrimary: (taskId: string, resourceId: string | null) => Promise<void>;
     listByProject: (projectId: string, options?: { signal?: AbortSignal }) => Promise<ResourceWithTask[]>;
+}
+
+interface TeamMemberEntityClient extends EntityClient<TeamMemberRow, Database['public']['Tables']['project_members']['Insert'], Database['public']['Tables']['project_members']['Update']> {
+    listByProjectWithProfiles: (projectId: string) => Promise<TeamMemberWithProfile[]>;
 }
 
 interface ProjectEntityClient extends Omit<EntityClient<Project, TaskInsert, TaskUpdate>, 'create' | 'listByCreator'> {
@@ -1241,7 +1263,19 @@ export const planter: PlanterClient = {
                 },
             };
         })(),
-        TeamMember: createEntityClient<TeamMemberRow, Database['public']['Tables']['project_members']['Insert'], Database['public']['Tables']['project_members']['Update']>('project_members'),
+        TeamMember: {
+            ...createEntityClient<TeamMemberRow, Database['public']['Tables']['project_members']['Insert'], Database['public']['Tables']['project_members']['Update']>('project_members'),
+            listByProjectWithProfiles: async (projectId: string): Promise<TeamMemberWithProfile[]> => {
+                return retry(async () => {
+                    const { data, error } = await supabase
+                        .rpc('list_project_members_with_profiles', {
+                            p_project_id: projectId,
+                        });
+                    if (error) throw new PlanterError(error.message, error.code ?? '500');
+                    return (data ?? []).map(normalizeTeamMemberWithProfile);
+                });
+            },
+        },
         Person: createEntityClient<PersonRow, Database['public']['Tables']['people']['Insert'], Database['public']['Tables']['people']['Update']>('people'),
 
         // -----------------------------------------------------------------

--- a/src/shared/db/app.types.ts
+++ b/src/shared/db/app.types.ts
@@ -54,6 +54,7 @@ export type TeamMemberWithProfile = TeamMemberRow & {
     email?: string | null;
     first_name?: string | null;
     last_name?: string | null;
+    display_name?: string | null;
     avatar_url?: string | null;
 };
 

--- a/src/shared/db/database.types.ts
+++ b/src/shared/db/database.types.ts
@@ -1484,6 +1484,21 @@ export type Database = {
           updated_at: string
         }[]
       }
+      list_project_members_with_profiles: {
+        Args: { p_project_id: string }
+        Returns: {
+          avatar_url: string | null
+          display_name: string | null
+          email: string | null
+          first_name: string | null
+          id: string
+          joined_at: string | null
+          last_name: string | null
+          project_id: string
+          role: string
+          user_id: string
+        }[]
+      }
       rag_get_project_context: {
         Args: { p_limit?: number; p_project_id: string }
         Returns: Json

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -445,6 +445,37 @@
       "role_editor": "Editor (Can edit tasks)",
       "role_limited": "Limited (Assigned tasks only)"
     },
+    "team_page": {
+      "title": "Team",
+      "title_with_project": "{{project}} Team",
+      "subtitle": "Review project access, roles, and roster details.",
+      "project_label": "Project",
+      "project_placeholder": "Select a project…",
+      "untitled_project": "Untitled project",
+      "add_member": "Add Member",
+      "add_first_member": "Add First Member",
+      "select_heading": "Select a project",
+      "select_description": "Choose a project to view its roster.",
+      "empty_heading": "Build your team",
+      "empty_description": "No members are assigned to this project yet.",
+      "unknown_member": "Unknown member",
+      "email_unavailable": "Email unavailable",
+      "joined_known": "Joined {{date}}",
+      "joined_unknown": "Join date unavailable",
+      "remove_member_aria": "Remove {{name}}",
+      "remove_confirm_title": "Remove {{name}}?",
+      "remove_confirm_description": "This removes the member from the project. Their historical task and comment activity remains intact.",
+      "remove_success": "Member removed successfully",
+      "remove_failed": "Failed to remove member",
+      "project_required": "Select a project before inviting a member.",
+      "roles": {
+        "owner": "Owner",
+        "editor": "Editor",
+        "coach": "Coach",
+        "viewer": "Viewer",
+        "limited": "Limited"
+      }
+    },
     "edit_modal": {
       "title": "Project Settings",
       "description": "Update project settings, status, and configuration. Destructive actions are in the Danger Zone below.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -451,6 +451,37 @@
       "role_editor": "Editor (puede editar tareas)",
       "role_limited": "Limitado (solo tareas asignadas)"
     },
+    "team_page": {
+      "title": "Equipo",
+      "title_with_project": "Equipo de {{project}}",
+      "subtitle": "Revisa el acceso, los roles y los detalles del equipo del proyecto.",
+      "project_label": "Proyecto",
+      "project_placeholder": "Selecciona un proyecto…",
+      "untitled_project": "Proyecto sin título",
+      "add_member": "Añadir miembro",
+      "add_first_member": "Añadir primer miembro",
+      "select_heading": "Selecciona un proyecto",
+      "select_description": "Elige un proyecto para ver su equipo.",
+      "empty_heading": "Crea tu equipo",
+      "empty_description": "Aún no hay miembros asignados a este proyecto.",
+      "unknown_member": "Miembro desconocido",
+      "email_unavailable": "Correo no disponible",
+      "joined_known": "Se unió el {{date}}",
+      "joined_unknown": "Fecha de incorporación no disponible",
+      "remove_member_aria": "Quitar {{name}}",
+      "remove_confirm_title": "¿Quitar a {{name}}?",
+      "remove_confirm_description": "Esto quita al miembro del proyecto. Su actividad histórica en tareas y comentarios se conserva.",
+      "remove_success": "Miembro quitado correctamente",
+      "remove_failed": "No se pudo quitar el miembro",
+      "project_required": "Selecciona un proyecto antes de invitar a un miembro.",
+      "roles": {
+        "owner": "Propietario",
+        "editor": "Editor",
+        "coach": "Coach",
+        "viewer": "Observador",
+        "limited": "Limitado"
+      }
+    },
     "edit_modal": {
       "title": "Configuración del proyecto",
       "description": "Actualiza la configuración, el estado y los ajustes del proyecto. Las acciones destructivas están en la Zona de peligro.",

--- a/supabase/migrations/20260507001000_team_member_profile_hydration.sql
+++ b/supabase/migrations/20260507001000_team_member_profile_hydration.sql
@@ -1,0 +1,128 @@
+-- PR 4: Hydrate project-member rosters through a trusted DB boundary.
+-- Project members and global admins can read safe profile fields for the
+-- selected project; non-members cannot use the RPC as an auth.users oracle.
+
+CREATE OR REPLACE FUNCTION public.list_project_members_with_profiles(p_project_id uuid)
+RETURNS TABLE (
+  id uuid,
+  project_id uuid,
+  user_id uuid,
+  role text,
+  joined_at timestamptz,
+  email text,
+  first_name text,
+  last_name text,
+  display_name text,
+  avatar_url text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_authorized boolean;
+BEGIN
+  IF p_project_id IS NULL THEN
+    RAISE EXCEPTION 'project_id is required';
+  END IF;
+
+  IF v_actor_id IS NULL THEN
+    RAISE EXCEPTION 'unauthorized: authentication required';
+  END IF;
+
+  SELECT
+    public.is_admin(v_actor_id)
+    OR EXISTS (
+      SELECT 1
+      FROM public.project_members pm
+      WHERE pm.project_id = p_project_id
+        AND pm.user_id = v_actor_id
+    )
+  INTO v_authorized;
+
+  IF NOT COALESCE(v_authorized, false) THEN
+    RAISE EXCEPTION 'unauthorized: project membership required';
+  END IF;
+
+  RETURN QUERY
+  WITH hydrated AS (
+    SELECT
+      pm.id,
+      pm.project_id,
+      pm.user_id,
+      pm.role,
+      pm.joined_at,
+      u.email::text AS email,
+      COALESCE(
+        NULLIF(btrim(u.raw_user_meta_data ->> 'full_name'), ''),
+        NULLIF(btrim(u.raw_user_meta_data ->> 'name'), '')
+      ) AS full_name,
+      NULLIF(btrim(u.raw_user_meta_data ->> 'first_name'), '') AS meta_first_name,
+      NULLIF(btrim(u.raw_user_meta_data ->> 'last_name'), '') AS meta_last_name,
+      NULLIF(btrim(u.raw_user_meta_data ->> 'avatar_url'), '') AS avatar_url
+    FROM public.project_members pm
+    LEFT JOIN auth.users u ON u.id = pm.user_id
+    WHERE pm.project_id = p_project_id
+  ),
+  normalized AS (
+    SELECT
+      hydrated.id,
+      hydrated.project_id,
+      hydrated.user_id,
+      hydrated.role,
+      hydrated.joined_at,
+      hydrated.email,
+      COALESCE(
+        hydrated.meta_first_name,
+        NULLIF(split_part(COALESCE(hydrated.full_name, ''), ' ', 1), '')
+      ) AS first_name,
+      COALESCE(
+        hydrated.meta_last_name,
+        NULLIF(btrim(regexp_replace(COALESCE(hydrated.full_name, ''), '^[^[:space:]]+[[:space:]]*', '')), '')
+      ) AS last_name,
+      COALESCE(hydrated.full_name, hydrated.email, hydrated.user_id::text) AS display_name,
+      hydrated.avatar_url
+    FROM hydrated
+  )
+  SELECT
+    normalized.id,
+    normalized.project_id,
+    normalized.user_id,
+    normalized.role,
+    normalized.joined_at,
+    normalized.email,
+    normalized.first_name,
+    normalized.last_name,
+    normalized.display_name,
+    normalized.avatar_url
+  FROM normalized
+  ORDER BY
+    CASE normalized.role
+      WHEN 'owner' THEN 0
+      WHEN 'editor' THEN 1
+      WHEN 'coach' THEN 2
+      WHEN 'viewer' THEN 3
+      WHEN 'limited' THEN 4
+      ELSE 5
+    END,
+    lower(COALESCE(normalized.display_name, normalized.email, normalized.user_id::text));
+END;
+$$;
+
+COMMENT ON FUNCTION public.list_project_members_with_profiles(uuid)
+IS 'Project-member/admin gated roster reader that hydrates safe auth.users profile fields for team UI labels.';
+
+REVOKE ALL ON FUNCTION public.list_project_members_with_profiles(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.list_project_members_with_profiles(uuid) TO authenticated;
+
+DROP POLICY IF EXISTS "members_delete_policy" ON public.project_members;
+
+CREATE POLICY "members_delete_policy" ON public.project_members
+FOR DELETE
+USING (
+  user_id = (SELECT auth.uid())
+  OR public.is_admin((SELECT auth.uid()))
+  OR public.check_project_ownership_by_role(project_id, (SELECT auth.uid()))
+);

--- a/supabase/tests/pgtap_team_member_profiles.sql
+++ b/supabase/tests/pgtap_team_member_profiles.sql
@@ -1,0 +1,182 @@
+BEGIN;
+
+SELECT plan(12);
+
+TRUNCATE TABLE
+    public.activity_log,
+    public.admin_users,
+    public.project_members,
+    public.tasks
+CASCADE;
+
+DELETE FROM auth.users
+WHERE email IN (
+    'team-owner@example.com',
+    'team-editor@example.com',
+    'team-viewer@example.com',
+    'team-outsider@example.com',
+    'team-admin@example.com'
+);
+
+INSERT INTO auth.users (id, email, raw_user_meta_data) VALUES
+    (
+        '00000000-0000-0000-0000-000000002101',
+        'team-owner@example.com',
+        '{"full_name":"Owner Person","avatar_url":"https://img.example.com/owner.png"}'::jsonb
+    ),
+    (
+        '00000000-0000-0000-0000-000000002102',
+        'team-editor@example.com',
+        '{"first_name":"Ed","last_name":"Itor"}'::jsonb
+    ),
+    (
+        '00000000-0000-0000-0000-000000002103',
+        'team-viewer@example.com',
+        '{"name":"Viewer Name"}'::jsonb
+    ),
+    (
+        '00000000-0000-0000-0000-000000002104',
+        'team-outsider@example.com',
+        '{}'::jsonb
+    ),
+    (
+        '00000000-0000-0000-0000-000000002105',
+        'team-admin@example.com',
+        '{}'::jsonb
+    );
+
+INSERT INTO public.admin_users (user_id, email)
+VALUES ('00000000-0000-0000-0000-000000002105', 'team-admin@example.com');
+
+INSERT INTO public.tasks (id, title, status, creator, root_id, origin)
+VALUES (
+    '11111111-1111-1111-1111-111111112101',
+    'Team Profile Project',
+    'not_started',
+    '00000000-0000-0000-0000-000000002101',
+    '11111111-1111-1111-1111-111111112101',
+    'instance'
+);
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+    ('11111111-1111-1111-1111-111111112101', '00000000-0000-0000-0000-000000002101', 'owner'),
+    ('11111111-1111-1111-1111-111111112101', '00000000-0000-0000-0000-000000002102', 'editor'),
+    ('11111111-1111-1111-1111-111111112101', '00000000-0000-0000-0000-000000002103', 'viewer');
+
+SELECT ok(
+    has_function_privilege('authenticated', 'public.list_project_members_with_profiles(uuid)', 'EXECUTE'),
+    'authenticated users can execute the team profile hydration RPC'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000002101', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000002101"}', true);
+
+SELECT is(
+    (SELECT count(*) FROM public.list_project_members_with_profiles('11111111-1111-1111-1111-111111112101')),
+    3::bigint,
+    'project owners can read the hydrated team roster'
+);
+
+SELECT is(
+    (
+        SELECT first_name
+        FROM public.list_project_members_with_profiles('11111111-1111-1111-1111-111111112101')
+        WHERE user_id = '00000000-0000-0000-0000-000000002102'
+    ),
+    'Ed',
+    'explicit first_name metadata is returned'
+);
+
+SELECT is(
+    (
+        SELECT last_name
+        FROM public.list_project_members_with_profiles('11111111-1111-1111-1111-111111112101')
+        WHERE user_id = '00000000-0000-0000-0000-000000002102'
+    ),
+    'Itor',
+    'explicit last_name metadata is returned'
+);
+
+SELECT is(
+    (
+        SELECT display_name
+        FROM public.list_project_members_with_profiles('11111111-1111-1111-1111-111111112101')
+        WHERE user_id = '00000000-0000-0000-0000-000000002103'
+    ),
+    'Viewer Name',
+    'name metadata hydrates display_name'
+);
+
+SELECT is(
+    (
+        SELECT avatar_url
+        FROM public.list_project_members_with_profiles('11111111-1111-1111-1111-111111112101')
+        WHERE user_id = '00000000-0000-0000-0000-000000002101'
+    ),
+    'https://img.example.com/owner.png',
+    'avatar_url metadata is returned for roster display'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000002104', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000002104"}', true);
+
+SELECT throws_like(
+    $$ SELECT public.list_project_members_with_profiles('11111111-1111-1111-1111-111111112101') $$,
+    '%unauthorized: project membership required%',
+    'non-members cannot use the RPC to hydrate project member profiles'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000002105', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000002105"}', true);
+
+SELECT is(
+    (SELECT count(*) FROM public.list_project_members_with_profiles('11111111-1111-1111-1111-111111112101')),
+    3::bigint,
+    'global admins can read hydrated team rosters'
+);
+
+SELECT lives_ok(
+    $$ DELETE FROM public.project_members
+       WHERE project_id = '11111111-1111-1111-1111-111111112101'
+         AND user_id = '00000000-0000-0000-0000-000000002103' $$,
+    'global admins can remove project members through RLS'
+);
+
+RESET ROLE;
+
+SELECT is(
+    (
+        SELECT count(*)
+        FROM public.project_members
+        WHERE user_id = '00000000-0000-0000-0000-000000002103'
+    ),
+    0::bigint,
+    'admin remove action deletes the target membership'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000002102', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000002102"}', true);
+
+SELECT lives_ok(
+    $$ DELETE FROM public.project_members
+       WHERE project_id = '11111111-1111-1111-1111-111111112101'
+         AND user_id = '00000000-0000-0000-0000-000000002101' $$,
+    'editor remove attempts are filtered by RLS'
+);
+
+RESET ROLE;
+
+SELECT is(
+    (
+        SELECT count(*)
+        FROM public.project_members
+        WHERE user_id = '00000000-0000-0000-0000-000000002101'
+    ),
+    1::bigint,
+    'editor remove attempts do not remove owner memberships'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Findings addressed
- `/team` was linked from ProjectHeader, CommandPalette, and E2E fixtures but had no application route.
- Project/team surfaces read raw `project_members`, causing member labels and phase-lead/task-detail UI to fall back to UUIDs instead of safe profile fields.
- Global admins could invite through the hardened invite path but could not remove project members through the direct RLS-backed member delete path.

## Files changed
- Added `/team?project=:id` route and `src/pages/Team.tsx` roster UI.
- Added `list_project_members_with_profiles(p_project_id)` SECURITY DEFINER RPC in `supabase/migrations/20260507001000_team_member_profile_hydration.sql` and mirrored it in `docs/db/schema.sql` / generated DB types.
- Added typed `TeamMember.listByProjectWithProfiles()` in `planterClient`, updated `useTeam()` and `useProjectData()` to use hydrated roster rows.
- Added owner/admin member removal parity to `members_delete_policy`.
- Added localized team-page copy in `en.json` and `es.json`.
- Added unit, schema-source, pgTAP, route, and release E2E coverage.

## Data/security impact
- New RPC gates profile hydration to project members or global admins and returns only safe roster fields: email, first/last/display name, avatar URL, role, and membership metadata.
- Non-members cannot use the RPC as an `auth.users` oracle.
- Member deletion remains RLS-enforced; self-removal and project-owner removal are preserved, and global admin removal is added to align with owner/admin member-management expectations.
- No destructive schema cleanup or data backfill is required.

## Tests added/updated
- `supabase/tests/pgtap_team_member_profiles.sql`
- `Testing/unit/pages/Team.test.tsx`
- Updated `useTeam`, `useProjectData`, `planterClient`, schema-source, app routing, and release E2E tests.

## Commands run and results
- `npm test -- Testing/unit/pages/Team.test.tsx Testing/unit/features/people/hooks/useTeam.test.ts Testing/unit/features/projects/hooks/useProjectData.test.ts Testing/unit/shared/api/planterClient.test.ts Testing/unit/shared/db/schema-source.test.ts Testing/unit/app/App.routing.test.tsx` - passed, 93 tests.
- `npm run verify-architecture` - passed.
- `npm run lint` - passed with the 4 existing Fast Refresh warnings in `AuthContext.tsx` and `confirm-dialog.tsx`.
- `npm run build` - passed.
- `npm test` - passed, 132 files / 1084 tests; existing AuthContext negative-test error output still prints.
- `npm run db:local:test` - passed, 14 pgTAP files / 170 tests.
- `npm run test:e2e:release` - passed, 8 tests.
- `git diff --cached --check` - passed.

## Rollback/migration notes
- Rollback by dropping `public.list_project_members_with_profiles(uuid)` and restoring the previous `members_delete_policy` if needed.
- No irreversible data migration is performed.
