### PR TITLE
Localize resource management copy

### DIFF
--- a/Testing/unit/features/projects/components/ResourceLibrary.test.tsx
+++ b/Testing/unit/features/projects/components/ResourceLibrary.test.tsx
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { i18n } from '@/shared/i18n';
+import { renderWithProviders } from '@test/render-with-providers';
+import type { ResourceWithTask } from '@/shared/db/app.types';
+
+const mocks = vi.hoisted(() => ({
+    useProjectResources: vi.fn(),
+}));
+
+vi.mock('@/features/projects/hooks/useProjectResources', () => ({
+    useProjectResources: mocks.useProjectResources,
+}));
+
+import ResourceLibrary from '@/features/projects/components/ResourceLibrary';
+
+function makeResource(overrides: Partial<ResourceWithTask> = {}): ResourceWithTask {
+    return {
+        id: 'resource-1',
+        task_id: 'task-1',
+        resource_type: 'url',
+        resource_url: 'https://example.com',
+        resource_text: null,
+        storage_bucket: null,
+        storage_path: null,
+        created_at: '2026-05-07T00:00:00.000Z',
+        updated_at: '2026-05-07T00:00:00.000Z',
+        task: { id: 'task-1', title: 'Alpha Task', root_id: 'project-1' },
+        ...overrides,
+    };
+}
+
+describe('ResourceLibrary localization', () => {
+    beforeEach(() => {
+        mocks.useProjectResources.mockReset();
+    });
+
+    it('renders project resources from the active locale catalog', async () => {
+        mocks.useProjectResources.mockReturnValue({
+            data: [makeResource()],
+            isLoading: false,
+        });
+        await i18n.changeLanguage('es');
+
+        renderWithProviders(<ResourceLibrary projectId="project-1" />);
+
+        expect(screen.getByPlaceholderText('Buscar recursos…')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Todos' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Enlaces' })).toBeInTheDocument();
+        expect(screen.getByText('Enlace externo')).toBeInTheDocument();
+        expect(screen.getByText('De: Alpha Task')).toBeInTheDocument();
+        expect(screen.getByText('1 recurso total')).toBeInTheDocument();
+    });
+
+    it('uses localized empty-search copy', async () => {
+        mocks.useProjectResources.mockReturnValue({
+            data: [makeResource({ resource_text: 'Implementation note', resource_type: 'text', resource_url: null })],
+            isLoading: false,
+        });
+        await i18n.changeLanguage('es');
+
+        renderWithProviders(<ResourceLibrary projectId="project-1" />);
+
+        await screen.findByText('Nota');
+        fireEvent.change(screen.getByPlaceholderText('Buscar recursos…'), {
+            target: { value: 'missing' },
+        });
+
+        expect(screen.getByText('Ningún recurso coincide con tu búsqueda')).toBeInTheDocument();
+        expect(screen.getByText('Prueba a ajustar tu búsqueda o filtro.')).toBeInTheDocument();
+    });
+});

