### PR TITLE
fix: harden task role matrix enforcement

### DIFF
--- a/Testing/unit/features/tasks/lib/task-permissions.test.ts
+++ b/Testing/unit/features/tasks/lib/task-permissions.test.ts
@@ -9,6 +9,46 @@ import {
 } from '@/features/tasks/lib/task-permissions';
 
 describe('task permission capabilities', () => {
+    const phaseLeadUserId = 'viewer-phase-lead';
+    const root = makeTask({
+        id: 'project-root',
+        parent_task_id: null,
+        root_id: 'project-root',
+        settings: {},
+    });
+    const phase = makeTask({
+        id: 'phase-1',
+        parent_task_id: root.id,
+        root_id: root.id,
+        settings: { phase_lead_user_ids: [phaseLeadUserId] },
+    });
+    const milestone = makeTask({
+        id: 'milestone-1',
+        parent_task_id: phase.id,
+        root_id: root.id,
+        settings: {},
+    });
+    const phaseLeadTask = makeTask({
+        id: 'task-under-phase-lead',
+        parent_task_id: milestone.id,
+        root_id: root.id,
+        origin: 'instance',
+        settings: {},
+    });
+    const siblingPhase = makeTask({
+        id: 'phase-2',
+        parent_task_id: root.id,
+        root_id: root.id,
+        settings: {},
+    });
+    const siblingTask = makeTask({
+        id: 'task-outside-phase-lead',
+        parent_task_id: siblingPhase.id,
+        root_id: root.id,
+        origin: 'instance',
+        settings: {},
+    });
+    const allProjectTasks = [root, phase, milestone, phaseLeadTask, siblingPhase, siblingTask];
     const coachingTask = makeTask({
         origin: 'instance',
         settings: { is_coaching_task: true },
@@ -37,10 +77,47 @@ describe('task permission capabilities', () => {
 
     it('keeps owner/editor full task capabilities while preserving template-origin delete protection', () => {
         expect(canEditTaskContent('owner')).toBe(true);
+        expect(canEditTaskContent('editor')).toBe(true);
+        expect(canEditTaskContent('admin')).toBe(true);
         expect(canCreateChildTask('editor')).toBe(true);
         expect(canReorderTask('owner')).toBe(true);
         expect(canUpdateTaskProgress('editor', plainTask)).toBe(true);
         expect(canDeleteTask('editor', plainTask)).toBe(true);
         expect(canDeleteTask('owner', makeTask({ cloned_from_task_id: 'template-task-id' }))).toBe(false);
+    });
+
+    it('keeps viewer and limited users read-only unless they lead an ancestor phase or milestone', () => {
+        const phaseLeadContext = {
+            task: phaseLeadTask,
+            allProjectTasks,
+            userId: phaseLeadUserId,
+        };
+
+        expect(canEditTaskContent('viewer')).toBe(false);
+        expect(canEditTaskContent('limited')).toBe(false);
+        expect(canEditTaskContent('viewer', phaseLeadContext)).toBe(true);
+        expect(canEditTaskContent('limited', phaseLeadContext)).toBe(true);
+        expect(canUpdateTaskProgress('viewer', phaseLeadTask, {
+            allProjectTasks,
+            userId: phaseLeadUserId,
+        })).toBe(true);
+    });
+
+    it('does not treat phase lead assignment as self, sibling, create, delete, or reorder authority', () => {
+        expect(canEditTaskContent('viewer', {
+            task: phase,
+            allProjectTasks,
+            userId: phaseLeadUserId,
+        })).toBe(false);
+        expect(canEditTaskContent('viewer', {
+            task: siblingTask,
+            allProjectTasks,
+            userId: phaseLeadUserId,
+        })).toBe(false);
+        expect(canCreateChildTask('viewer')).toBe(false);
+        expect(canCreateChildTask('limited')).toBe(false);
+        expect(canReorderTask('viewer')).toBe(false);
+        expect(canDeleteTask('viewer', phaseLeadTask)).toBe(false);
+        expect(canDeleteTask('limited', phaseLeadTask)).toBe(false);
     });
 });

--- a/Testing/unit/shared/db/schema-source.test.ts
+++ b/Testing/unit/shared/db/schema-source.test.ts
@@ -32,6 +32,8 @@ describe('docs/db/schema.sql source of truth', () => {
   'CREATE OR REPLACE TRIGGER "trg_enforce_template_scaffold_immutability"',
    'CREATE OR REPLACE FUNCTION "public"."enforce_coach_task_update_scope"',
    'CREATE OR REPLACE TRIGGER "trg_enforce_coach_task_update_scope"',
+   'CREATE OR REPLACE FUNCTION "public"."enforce_phase_lead_task_update_scope"',
+   'CREATE OR REPLACE TRIGGER "trg_enforce_phase_lead_task_update_scope"',
    'CREATE OR REPLACE FUNCTION "public"."enforce_task_hierarchy_depth"',
    'CREATE OR REPLACE TRIGGER "trg_enforce_task_hierarchy_depth"',
    'CREATE OR REPLACE FUNCTION "public"."enforce_task_date_envelope"',
@@ -128,7 +130,24 @@ describe('docs/db/schema.sql source of truth', () => {
   expect(sql).toContain('OLD.assignee_id IS DISTINCT FROM NEW.assignee_id');
   expect(sql).toContain("COALESCE(NEW.status, '') NOT IN");
   expect(schema).toContain('WITH CHECK (("public"."has_project_role"(COALESCE("root_id", "id"), ( SELECT "auth"."uid"() AS "uid"), ARRAY[\'coach\'::"text"])');
-  expect(schema).toContain('COMMENT ON POLICY "Enable update for coaches on coaching tasks"');
+ expect(schema).toContain('COMMENT ON POLICY "Enable update for coaches on coaching tasks"');
+ });
+
+ it('keeps task role matrix admin and phase-lead rules enforced below the UI', () => {
+  const sql = functionSql('enforce_phase_lead_task_update_scope');
+
+  expect(sql).toContain("public.has_project_role(v_project_id, v_actor_id, ARRAY['viewer', 'limited'])");
+  expect(sql).toContain('public.user_is_phase_lead(OLD.id, v_actor_id)');
+  expect(sql).toContain('phase lead role may update only task content, schedule, and progress fields');
+  expect(sql).toContain('OLD.settings IS DISTINCT FROM NEW.settings');
+  expect(sql).toContain('OLD.assignee_id IS DISTINCT FROM NEW.assignee_id');
+  expect(sql).toContain('OLD.parent_task_id IS DISTINCT FROM NEW.parent_task_id');
+  expect(schema).toContain('CREATE POLICY "Enable update for phase leads"');
+  expect(schema).toContain('ARRAY[\'viewer\'::"text", \'limited\'::"text"]');
+  expect(schema).toContain('CREATE POLICY "Enable update for users" ON "public"."tasks" FOR UPDATE USING (((("creator" = ( SELECT "auth"."uid"() AS "uid"))');
+  expect(schema).toContain('OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid"))) AND (("origin" IS DISTINCT FROM \'template\'::"text")');
+  expect(schema).toContain('CREATE POLICY "Enable delete for users" ON "public"."tasks" FOR DELETE USING ((("creator" = ( SELECT "auth"."uid"() AS "uid"))');
+  expect(schema).toContain('CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated"');
  });
 
  it('keeps task hierarchy depth enforced below the UI', () => {

--- a/docs/architecture/auth-rbac.md
+++ b/docs/architecture/auth-rbac.md
@@ -25,7 +25,7 @@ The Auth & RBAC system manages application-level authentication, user account li
 | **View all tasks/hierarchy** | Yes | Yes | Yes | Yes |
 | **Edit task text info/fields**| Yes | Yes | Yes (If Assigned Lead) | No |
 | **Update task status** | Yes | Yes | Yes (If Assigned Lead) | Yes (Coaching Tasks Only)|
-| **Add tasks / subtasks** | Yes | Yes | Yes (If Assigned Lead) | No |
+| **Add tasks / subtasks** | Yes | Yes | No | No |
 | **Delete tasks / subtasks** | Yes | Yes | No | No |
 | **Assign Lead to task** | Yes | No | No | No |
 | **Drag & Drop (Mutate)** | Yes | Yes | No | No |
@@ -92,7 +92,7 @@ A project Owner may designate any `viewer` or `limited`-role member as the **Lea
 
 **UI** (`src/features/tasks/components/TaskFormFields.tsx`): the `<PhaseLeadPicker>` sub-component (multi-select popover) renders only for `membershipRole === 'owner'` on phase/milestone rows. Options come from `useTeam(projectId).teamMembers.filter(m => m.role === 'viewer' || m.role === 'limited')` — owners/editors/admins already have task edit privileges, while coaches are governed by the separate Coaching-task progress scope. Badge in `TaskDetailsView.tsx` lists current leads.
 
-**Permission matrix update**: limited viewers may now edit tasks under any phase/milestone they are designated as Phase Lead for. See the matrix footnote above.
+**Permission matrix update**: limited viewers may now edit existing tasks under any phase/milestone they are designated as Phase Lead for. Phase Lead scope does not grant INSERT, DELETE, drag/reparent, task assignment, project settings, or phase-lead assignment authority; those remain owner/editor/admin-controlled below UI.
 
 ### Notification Preferences (Wave 30)
 

--- a/docs/db/schema.sql
+++ b/docs/db/schema.sql
@@ -869,6 +869,83 @@ ALTER FUNCTION "public"."enforce_coach_task_update_scope"() OWNER TO "postgres";
 COMMENT ON FUNCTION "public"."enforce_coach_task_update_scope"() IS 'Restricts project coaches to status/progress updates on Coaching-labeled instance tasks. Owner/editor/admin and service-role maintenance paths bypass explicitly.';
 
 
+CREATE OR REPLACE FUNCTION "public"."enforce_phase_lead_task_update_scope"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO ''
+    AS $$
+DECLARE
+    v_actor_id uuid := auth.uid();
+    v_project_id uuid := COALESCE(OLD.root_id, NEW.root_id, OLD.id, NEW.id);
+BEGIN
+    IF current_user IN ('postgres', 'supabase_admin', 'service_role')
+        OR auth.role() = 'service_role'
+    THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_actor_id IS NULL OR v_project_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF public.is_admin(v_actor_id)
+        OR public.has_project_role(v_project_id, v_actor_id, ARRAY['owner', 'editor'])
+    THEN
+        RETURN NEW;
+    END IF;
+
+    IF NOT (
+        public.has_project_role(v_project_id, v_actor_id, ARRAY['viewer', 'limited'])
+        AND public.user_is_phase_lead(OLD.id, v_actor_id)
+    ) THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.origin IS DISTINCT FROM 'instance'
+        OR NOT public.user_is_phase_lead(NEW.id, v_actor_id)
+    THEN
+        RAISE EXCEPTION 'phase lead role may update only existing descendant instance tasks'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF
+        OLD.id IS DISTINCT FROM NEW.id
+        OR OLD.root_id IS DISTINCT FROM NEW.root_id
+        OR OLD.parent_task_id IS DISTINCT FROM NEW.parent_task_id
+        OR OLD.position IS DISTINCT FROM NEW.position
+        OR OLD.origin IS DISTINCT FROM NEW.origin
+        OR OLD.creator IS DISTINCT FROM NEW.creator
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at
+        OR OLD.assignee_id IS DISTINCT FROM NEW.assignee_id
+        OR OLD.settings IS DISTINCT FROM NEW.settings
+        OR OLD.notes IS DISTINCT FROM NEW.notes
+        OR OLD.primary_resource_id IS DISTINCT FROM NEW.primary_resource_id
+        OR OLD.is_locked IS DISTINCT FROM NEW.is_locked
+        OR OLD.prerequisite_phase_id IS DISTINCT FROM NEW.prerequisite_phase_id
+        OR OLD.parent_project_id IS DISTINCT FROM NEW.parent_project_id
+        OR OLD.project_type IS DISTINCT FROM NEW.project_type
+        OR OLD.is_premium IS DISTINCT FROM NEW.is_premium
+        OR OLD.location IS DISTINCT FROM NEW.location
+        OR OLD.priority IS DISTINCT FROM NEW.priority
+        OR OLD.supervisor_email IS DISTINCT FROM NEW.supervisor_email
+        OR OLD.task_type IS DISTINCT FROM NEW.task_type
+        OR OLD.template_version IS DISTINCT FROM NEW.template_version
+        OR OLD.cloned_from_task_id IS DISTINCT FROM NEW.cloned_from_task_id
+    THEN
+        RAISE EXCEPTION 'phase lead role may update only task content, schedule, and progress fields'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."enforce_phase_lead_task_update_scope"() OWNER TO "postgres";
+
+
+COMMENT ON FUNCTION "public"."enforce_phase_lead_task_update_scope"() IS 'Restricts viewer/limited Phase Leads to content, schedule, and progress updates on existing descendant instance tasks. Owner/editor/admin and service-role maintenance paths bypass explicitly.';
+
+
 CREATE OR REPLACE FUNCTION "public"."calc_task_date_rollup"() RETURNS "trigger"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''
@@ -3246,6 +3323,9 @@ CREATE OR REPLACE TRIGGER "trg_enforce_coach_task_update_scope" BEFORE UPDATE ON
 CREATE OR REPLACE TRIGGER "trg_enforce_ics_feed_token_update_scope" BEFORE UPDATE ON "public"."ics_feed_tokens" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_ics_feed_token_update_scope"();
 
 
+CREATE OR REPLACE TRIGGER "trg_enforce_phase_lead_task_update_scope" BEFORE UPDATE ON "public"."tasks" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_phase_lead_task_update_scope"();
+
+
 
 CREATE OR REPLACE TRIGGER "trg_enforce_task_hierarchy_depth" BEFORE INSERT OR UPDATE OF "parent_task_id" ON "public"."tasks" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_task_hierarchy_depth"();
 
@@ -3480,7 +3560,7 @@ CREATE POLICY "Allow project creation" ON "public"."tasks" FOR INSERT TO "authen
 
 
 
-CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((("root_id" IS NOT NULL) AND "public"."has_project_role"("root_id", ( SELECT "auth"."uid"() AS "uid"), ARRAY['owner'::"text", 'editor'::"text"]) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid")))));
+CREATE POLICY "Allow subtask creation by members" ON "public"."tasks" FOR INSERT TO "authenticated" WITH CHECK ((("root_id" IS NOT NULL) AND ("public"."has_project_role"("root_id", ( SELECT "auth"."uid"() AS "uid"), ARRAY['owner'::"text", 'editor'::"text"]) OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid"))) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid")))));
 
 
 
@@ -3516,11 +3596,11 @@ CREATE POLICY "Delete invites for project owners" ON "public"."project_invites" 
 
 
 
-CREATE POLICY "Enable delete for users" ON "public"."tasks" FOR DELETE USING ((("creator" = ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")) OR "public"."has_project_role"(COALESCE("root_id", "id"), ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"), ARRAY['owner'::"text", 'editor'::"text"])));
+CREATE POLICY "Enable delete for users" ON "public"."tasks" FOR DELETE USING ((("creator" = ( SELECT "auth"."uid"() AS "uid")) OR "public"."has_project_role"(COALESCE("root_id", "id"), ( SELECT "auth"."uid"() AS "uid"), ARRAY['owner'::"text", 'editor'::"text"]) OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid"))));
 
 
 
-CREATE POLICY "Enable insert for authenticated users within project" ON "public"."tasks" FOR INSERT WITH CHECK ((((("auth"."role"() = 'authenticated'::"text") AND ("root_id" IS NULL) AND ("parent_task_id" IS NULL) AND ("creator" = ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))) OR "public"."has_project_role"("root_id", ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"), ARRAY['owner'::"text", 'editor'::"text"])) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")))));
+CREATE POLICY "Enable insert for authenticated users within project" ON "public"."tasks" FOR INSERT WITH CHECK (((("auth"."role"() = 'authenticated'::"text") AND ("root_id" IS NULL) AND ("parent_task_id" IS NULL) AND ("creator" = ( SELECT "auth"."uid"() AS "uid"))) OR "public"."has_project_role"("root_id", ( SELECT "auth"."uid"() AS "uid"), ARRAY['owner'::"text", 'editor'::"text"]) OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid"))) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid"))));
 
 
 
@@ -3536,11 +3616,11 @@ COMMENT ON POLICY "Enable update for coaches on coaching tasks" ON "public"."tas
 
 
 
-CREATE POLICY "Enable update for phase leads" ON "public"."tasks" FOR UPDATE TO "authenticated" USING ((("origin" = 'instance'::"text") AND "public"."user_is_phase_lead"("id", ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")))) WITH CHECK ((("origin" = 'instance'::"text") AND "public"."user_is_phase_lead"("id", ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"))));
+CREATE POLICY "Enable update for phase leads" ON "public"."tasks" FOR UPDATE TO "authenticated" USING ((("origin" = 'instance'::"text") AND "public"."has_project_role"(COALESCE("root_id", "id"), ( SELECT "auth"."uid"() AS "uid"), ARRAY['viewer'::"text", 'limited'::"text"]) AND "public"."user_is_phase_lead"("id", ( SELECT "auth"."uid"() AS "uid")))) WITH CHECK ((("origin" = 'instance'::"text") AND "public"."has_project_role"(COALESCE("root_id", "id"), ( SELECT "auth"."uid"() AS "uid"), ARRAY['viewer'::"text", 'limited'::"text"]) AND "public"."user_is_phase_lead"("id", ( SELECT "auth"."uid"() AS "uid"))));
 
 
 
-CREATE POLICY "Enable update for users" ON "public"."tasks" FOR UPDATE USING (((("creator" = ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")) OR "public"."has_project_role"(COALESCE("root_id", "id"), ( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid"), ARRAY['owner'::"text", 'editor'::"text"])) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT (("auth"."jwt"() ->> 'sub'::"text"))::"uuid" AS "uuid")))));
+CREATE POLICY "Enable update for users" ON "public"."tasks" FOR UPDATE USING (((("creator" = ( SELECT "auth"."uid"() AS "uid")) OR "public"."has_project_role"(COALESCE("root_id", "id"), ( SELECT "auth"."uid"() AS "uid"), ARRAY['owner'::"text", 'editor'::"text"]) OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid"))) AND (("origin" IS DISTINCT FROM 'template'::"text") OR "public"."is_admin"(( SELECT "auth"."uid"() AS "uid")))));
 
 
 

--- a/src/features/tasks/lib/task-permissions.ts
+++ b/src/features/tasks/lib/task-permissions.ts
@@ -21,6 +21,13 @@ export function hasFullTaskEditRole(role: ProjectMembershipRole): boolean {
     return role === ROLES.OWNER || role === ROLES.EDITOR || role === ROLES.ADMIN;
 }
 
+/**
+ * Determine whether a viewer/limited user has Phase Lead authority for a task.
+ *
+ * @param role - The caller's project membership role.
+ * @param context - Task ancestry and current-user context for the permission check.
+ * @returns True when the user leads an ancestor phase or milestone for the task.
+ */
 function hasPhaseLeadTaskEditScope(
     role: ProjectMembershipRole,
     context?: TaskPermissionContext,
@@ -53,6 +60,7 @@ function hasPhaseLeadTaskEditScope(
  *
  * @param role - The caller's project membership role.
  * @param task - The task being updated.
+ * @param context - Optional project context for Phase Lead permission evaluation.
  * @returns True when status/progress updates are allowed for this task.
  */
 export function canUpdateTaskProgress(

--- a/src/features/tasks/lib/task-permissions.ts
+++ b/src/features/tasks/lib/task-permissions.ts
@@ -1,8 +1,15 @@
 import { ROLES } from '@/shared/constants';
 import type { TaskRow } from '@/shared/db/app.types';
 import { extractCoachingFlag } from '@/features/tasks/lib/coaching-form';
+import { extractPhaseLeads } from '@/shared/lib/phase-lead';
 
 export type ProjectMembershipRole = string | null | undefined;
+
+type TaskPermissionContext = {
+    task?: Partial<TaskRow> | null;
+    allProjectTasks?: readonly Partial<TaskRow>[];
+    userId?: string | null;
+};
 
 /**
  * Determine whether a project role has unrestricted task edit authority.
@@ -14,6 +21,33 @@ export function hasFullTaskEditRole(role: ProjectMembershipRole): boolean {
     return role === ROLES.OWNER || role === ROLES.EDITOR || role === ROLES.ADMIN;
 }
 
+function hasPhaseLeadTaskEditScope(
+    role: ProjectMembershipRole,
+    context?: TaskPermissionContext,
+): boolean {
+    if (role !== ROLES.VIEWER && role !== ROLES.LIMITED) return false;
+    if (!context?.userId || !context.task?.parent_task_id) return false;
+
+    const tasksById = new Map(
+        (context.allProjectTasks ?? [])
+            .filter((task): task is Partial<TaskRow> & { id: string } => typeof task.id === 'string')
+            .map((task) => [task.id, task]),
+    );
+
+    let parentId: string | null | undefined = context.task.parent_task_id;
+    const visited = new Set<string>();
+
+    while (parentId && !visited.has(parentId)) {
+        visited.add(parentId);
+        const parent = tasksById.get(parentId);
+        if (!parent) return false;
+        if (extractPhaseLeads(parent).includes(context.userId)) return true;
+        parentId = parent.parent_task_id;
+    }
+
+    return false;
+}
+
 /**
  * Determine whether a role may update a task's progress/status fields.
  *
@@ -21,8 +55,13 @@ export function hasFullTaskEditRole(role: ProjectMembershipRole): boolean {
  * @param task - The task being updated.
  * @returns True when status/progress updates are allowed for this task.
  */
-export function canUpdateTaskProgress(role: ProjectMembershipRole, task?: Partial<TaskRow> | null): boolean {
+export function canUpdateTaskProgress(
+    role: ProjectMembershipRole,
+    task?: Partial<TaskRow> | null,
+    context?: Omit<TaskPermissionContext, 'task'>,
+): boolean {
     if (hasFullTaskEditRole(role)) return true;
+    if (hasPhaseLeadTaskEditScope(role, { ...context, task })) return true;
     return role === ROLES.COACH
         && task?.origin === 'instance'
         && extractCoachingFlag(task);
@@ -34,8 +73,11 @@ export function canUpdateTaskProgress(role: ProjectMembershipRole, task?: Partia
  * @param role - The caller's project membership role.
  * @returns True when task content edits are allowed.
  */
-export function canEditTaskContent(role: ProjectMembershipRole): boolean {
-    return hasFullTaskEditRole(role);
+export function canEditTaskContent(
+    role: ProjectMembershipRole,
+    context?: TaskPermissionContext,
+): boolean {
+    return hasFullTaskEditRole(role) || hasPhaseLeadTaskEditScope(role, context);
 }
 
 /**

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -224,15 +224,27 @@ export default function Project() {
     const isGlobalAdmin = user?.role === ROLES.ADMIN;
     const currentMember = teamMembers?.find((m: { user_id?: string }) => m.user_id === user?.id);
     const userRole = isGlobalAdmin ? ROLES.ADMIN : currentMember?.role || (isOwnerByProject ? ROLES.OWNER : ROLES.VIEWER);
+    const projectTaskRows = useMemo(() => (projectHierarchy as TaskRow[]) || [], [projectHierarchy]);
 
     const canEdit = canEditTaskContent(userRole);
     const canCreateTasks = canCreateChildTask(userRole);
     const canReorderTasks = canReorderTask(userRole);
     const canInvite = canManageProjectMembers(userRole);
     const canManageSettings = canManageProjectMembers(userRole);
+    const canEditTaskForRow = useCallback(
+        (task: TaskRow) => canEditTaskContent(userRole, {
+            task,
+            allProjectTasks: projectTaskRows,
+            userId: user?.id ?? null,
+        }),
+        [projectTaskRows, user?.id, userRole],
+    );
     const canUpdateTaskStatusForRow = useCallback(
-        (task: TaskRow) => canUpdateTaskProgress(userRole, task),
-        [userRole],
+        (task: TaskRow) => canUpdateTaskProgress(userRole, task, {
+            allProjectTasks: projectTaskRows,
+            userId: user?.id ?? null,
+        }),
+        [projectTaskRows, user?.id, userRole],
     );
     const handleInvalidHierarchyDrop = useCallback(() => {
         toast.error(t('projects.invalid_task_hierarchy_drop'));
@@ -292,7 +304,7 @@ export default function Project() {
         <>
             <div className="flex h-full gap-8 min-w-0">
             <ProjectDndShell
-                tasks={(projectHierarchy as TaskRow[]) || []}
+                tasks={projectTaskRows}
                 onTaskUpdate={canReorderTasks ? handlers.handleTaskUpdate : () => undefined}
                 onToggleExpand={handlers.handleToggleExpand}
                 onInvalidDrop={handleInvalidHierarchyDrop}
@@ -302,7 +314,7 @@ export default function Project() {
                     <ProjectHeader
                         project={project as ProjectType}
                         tasks={tasks as TaskRow[]}
-                        stateTasks={projectHierarchy as TaskRow[]}
+                        stateTasks={projectTaskRows}
                         teamMembers={teamMembers}
                         canInvite={canInvite}
                         canManageSettings={canManageSettings}
@@ -389,7 +401,7 @@ export default function Project() {
                                                         onToggleExpand={handlers.handleToggleExpand}
                                                         onTaskClick={(task: TaskRow) => {
                                                             handlers.handleTaskClick(task);
-                                                            setTaskFormState(canEdit ? { mode: 'edit', origin: projectOrigin } : null);
+                                                            setTaskFormState(canEditTaskForRow(task) ? { mode: 'edit', origin: projectOrigin } : null);
                                                         }}
                                                         onInlineCommit={canCreateTasks ? handlers.handleInlineCommit : undefined}
                                                         onInlineCancel={() => actions.setInlineAddingParentId(null)}
@@ -448,7 +460,7 @@ export default function Project() {
                         taskBeingEdited={taskFormState?.mode === 'edit' ? state.selectedTask || undefined : undefined}
                         parentTaskForForm={state.inlineAddingParentId ? (tasks?.find(t => t.id === state.inlineAddingParentId) as TaskRow) : undefined}
                         membershipRole={userRole}
-                        allProjectTasks={(projectHierarchy as TaskRow[]) || []}
+                        allProjectTasks={projectTaskRows}
                         teamMembers={teamMembers}
                         showComments={false}
                         onClose={() => {
@@ -468,12 +480,13 @@ export default function Project() {
                                 excludeTemplateIds={excludedTemplateIds}
                             />
                         )}
-                        canEdit={canEdit}
+                        canEdit={state.selectedTask ? canEditTaskForRow(state.selectedTask) : canEdit}
                         onDeleteTaskWrapper={
                             state.selectedTask && canDeleteTaskForRole(userRole, state.selectedTask)
                                 ? async () => { if (state.selectedTask) await handlers.handleDeleteTask(state.selectedTask); }
                                 : undefined
                         }
+                        handleAddChildTask={canCreateTasks ? handlers.handleStartInlineAdd : undefined}
                         handleEditTask={(task) => {
                             actions.setSelectedTask(task as TaskRow);
                             setTaskFormState({ mode: 'edit', origin: projectOrigin });

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -198,7 +198,11 @@ export default function TasksPage() {
               }
               return undefined;
        }, [currentSelectedTask, selectedTeamMembers, selectedProjectRoot, currentUserId]);
-       const selectedCanEdit = canEditTaskContent(selectedMembershipRole);
+       const selectedCanEdit = canEditTaskContent(selectedMembershipRole, {
+              task: selectedTaskForPanel,
+              allProjectTasks: selectedProjectTasks,
+              userId: currentUserId,
+       });
        const selectedCanDelete = selectedTaskForPanel
               ? canDeleteTaskForRole(selectedMembershipRole, selectedTaskForPanel)
               : false;

--- a/supabase/migrations/20260509000000_rbac_role_matrix_hardening.sql
+++ b/supabase/migrations/20260509000000_rbac_role_matrix_hardening.sql
@@ -1,0 +1,163 @@
+-- PR 2: role-permission matrix hardening.
+--
+-- Current architecture treats global admins as full task administrators, but
+-- the task INSERT/UPDATE/DELETE policies only covered creators and
+-- owner/editor project members. It also lets viewer/limited Phase Leads update
+-- existing descendant tasks, but the policy was broad enough to accept crafted
+-- structural/settings/assignment payloads. Keep both rules explicit below RLS.
+
+CREATE OR REPLACE FUNCTION public.enforce_phase_lead_task_update_scope()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+    v_actor_id uuid := auth.uid();
+    v_project_id uuid := COALESCE(OLD.root_id, NEW.root_id, OLD.id, NEW.id);
+BEGIN
+    IF current_user IN ('postgres', 'supabase_admin', 'service_role')
+        OR auth.role() = 'service_role'
+    THEN
+        RETURN NEW;
+    END IF;
+
+    IF v_actor_id IS NULL OR v_project_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF public.is_admin(v_actor_id)
+        OR public.has_project_role(v_project_id, v_actor_id, ARRAY['owner', 'editor'])
+    THEN
+        RETURN NEW;
+    END IF;
+
+    IF NOT (
+        public.has_project_role(v_project_id, v_actor_id, ARRAY['viewer', 'limited'])
+        AND public.user_is_phase_lead(OLD.id, v_actor_id)
+    ) THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.origin IS DISTINCT FROM 'instance'
+        OR NOT public.user_is_phase_lead(NEW.id, v_actor_id)
+    THEN
+        RAISE EXCEPTION 'phase lead role may update only existing descendant instance tasks'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    IF
+        OLD.id IS DISTINCT FROM NEW.id
+        OR OLD.root_id IS DISTINCT FROM NEW.root_id
+        OR OLD.parent_task_id IS DISTINCT FROM NEW.parent_task_id
+        OR OLD.position IS DISTINCT FROM NEW.position
+        OR OLD.origin IS DISTINCT FROM NEW.origin
+        OR OLD.creator IS DISTINCT FROM NEW.creator
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at
+        OR OLD.assignee_id IS DISTINCT FROM NEW.assignee_id
+        OR OLD.settings IS DISTINCT FROM NEW.settings
+        OR OLD.notes IS DISTINCT FROM NEW.notes
+        OR OLD.primary_resource_id IS DISTINCT FROM NEW.primary_resource_id
+        OR OLD.is_locked IS DISTINCT FROM NEW.is_locked
+        OR OLD.prerequisite_phase_id IS DISTINCT FROM NEW.prerequisite_phase_id
+        OR OLD.parent_project_id IS DISTINCT FROM NEW.parent_project_id
+        OR OLD.project_type IS DISTINCT FROM NEW.project_type
+        OR OLD.is_premium IS DISTINCT FROM NEW.is_premium
+        OR OLD.location IS DISTINCT FROM NEW.location
+        OR OLD.priority IS DISTINCT FROM NEW.priority
+        OR OLD.supervisor_email IS DISTINCT FROM NEW.supervisor_email
+        OR OLD.task_type IS DISTINCT FROM NEW.task_type
+        OR OLD.template_version IS DISTINCT FROM NEW.template_version
+        OR OLD.cloned_from_task_id IS DISTINCT FROM NEW.cloned_from_task_id
+    THEN
+        RAISE EXCEPTION 'phase lead role may update only task content, schedule, and progress fields'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.enforce_phase_lead_task_update_scope() OWNER TO postgres;
+
+COMMENT ON FUNCTION public.enforce_phase_lead_task_update_scope() IS
+    'Restricts viewer/limited Phase Leads to content, schedule, and progress updates on existing descendant instance tasks. Owner/editor/admin and service-role maintenance paths bypass explicitly.';
+
+DROP TRIGGER IF EXISTS "trg_enforce_phase_lead_task_update_scope" ON public.tasks;
+CREATE TRIGGER "trg_enforce_phase_lead_task_update_scope"
+BEFORE UPDATE ON public.tasks
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_phase_lead_task_update_scope();
+
+DROP POLICY IF EXISTS "Allow project creation" ON public.tasks;
+CREATE POLICY "Allow project creation" ON public.tasks
+FOR INSERT TO authenticated
+WITH CHECK (
+    ((root_id IS NULL) OR (root_id = id))
+    AND parent_task_id IS NULL
+    AND creator = (SELECT auth.uid() AS uid)
+    AND (origin IS DISTINCT FROM 'template' OR public.is_admin((SELECT auth.uid() AS uid)))
+);
+
+DROP POLICY IF EXISTS "Allow subtask creation by members" ON public.tasks;
+CREATE POLICY "Allow subtask creation by members" ON public.tasks
+FOR INSERT TO authenticated
+WITH CHECK (
+    root_id IS NOT NULL
+    AND (
+        public.has_project_role(root_id, (SELECT auth.uid() AS uid), ARRAY['owner', 'editor'])
+        OR public.is_admin((SELECT auth.uid() AS uid))
+    )
+    AND (origin IS DISTINCT FROM 'template' OR public.is_admin((SELECT auth.uid() AS uid)))
+);
+
+DROP POLICY IF EXISTS "Enable insert for authenticated users within project" ON public.tasks;
+CREATE POLICY "Enable insert for authenticated users within project" ON public.tasks
+FOR INSERT
+WITH CHECK (
+    (
+        (
+            auth.role() = 'authenticated'
+            AND root_id IS NULL
+            AND parent_task_id IS NULL
+            AND creator = (SELECT auth.uid() AS uid)
+        )
+        OR public.has_project_role(root_id, (SELECT auth.uid() AS uid), ARRAY['owner', 'editor'])
+        OR public.is_admin((SELECT auth.uid() AS uid))
+    )
+    AND (origin IS DISTINCT FROM 'template' OR public.is_admin((SELECT auth.uid() AS uid)))
+);
+
+DROP POLICY IF EXISTS "Enable delete for users" ON public.tasks;
+CREATE POLICY "Enable delete for users" ON public.tasks
+FOR DELETE
+USING (
+    creator = (SELECT auth.uid() AS uid)
+    OR public.has_project_role(COALESCE(root_id, id), (SELECT auth.uid() AS uid), ARRAY['owner', 'editor'])
+    OR public.is_admin((SELECT auth.uid() AS uid))
+);
+
+DROP POLICY IF EXISTS "Enable update for phase leads" ON public.tasks;
+CREATE POLICY "Enable update for phase leads" ON public.tasks
+FOR UPDATE TO authenticated
+USING (
+    origin = 'instance'
+    AND public.has_project_role(COALESCE(root_id, id), (SELECT auth.uid() AS uid), ARRAY['viewer', 'limited'])
+    AND public.user_is_phase_lead(id, (SELECT auth.uid() AS uid))
+)
+WITH CHECK (
+    origin = 'instance'
+    AND public.has_project_role(COALESCE(root_id, id), (SELECT auth.uid() AS uid), ARRAY['viewer', 'limited'])
+    AND public.user_is_phase_lead(id, (SELECT auth.uid() AS uid))
+);
+
+DROP POLICY IF EXISTS "Enable update for users" ON public.tasks;
+CREATE POLICY "Enable update for users" ON public.tasks
+FOR UPDATE
+USING (
+    (
+        creator = (SELECT auth.uid() AS uid)
+        OR public.has_project_role(COALESCE(root_id, id), (SELECT auth.uid() AS uid), ARRAY['owner', 'editor'])
+        OR public.is_admin((SELECT auth.uid() AS uid))
+    )
+    AND (origin IS DISTINCT FROM 'template' OR public.is_admin((SELECT auth.uid() AS uid)))
+);

--- a/supabase/tests/pgtap_task_role_matrix.sql
+++ b/supabase/tests/pgtap_task_role_matrix.sql
@@ -1,0 +1,352 @@
+BEGIN;
+
+SELECT plan(33);
+
+TRUNCATE TABLE
+    public.activity_log,
+    public.admin_users,
+    public.task_comments,
+    public.project_members,
+    public.tasks
+CASCADE;
+
+DELETE FROM auth.users
+WHERE email IN (
+    'role-matrix-owner@example.com',
+    'role-matrix-editor@example.com',
+    'role-matrix-coach@example.com',
+    'role-matrix-viewer@example.com',
+    'role-matrix-limited@example.com',
+    'role-matrix-admin@example.com',
+    'role-matrix-outsider@example.com'
+);
+
+INSERT INTO auth.users (id, email) VALUES
+    ('00000000-0000-0000-0000-000000000801', 'role-matrix-owner@example.com'),
+    ('00000000-0000-0000-0000-000000000802', 'role-matrix-editor@example.com'),
+    ('00000000-0000-0000-0000-000000000803', 'role-matrix-coach@example.com'),
+    ('00000000-0000-0000-0000-000000000804', 'role-matrix-viewer@example.com'),
+    ('00000000-0000-0000-0000-000000000805', 'role-matrix-limited@example.com'),
+    ('00000000-0000-0000-0000-000000000806', 'role-matrix-admin@example.com'),
+    ('00000000-0000-0000-0000-000000000807', 'role-matrix-outsider@example.com');
+
+INSERT INTO public.admin_users (user_id, email, granted_by)
+VALUES ('00000000-0000-0000-0000-000000000806', 'role-matrix-admin@example.com', 'pgtap');
+
+INSERT INTO public.tasks (
+    id, title, origin, creator, root_id, parent_task_id, settings, status, position, task_type
+) VALUES
+    (
+        '11111111-1111-1111-1111-111111111801',
+        'Role Matrix Project',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        NULL,
+        '{}'::jsonb,
+        'not_started',
+        1,
+        'project'
+    ),
+    (
+        '22222222-2222-2222-2222-222222222801',
+        'Lead Phase',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        '11111111-1111-1111-1111-111111111801',
+        '{"phase_lead_user_ids": ["00000000-0000-0000-0000-000000000804", "00000000-0000-0000-0000-000000000805"]}'::jsonb,
+        'not_started',
+        1,
+        'phase'
+    ),
+    (
+        '22222222-2222-2222-2222-222222222802',
+        'Sibling Phase',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        '11111111-1111-1111-1111-111111111801',
+        '{}'::jsonb,
+        'not_started',
+        2,
+        'phase'
+    ),
+    (
+        '33333333-3333-3333-3333-333333333801',
+        'Lead Milestone',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        '22222222-2222-2222-2222-222222222801',
+        '{}'::jsonb,
+        'not_started',
+        1,
+        'milestone'
+    ),
+    (
+        '33333333-3333-3333-3333-333333333802',
+        'Sibling Milestone',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        '22222222-2222-2222-2222-222222222802',
+        '{}'::jsonb,
+        'not_started',
+        1,
+        'milestone'
+    ),
+    (
+        '44444444-4444-4444-4444-444444444801',
+        'Lead Task',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        '33333333-3333-3333-3333-333333333801',
+        '{}'::jsonb,
+        'not_started',
+        1,
+        'task'
+    ),
+    (
+        '44444444-4444-4444-4444-444444444802',
+        'Sibling Task',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        '33333333-3333-3333-3333-333333333802',
+        '{}'::jsonb,
+        'not_started',
+        1,
+        'task'
+    ),
+    (
+        '44444444-4444-4444-4444-444444444803',
+        'Coaching Task',
+        'instance',
+        '00000000-0000-0000-0000-000000000801',
+        '11111111-1111-1111-1111-111111111801',
+        '33333333-3333-3333-3333-333333333801',
+        '{"is_coaching_task": true}'::jsonb,
+        'not_started',
+        2,
+        'task'
+    );
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+    ('11111111-1111-1111-1111-111111111801', '00000000-0000-0000-0000-000000000801', 'owner'),
+    ('11111111-1111-1111-1111-111111111801', '00000000-0000-0000-0000-000000000802', 'editor'),
+    ('11111111-1111-1111-1111-111111111801', '00000000-0000-0000-0000-000000000803', 'coach'),
+    ('11111111-1111-1111-1111-111111111801', '00000000-0000-0000-0000-000000000804', 'viewer'),
+    ('11111111-1111-1111-1111-111111111801', '00000000-0000-0000-0000-000000000805', 'limited');
+
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000801', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000801"}', true);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET title = 'Owner edited task' WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    'owner can update task content'
+);
+
+SELECT lives_ok(
+    $$ INSERT INTO public.tasks (id, root_id, parent_task_id, creator, title, origin, status)
+       VALUES ('55555555-5555-5555-5555-555555555801', '11111111-1111-1111-1111-111111111801', '44444444-4444-4444-4444-444444444801', '00000000-0000-0000-0000-000000000801', 'Owner subtask', 'instance', 'not_started') $$,
+    'owner can create child tasks'
+);
+
+SELECT lives_ok(
+    $$ DELETE FROM public.tasks WHERE id = '55555555-5555-5555-5555-555555555801' $$,
+    'owner can delete custom child tasks'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000802', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000802"}', true);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET description = 'Editor content edit' WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    'editor can update task content'
+);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET settings = settings || '{"due_soon_threshold": 5}'::jsonb WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    'editor settings access is unaffected by phase lead restrictions'
+);
+
+SELECT lives_ok(
+    $$ INSERT INTO public.tasks (id, root_id, parent_task_id, creator, title, origin, status)
+       VALUES ('55555555-5555-5555-5555-555555555802', '11111111-1111-1111-1111-111111111801', '44444444-4444-4444-4444-444444444801', '00000000-0000-0000-0000-000000000802', 'Editor subtask', 'instance', 'not_started') $$,
+    'editor can create child tasks'
+);
+
+SELECT lives_ok(
+    $$ DELETE FROM public.tasks WHERE id = '55555555-5555-5555-5555-555555555802' $$,
+    'editor can delete custom child tasks'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000806', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000806"}', true);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET title = 'Admin edited task' WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    'global admin can update instance tasks without project membership'
+);
+
+SELECT lives_ok(
+    $$ INSERT INTO public.tasks (id, root_id, parent_task_id, creator, title, origin, status)
+       VALUES ('55555555-5555-5555-5555-555555555806', '11111111-1111-1111-1111-111111111801', '44444444-4444-4444-4444-444444444801', '00000000-0000-0000-0000-000000000806', 'Admin subtask', 'instance', 'not_started') $$,
+    'global admin can create instance child tasks without project membership'
+);
+
+SELECT lives_ok(
+    $$ DELETE FROM public.tasks WHERE id = '55555555-5555-5555-5555-555555555806' $$,
+    'global admin can delete instance tasks without project membership'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000804', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000804"}', true);
+
+SELECT is(
+    (SELECT count(*) FROM public.tasks),
+    8::bigint,
+    'viewer can read project tasks'
+);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET title = 'Viewer lead content edit' WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    'viewer phase lead can update content on descendant tasks'
+);
+
+SELECT is(
+    (SELECT title FROM public.tasks WHERE id = '44444444-4444-4444-4444-444444444801'),
+    'Viewer lead content edit',
+    'viewer phase lead content update persists'
+);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET title = 'Viewer sibling edit attempt' WHERE id = '44444444-4444-4444-4444-444444444802' $$,
+    'viewer non-lead sibling update is rejected by RLS without mutating'
+);
+
+SELECT isnt(
+    (SELECT title FROM public.tasks WHERE id = '44444444-4444-4444-4444-444444444802'),
+    'Viewer sibling edit attempt',
+    'viewer cannot update tasks outside their lead scope'
+);
+
+SELECT throws_like(
+    $$ UPDATE public.tasks SET settings = settings || '{"phase_lead_user_ids": ["00000000-0000-0000-0000-000000000804"]}'::jsonb WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    '%phase lead role may update only task content, schedule, and progress fields%',
+    'viewer phase lead cannot mutate protected settings'
+);
+
+SELECT throws_like(
+    $$ UPDATE public.tasks SET parent_task_id = '33333333-3333-3333-3333-333333333802' WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    '%phase lead role may update only task content, schedule, and progress fields%',
+    'viewer phase lead cannot reparent tasks'
+);
+
+SELECT throws_ok(
+    $$ INSERT INTO public.tasks (id, root_id, parent_task_id, creator, title, origin, status)
+       VALUES ('55555555-5555-5555-5555-555555555804', '11111111-1111-1111-1111-111111111801', '44444444-4444-4444-4444-444444444801', '00000000-0000-0000-0000-000000000804', 'Viewer subtask attempt', 'instance', 'not_started') $$,
+    'new row violates row-level security policy for table "tasks"',
+    'viewer phase lead child insert is rejected by RLS'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.tasks WHERE id = '55555555-5555-5555-5555-555555555804'),
+    0::bigint,
+    'viewer phase lead cannot create child tasks'
+);
+
+SELECT lives_ok(
+    $$ DELETE FROM public.tasks WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    'viewer phase lead delete is rejected by RLS without deleting'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.tasks WHERE id = '44444444-4444-4444-4444-444444444801'),
+    1::bigint,
+    'viewer phase lead cannot delete tasks'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000805', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000805"}', true);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET status = 'completed' WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    'limited phase lead can update task progress'
+);
+
+SELECT is(
+    (SELECT is_complete FROM public.tasks WHERE id = '44444444-4444-4444-4444-444444444801'),
+    true,
+    'limited phase lead status update keeps completion flags in sync'
+);
+
+SELECT throws_like(
+    $$ UPDATE public.tasks SET assignee_id = '00000000-0000-0000-0000-000000000805' WHERE id = '44444444-4444-4444-4444-444444444801' $$,
+    '%phase lead role may update only task content, schedule, and progress fields%',
+    'limited phase lead cannot reassign tasks'
+);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET title = 'Limited phase self edit attempt' WHERE id = '22222222-2222-2222-2222-222222222801' $$,
+    'limited phase lead self-row update is rejected by RLS without mutating'
+);
+
+SELECT isnt(
+    (SELECT title FROM public.tasks WHERE id = '22222222-2222-2222-2222-222222222801'),
+    'Limited phase self edit attempt',
+    'limited phase lead cannot edit the phase row that grants lead scope'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000803', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000803"}', true);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET status = 'in_progress' WHERE id = '44444444-4444-4444-4444-444444444803' $$,
+    'coach can update progress on Coaching tasks'
+);
+
+SELECT throws_like(
+    $$ UPDATE public.tasks SET title = 'Coach content edit attempt' WHERE id = '44444444-4444-4444-4444-444444444803' $$,
+    '%coach role may update only task progress fields%',
+    'coach cannot update Coaching task content'
+);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET status = 'blocked' WHERE id = '44444444-4444-4444-4444-444444444802' $$,
+    'coach non-Coaching status update is rejected by RLS without mutating'
+);
+
+SELECT is(
+    (SELECT status FROM public.tasks WHERE id = '44444444-4444-4444-4444-444444444802'),
+    'not_started',
+    'coach cannot update non-Coaching tasks'
+);
+
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000807', true);
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000807"}', true);
+
+SELECT is(
+    (SELECT count(*) FROM public.tasks),
+    0::bigint,
+    'outsider cannot read project tasks'
+);
+
+SELECT lives_ok(
+    $$ UPDATE public.tasks SET title = 'Outsider edit attempt' WHERE id = '44444444-4444-4444-4444-444444444802' $$,
+    'outsider update is rejected by RLS without mutating'
+);
+
+SET LOCAL ROLE postgres;
+
+SELECT isnt(
+    (SELECT title FROM public.tasks WHERE id = '44444444-4444-4444-4444-444444444802'),
+    'Outsider edit attempt',
+    'outsider cannot update project tasks'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Harden task role-matrix enforcement below the UI for global admins and viewer/limited phase leads.
- Add pgTAP and unit characterization for owner/editor/admin/coach/viewer/limited/outsider task capabilities.
- Align RBAC docs with current DB behavior: phase leads edit existing descendant tasks only; they cannot insert/reparent/delete/assign.

## Findings addressed
- Security/RBAC/P0-P1: global admin UI claimed full task authority while DB task policies denied non-member admin mutations.
- Security/RBAC/P1: phase-lead update policy accepted crafted protected-field updates below the UI.
- UI/UX/RBAC/P1: UI hid DB-allowed phase-lead edit/status affordances for existing descendant tasks.
- Documentation/ADR drift/P2: docs implied phase leads could add tasks, contradicted by current DB insert policy.

## Evidence inspected
- Files: `src/features/tasks/lib/task-permissions.ts`, `src/pages/Project.tsx`, `src/pages/TasksPage.tsx`, `src/shared/lib/phase-lead.ts`, `src/shared/api/planterClient.ts`
- Docs/ADRs: `docs/architecture/auth-rbac.md`, `docs/architecture/tasks-subtasks.md`, `docs/AGENT_CONTEXT.md`
- Migrations/RLS/RPC/Edge: baseline task policies, coach RBAC migration/tests, new role-matrix migration
- Tests: task permission unit tests, schema-source assertions, pgTAP RLS coverage, release E2E project creation scenarios

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Task role matrix | phase-lead-aware edit/status gates; add/delete/reorder still full-role only | `planterClient` unchanged; RLS is source of truth | task policies add admin override; phase-lead trigger restricts protected fields | N/A | unit + pgTAP + release E2E | none known |

## Data/security impact
- Global admins can now mutate instance tasks according to documented/admin UI authority.
- Viewer/limited phase leads are constrained below UI to content/schedule/progress on existing descendant instance tasks only.
- No service-role/browser exposure or secret changes.

## Tests added/updated
- New pgTAP role matrix: `supabase/tests/pgtap_task_role_matrix.sql`.
- Expanded task-permission tests for phase-lead ancestry scope.
- Expanded `docs/db/schema.sql` source assertions for task RBAC enforcement.

## Commands run
```bash
npm test -- task-permissions schema-source
npm run db:local:test
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run db:local:bootstrap
node scripts/seed-e2e.js
npm run test:e2e:release
npm test -- task-permissions
npm run lint
npm run build
```

Notes:
- `npm run db:local:test` failed once while the new trigger was incorrectly marked `SECURITY DEFINER`; fixed and reran passing.
- `npm run build` failed once on a wrong `Project.tsx` handler name; fixed and reran passing.

## Bot review follow-up
- PR opened at: 2026-05-09 09:19:28 UTC
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: two low-priority JSDoc comments; fixed in `33c90691` and review threads resolved
- Codex Connector Bot comments: none found
- Other review comments: Vercel preview ready; no requested code changes
- Follow-up commits/checks: pushed JSDoc follow-up; reran local lint/focused test/build; GitHub Build & Test, E2E Tests, CodeQL, Release Drafter, and Vercel checks are green

## Rollback
- Revert this PR, including migration `20260509000000_rbac_role_matrix_hardening.sql`, UI permission mirroring, docs, and tests.

## Deferred/non-blocking follow-ups
- None.