--- a/Testing/unit/features/tasks/components/TaskResources.test.tsx
+++ b/Testing/unit/features/tasks/components/TaskResources.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { i18n } from '@/shared/i18n';
+import { renderWithProviders } from '@test/render-with-providers';
+import type { TaskResourceRow } from '@/shared/db/app.types';
+
+const mocks = vi.hoisted(() => ({
+    filter: vi.fn(),
+    create: vi.fn(),
+    delete: vi.fn(),
+    setPrimary: vi.fn(),
+}));
+
+vi.mock('@/shared/api/planterClient', () => ({
+    planter: {
+        entities: {
+            TaskResource: {
+                filter: mocks.filter,
+                create: mocks.create,
+                delete: mocks.delete,
+                setPrimary: mocks.setPrimary,
+            },
+        },
+    },
+}));
+
+import TaskResources from '@/features/tasks/components/TaskResources';
+
+function makeResource(overrides: Partial<TaskResourceRow> = {}): TaskResourceRow {
+    return {
+        id: 'resource-1',
+        task_id: 'task-1',
+        resource_type: 'url',
+        resource_url: 'https://example.com',
+        resource_text: null,
+        storage_bucket: null,
+        storage_path: null,
+        created_at: '2026-05-07T00:00:00.000Z',
+        updated_at: '2026-05-07T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+describe('TaskResources localization', () => {
+    beforeEach(() => {
+        mocks.filter.mockReset();
+        mocks.create.mockReset();
+        mocks.delete.mockReset();
+        mocks.setPrimary.mockReset();
+    });
+
+    it('renders empty state and add-resource modal from the active locale catalog', async () => {
+        const user = userEvent.setup();
+        mocks.filter.mockResolvedValue([]);
+        await i18n.changeLanguage('es');
+
+        renderWithProviders(<TaskResources taskId="task-1" />);
+
+        expect(await screen.findByText('Aún no hay recursos')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Agregar recurso' }));
+
+        expect(screen.getByRole('dialog', { name: 'Agregar recurso' })).toBeInTheDocument();
+        expect(screen.getByText('Adjunta un enlace, una nota o una referencia de documento a esta tarea.')).toBeInTheDocument();
+        expect(screen.getByText('Tipo de recurso')).toBeInTheDocument();
+        expect(screen.getAllByText('Enlace externo').length).toBeGreaterThan(0);
+        expect(screen.getByText('URL')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('https://example.com')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Cancelar' })).toBeInTheDocument();
+    });
+
+    it('localizes resource labels and row action accessible names', async () => {
+        mocks.filter.mockResolvedValue([makeResource()]);
+        await i18n.changeLanguage('es');
+
+        renderWithProviders(<TaskResources taskId="task-1" primaryResourceId="resource-1" />);
+
+        expect(await screen.findByText('Enlace externo')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Quitar recurso principal' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Eliminar recurso Enlace externo' })).toBeInTheDocument();
+    });
+});

--- a/Testing/unit/features/tasks/components/TaskResources.test.tsx
+++ b/Testing/unit/features/tasks/components/TaskResources.test.tsx
@@ -77,7 +77,7 @@ describe('TaskResources localization', () => {
         renderWithProviders(<TaskResources taskId="task-1" primaryResourceId="resource-1" />);
 
         expect(await screen.findByText('Enlace externo')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Quitar recurso principal' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Quitar Enlace externo como recurso principal' })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Eliminar recurso Enlace externo' })).toBeInTheDocument();
     });
 });

--- a/src/features/projects/components/ResourceLibrary.tsx
+++ b/src/features/projects/components/ResourceLibrary.tsx
@@ -105,9 +105,11 @@ export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
     const { data: resources = [], isLoading } = useProjectResources(projectId);
     const [search, setSearch] = useState('');
     const [activeFilter, setActiveFilter] = useState<FilterTab>('all');
+    const trimmedSearch = search.trim();
+    const hasActiveRefinement = activeFilter !== 'all' || trimmedSearch.length > 0;
 
     const filtered = useMemo(() => {
-        const q = search.trim().toLowerCase();
+        const q = trimmedSearch.toLowerCase();
 
         return resources.filter((r: ResourceWithTask) => {
             // Type filter
@@ -128,7 +130,7 @@ export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
 
             return true;
         });
-    }, [resources, search, activeFilter]);
+    }, [resources, trimmedSearch, activeFilter]);
 
     return (
         <div className="space-y-6">
@@ -192,7 +194,7 @@ export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
             {/* Count footer */}
             {!isLoading && filtered.length > 0 && (
                 <p className="text-xs text-slate-400 text-right">
-                    {t(activeFilter !== 'all' || search.trim()
+                    {t(hasActiveRefinement
                         ? 'projects.resources.count_matching'
                         : 'projects.resources.count_total', {
                         count: filtered.length,

--- a/src/features/projects/components/ResourceLibrary.tsx
+++ b/src/features/projects/components/ResourceLibrary.tsx
@@ -1,9 +1,11 @@
 import { useState, useMemo } from 'react';
 import { ExternalLink, FileText, StickyNote, Search, BookOpen } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Input } from '@/shared/ui/input';
 import { cn } from '@/shared/lib/utils';
 import { safeUrl } from '@/shared/lib/safe-url';
 import { useProjectResources } from '@/features/projects/hooks/useProjectResources';
+import { formatNumberLocalized } from '@/shared/i18n/formatters';
 import type { ResourceWithTask } from '@/shared/db/app.types';
 
 // ---------------------------------------------------------------------------
@@ -18,11 +20,15 @@ const resourceTypeIcons: Record<ResourceType, React.ElementType> = {
     text: StickyNote,
 };
 
-const resourceTypeLabels: Record<ResourceType, string> = {
-    url: 'External Link',
-    pdf: 'Document',
-    text: 'Note',
-};
+const resourceTypeLabelKeys = {
+    url: 'projects.resources.types.url',
+    pdf: 'projects.resources.types.pdf',
+    text: 'projects.resources.types.text',
+} as const;
+
+function normalizeResourceType(type: string | null | undefined): ResourceType {
+    return type === 'pdf' || type === 'text' || type === 'url' ? type : 'url';
+}
 
 // ---------------------------------------------------------------------------
 // Filter tab definitions
@@ -30,22 +36,23 @@ const resourceTypeLabels: Record<ResourceType, string> = {
 
 type FilterTab = 'all' | ResourceType;
 
-const FILTER_TABS: { id: FilterTab; label: string }[] = [
-    { id: 'all', label: 'All' },
-    { id: 'url', label: 'Links' },
-    { id: 'pdf', label: 'Documents' },
-    { id: 'text', label: 'Notes' },
-];
+const FILTER_TABS = [
+    { id: 'all', label: 'projects.resources.filters.all' },
+    { id: 'url', label: 'projects.resources.filters.url' },
+    { id: 'pdf', label: 'projects.resources.filters.pdf' },
+    { id: 'text', label: 'projects.resources.filters.text' },
+] as const;
 
 // ---------------------------------------------------------------------------
 // Resource card
 // ---------------------------------------------------------------------------
 
 function ResourceCard({ resource }: { resource: ResourceWithTask }) {
-    const type = (resource.resource_type ?? 'url') as ResourceType;
+    const { t } = useTranslation();
+    const type = normalizeResourceType(resource.resource_type);
     const Icon = resourceTypeIcons[type] ?? FileText;
-    const label = resourceTypeLabels[type] ?? type;
-    const taskTitle = resource.task?.title ?? 'Unknown task';
+    const label = t(resourceTypeLabelKeys[type]);
+    const taskTitle = resource.task?.title ?? t('projects.resources.unknown_task');
 
     return (
         <div className="flex items-start gap-3 p-4 rounded-lg border border-border bg-card hover:border-brand-300 transition-colors">
@@ -78,7 +85,7 @@ function ResourceCard({ resource }: { resource: ResourceWithTask }) {
                 )}
 
                 <p className="text-xs text-slate-400 mt-1.5">
-                    From: <span className="font-medium text-slate-500">{taskTitle}</span>
+                    {t('projects.resources.from_task', { title: taskTitle })}
                 </p>
             </div>
         </div>
@@ -94,6 +101,7 @@ interface ResourceLibraryProps {
 }
 
 export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
+    const { t } = useTranslation();
     const { data: resources = [], isLoading } = useProjectResources(projectId);
     const [search, setSearch] = useState('');
     const [activeFilter, setActiveFilter] = useState<FilterTab>('all');
@@ -129,7 +137,7 @@ export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
                 <div className="relative flex-1">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <Input
-                        placeholder="Search resources…"
+                        placeholder={t('projects.resources.search_placeholder')}
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
                         className="pl-9"
@@ -148,7 +156,7 @@ export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
                                     : 'text-muted-foreground hover:text-slate-700',
                             )}
                         >
-                            {tab.label}
+                            {t(tab.label)}
                         </button>
                     ))}
                 </div>
@@ -164,13 +172,13 @@ export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
                     <BookOpen className="w-10 h-10 text-slate-300 mb-3" />
                     <p className="text-slate-500 font-medium">
                         {resources.length === 0
-                            ? 'No resources in this project yet'
-                            : 'No resources match your search'}
+                            ? t('projects.resources.empty_project_title')
+                            : t('projects.resources.empty_search_title')}
                     </p>
                     <p className="text-slate-400 text-sm mt-1">
                         {resources.length === 0
-                            ? 'Add links, documents, or notes to tasks to see them here.'
-                            : 'Try adjusting your search or filter.'}
+                            ? t('projects.resources.empty_project_description')
+                            : t('projects.resources.empty_search_description')}
                     </p>
                 </div>
             ) : (
@@ -184,8 +192,12 @@ export default function ResourceLibrary({ projectId }: ResourceLibraryProps) {
             {/* Count footer */}
             {!isLoading && filtered.length > 0 && (
                 <p className="text-xs text-slate-400 text-right">
-                    {filtered.length} {filtered.length === 1 ? 'resource' : 'resources'}
-                    {activeFilter !== 'all' || search ? ` matching` : ' total'}
+                    {t(activeFilter !== 'all' || search.trim()
+                        ? 'projects.resources.count_matching'
+                        : 'projects.resources.count_total', {
+                        count: filtered.length,
+                        formattedCount: formatNumberLocalized(filtered.length),
+                    })}
                 </p>
             )}
         </div>

--- a/src/features/tasks/components/TaskResources.tsx
+++ b/src/features/tasks/components/TaskResources.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import type { FormEvent } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import type { TaskResourceRow } from '@/shared/db/app.types';
 import { Button } from '@/shared/ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { Input } from '@/shared/ui/input';
 import { Textarea } from '@/shared/ui/textarea';
 import { Label } from '@/shared/ui/label';
@@ -19,14 +20,17 @@ const resourceTypeIcons = {
  text: StickyNote,
 } as const;
 
-const resourceTypeLabels = {
- url: 'External Link',
- pdf: 'Document',
- text: 'Note',
+const resourceTypeLabelKeys = {
+ url: 'projects.resources.types.url',
+ pdf: 'projects.resources.types.pdf',
+ text: 'projects.resources.types.text',
 } as const;
 
 type ResourceType = keyof typeof resourceTypeIcons;
 
+function normalizeResourceType(type: string | null | undefined): ResourceType {
+ return type === 'pdf' || type === 'text' || type === 'url' ? type : 'url';
+}
 
 interface TaskResourcesProps {
  taskId: string;
@@ -35,6 +39,7 @@ interface TaskResourcesProps {
 }
 
 export default function TaskResources({ taskId, primaryResourceId, onUpdate }: TaskResourcesProps) {
+ const { t } = useTranslation();
  const [showAddModal, setShowAddModal] = useState(false);
  const [formData, setFormData] = useState({
  type: 'url' as ResourceType,
@@ -92,25 +97,26 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
  return (
  <div data-testid="task-resources">
  <div className="flex items-center justify-between mb-4">
- <h4 className="text-sm font-semibold text-card-foreground uppercase tracking-wider">Resources</h4>
+ <h4 className="text-sm font-semibold text-card-foreground uppercase tracking-wider">{t('projects.resources.title')}</h4>
  <Button
  size="sm"
  onClick={() => setShowAddModal(true)}
  className="bg-brand-500 hover:bg-brand-600 text-white"
  >
  <Plus className="w-4 h-4 mr-1" />
- Add Resource
+ {t('projects.resources.add_button')}
  </Button>
  </div>
 
  <div className="space-y-2">
  {resources.length === 0 ? (
- <p className="text-sm text-muted-foreground py-4 text-center">No resources yet</p>
+ <p className="text-sm text-muted-foreground py-4 text-center">{t('projects.resources.empty')}</p>
  ) : (
  resources.map((resource) => {
- const type = (resource.resource_type || 'url') as ResourceType;
+ const type = normalizeResourceType(resource.resource_type);
  const Icon = resourceTypeIcons[type] || FileText;
  const isPrimary = primaryResourceId === resource.id;
+ const label = t(resourceTypeLabelKeys[type]);
 
  return (
  <div
@@ -133,7 +139,7 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
  </div>
  <div className="flex-1 min-w-0">
  <p className="text-sm font-medium text-card-foreground truncate">
- {resourceTypeLabels[type] || type}
+ {label}
  </p>
  {type === 'url' && resource.resource_url && (
  <a
@@ -158,6 +164,7 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
  size="icon"
  variant="ghost"
  onClick={() => setPrimaryMutation.mutate(resource.id)}
+ aria-label={t(isPrimary ? 'projects.resources.unset_primary_aria' : 'projects.resources.set_primary_aria', { type: label })}
  className={cn('h-8 w-8', isPrimary && 'text-brand-600 hover:text-brand-700')}
  >
  <Star className={cn('w-4 h-4', isPrimary && 'fill-brand-600')} />
@@ -166,6 +173,7 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
  size="icon"
  variant="ghost"
  onClick={() => deleteResourceMutation.mutate(resource.id)}
+ aria-label={t('projects.resources.delete_aria', { type: label })}
  className="h-8 w-8 text-rose-600 hover:bg-rose-50 "
  >
  <Trash2 className="w-4 h-4" />
@@ -180,11 +188,12 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
  <Dialog open={showAddModal} onOpenChange={setShowAddModal}>
  <DialogContent className="sm:max-w-md bg-card text-card-foreground">
  <DialogHeader>
- <DialogTitle>Add Resource</DialogTitle>
+ <DialogTitle>{t('projects.resources.add_modal_title')}</DialogTitle>
+ <DialogDescription>{t('projects.resources.add_modal_description')}</DialogDescription>
  </DialogHeader>
  <form onSubmit={handleSubmit} className="space-y-4">
  <div>
- <Label>Resource Type</Label>
+ <Label>{t('projects.resources.resource_type_label')}</Label>
  <Select
  value={formData.type}
  onValueChange={(value) => setFormData({ ...formData, type: value as ResourceType })}
@@ -193,21 +202,21 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
  <SelectValue />
  </SelectTrigger>
  <SelectContent>
- <SelectItem value="url">External Link</SelectItem>
- <SelectItem value="text">Note</SelectItem>
- <SelectItem value="pdf">Document</SelectItem>
+ <SelectItem value="url">{t(resourceTypeLabelKeys.url)}</SelectItem>
+ <SelectItem value="text">{t(resourceTypeLabelKeys.text)}</SelectItem>
+ <SelectItem value="pdf">{t(resourceTypeLabelKeys.pdf)}</SelectItem>
  </SelectContent>
  </Select>
  </div>
 
  {formData.type === 'url' && (
  <div>
- <Label>URL</Label>
+ <Label>{t('projects.resources.url_label')}</Label>
  <Input
  type="url"
  value={formData.resource_url}
  onChange={(e) => setFormData({ ...formData, resource_url: e.target.value })}
- placeholder="https://example.com"
+ placeholder={t('projects.resources.url_placeholder')}
  required
  />
  </div>
@@ -215,11 +224,11 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
 
  {formData.type === 'text' && (
  <div>
- <Label>Content</Label>
+ <Label>{t('projects.resources.content_label')}</Label>
  <Textarea
  value={formData.resource_text}
  onChange={(e) => setFormData({ ...formData, resource_text: e.target.value })}
- placeholder="Enter your note..."
+ placeholder={t('projects.resources.content_placeholder')}
  rows={4}
  required
  />
@@ -228,11 +237,11 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
 
  {formData.type === 'pdf' && (
  <div>
- <Label>Storage Path</Label>
+ <Label>{t('projects.resources.storage_path_label')}</Label>
  <Input
  value={formData.storage_path}
  onChange={(e) => setFormData({ ...formData, storage_path: e.target.value })}
- placeholder="path/to/document.pdf"
+ placeholder={t('projects.resources.storage_path_placeholder')}
  required
  />
  </div>
@@ -240,10 +249,10 @@ export default function TaskResources({ taskId, primaryResourceId, onUpdate }: T
 
  <div className="flex gap-2 justify-end pt-4">
  <Button type="button" variant="outline" onClick={() => setShowAddModal(false)}>
- Cancel
+ {t('common.cancel')}
  </Button>
  <Button type="submit" className="bg-brand-500 hover:bg-brand-600 text-white">
- Add Resource
+ {t('projects.resources.add_button')}
  </Button>
  </div>
  </form>

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -612,7 +612,41 @@
     "resources": {
       "title": "Resources",
       "empty": "No resources yet",
-      "search_placeholder": "Search resources…"
+      "search_placeholder": "Search resources…",
+      "add_button": "Add Resource",
+      "add_modal_title": "Add Resource",
+      "add_modal_description": "Attach a link, note, or document reference to this task.",
+      "resource_type_label": "Resource Type",
+      "url_label": "URL",
+      "content_label": "Content",
+      "storage_path_label": "Storage Path",
+      "url_placeholder": "https://example.com",
+      "content_placeholder": "Enter your note…",
+      "storage_path_placeholder": "path/to/document.pdf",
+      "unknown_task": "Unknown task",
+      "from_task": "From: {{title}}",
+      "empty_project_title": "No resources in this project yet",
+      "empty_search_title": "No resources match your search",
+      "empty_project_description": "Add links, documents, or notes to tasks to see them here.",
+      "empty_search_description": "Try adjusting your search or filter.",
+      "count_total_one": "{{formattedCount}} resource total",
+      "count_total_other": "{{formattedCount}} resources total",
+      "count_matching_one": "{{formattedCount}} resource matching",
+      "count_matching_other": "{{formattedCount}} resources matching",
+      "set_primary_aria": "Set {{type}} as primary resource",
+      "unset_primary_aria": "Unset primary resource",
+      "delete_aria": "Delete {{type}} resource",
+      "types": {
+        "url": "External Link",
+        "pdf": "Document",
+        "text": "Note"
+      },
+      "filters": {
+        "all": "All",
+        "url": "Links",
+        "pdf": "Documents",
+        "text": "Notes"
+      }
     },
     "activity": {
       "title": "Activity"

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -634,7 +634,7 @@
       "count_matching_one": "{{formattedCount}} resource matching",
       "count_matching_other": "{{formattedCount}} resources matching",
       "set_primary_aria": "Set {{type}} as primary resource",
-      "unset_primary_aria": "Unset primary resource",
+      "unset_primary_aria": "Unset {{type}} as primary resource",
       "delete_aria": "Delete {{type}} resource",
       "types": {
         "url": "External Link",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -640,7 +640,7 @@
       "count_matching_one": "{{formattedCount}} recurso coincidente",
       "count_matching_other": "{{formattedCount}} recursos coincidentes",
       "set_primary_aria": "Establecer {{type}} como recurso principal",
-      "unset_primary_aria": "Quitar recurso principal",
+      "unset_primary_aria": "Quitar {{type}} como recurso principal",
       "delete_aria": "Eliminar recurso {{type}}",
       "types": {
         "url": "Enlace externo",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -618,7 +618,41 @@
     "resources": {
       "title": "Recursos",
       "empty": "Aún no hay recursos",
-      "search_placeholder": "Buscar recursos…"
+      "search_placeholder": "Buscar recursos…",
+      "add_button": "Agregar recurso",
+      "add_modal_title": "Agregar recurso",
+      "add_modal_description": "Adjunta un enlace, una nota o una referencia de documento a esta tarea.",
+      "resource_type_label": "Tipo de recurso",
+      "url_label": "URL",
+      "content_label": "Contenido",
+      "storage_path_label": "Ruta de almacenamiento",
+      "url_placeholder": "https://example.com",
+      "content_placeholder": "Introduce tu nota…",
+      "storage_path_placeholder": "ruta/al/documento.pdf",
+      "unknown_task": "Tarea desconocida",
+      "from_task": "De: {{title}}",
+      "empty_project_title": "Aún no hay recursos en este proyecto",
+      "empty_search_title": "Ningún recurso coincide con tu búsqueda",
+      "empty_project_description": "Añade enlaces, documentos o notas a las tareas para verlos aquí.",
+      "empty_search_description": "Prueba a ajustar tu búsqueda o filtro.",
+      "count_total_one": "{{formattedCount}} recurso total",
+      "count_total_other": "{{formattedCount}} recursos en total",
+      "count_matching_one": "{{formattedCount}} recurso coincidente",
+      "count_matching_other": "{{formattedCount}} recursos coincidentes",
+      "set_primary_aria": "Establecer {{type}} como recurso principal",
+      "unset_primary_aria": "Quitar recurso principal",
+      "delete_aria": "Eliminar recurso {{type}}",
+      "types": {
+        "url": "Enlace externo",
+        "pdf": "Documento",
+        "text": "Nota"
+      },
+      "filters": {
+        "all": "Todos",
+        "url": "Enlaces",
+        "pdf": "Documentos",
+        "text": "Notas"
+      }
     },
     "activity": {
       "title": "Actividad"


### PR DESCRIPTION
## Finding addressed
Resource management surfaces still rendered English-only copy after the Wave 31 localization pass. The project resource library and per-task resource panel included hardcoded labels, placeholders, empty states, filter labels, and action text.

## Root cause
`ResourceLibrary` and `TaskResources` predated the completed i18n cleanup and continued to keep resource copy in component-local constants/JSX instead of resolving strings through `react-i18next` and `src/shared/i18n/locales/*`.

## Files changed
- `src/features/projects/components/ResourceLibrary.tsx`
- `src/features/tasks/components/TaskResources.tsx`
- `src/shared/i18n/locales/en.json`
- `src/shared/i18n/locales/es.json`
- `Testing/unit/features/projects/components/ResourceLibrary.test.tsx`
- `Testing/unit/features/tasks/components/TaskResources.test.tsx`

## Security/data impact
No database, RLS, RPC, auth, dependency, or CI changes. No data migration. The task resource dialog now also has localized descriptive text and localized accessible names for row actions.

## Tests added/updated
Added focused render coverage proving both resource surfaces resolve Spanish catalog strings for labels, empty states, modal copy, counts, and action accessible names.

## Commands run and results
- `npm test -- Testing/unit/features/projects/components/ResourceLibrary.test.tsx Testing/unit/features/tasks/components/TaskResources.test.tsx` — passed, 2 files / 4 tests.
- `npm run verify-architecture` — passed.
- `npm run lint` — passed.
- `npm test` — passed, 135 files / 1097 tests.
- `npm run build` — passed; Vite reported the existing large chunk warning.

## Skipped checks
- `npm run verify-dependencies` — not run; no dependency, package, or CI files changed.
- `npm run db:local:test` — not run; no DB/RLS/migration/RPC changes.
- `npm run test:e2e:release` — not run; no workflow or E2E behavior changed.

## Rollback/migration notes
Rollback is a normal revert of this PR. No migration or backfill is involved.