### PR TITLE
test: harden account lifecycle coverage

### DIFF
--- a/Testing/unit/shared/db/schema-source.test.ts
+++ b/Testing/unit/shared/db/schema-source.test.ts
@@ -297,8 +297,24 @@ describe('docs/db/schema.sql source of truth', () => {
   expect(schema).toContain(
    'ADD CONSTRAINT "tasks_creator_fkey" FOREIGN KEY ("creator") REFERENCES "auth"."users"("id") ON DELETE SET NULL;',
   );
+  expect(schema).toContain(
+   'ADD CONSTRAINT "activity_log_actor_id_fkey" FOREIGN KEY ("actor_id") REFERENCES "auth"."users"("id") ON DELETE SET NULL;',
+  );
+  [
+   'admin_users_user_id_fkey',
+   'ics_feed_tokens_user_id_fkey',
+   'notification_log_user_id_fkey',
+   'notification_preferences_user_id_fkey',
+   'project_members_user_id_fkey',
+   'push_subscriptions_user_id_fkey',
+  ].forEach((constraintName) => {
+   expect(schema).toMatch(new RegExp(`ADD CONSTRAINT "${constraintName}" FOREIGN KEY \\("user_id"\\).*ON DELETE CASCADE;`));
+  });
   expect(schema).not.toContain(
    'ADD CONSTRAINT "task_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;',
+  );
+  expect(schema).not.toContain(
+   'ADD CONSTRAINT "tasks_creator_fkey" FOREIGN KEY ("creator") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;',
   );
  });
 

--- a/docs/architecture/auth-rbac.md
+++ b/docs/architecture/auth-rbac.md
@@ -17,6 +17,27 @@ The Auth & RBAC system manages application-level authentication, user account li
 3. **Authenticated:** User receives session token and gains access to the application via `AuthContext`.
 4. **Error Handling:** Standardized generic error messages for invalid credentials to prevent enumeration.
 
+### Account Deletion / Anonymization Semantics
+
+PlanterPlan does not currently expose a self-service account deletion screen or
+an admin hard-delete action in `admin-user-moderation`; platform-level account
+deletion is performed through Supabase Auth administration. The database FK
+surface is still hardened so deleting an `auth.users` row does not corrupt
+project history:
+
+* Historical authored/assigned content is preserved and anonymized with
+  `ON DELETE SET NULL`: `task_comments.author_id`, `tasks.creator`,
+  `tasks.assignee_id`, and `activity_log.actor_id`.
+* Account-private or account-scoped rows disappear with `ON DELETE CASCADE`:
+  `project_members`, `admin_users`, `notification_preferences`,
+  `notification_log`, `push_subscriptions`, and `ics_feed_tokens`.
+* Direct authenticated-user deletion of arbitrary `auth.users` rows remains
+  blocked by database permissions; the lifecycle test verifies that failed
+  non-admin deletes leave the target account intact.
+
+Runtime coverage lives in `supabase/tests/pgtap_account_lifecycle.sql`; the
+schema-source unit test also guards the intended FK actions.
+
 ## Business Rules & Constraints
 * **Project Role Permission Matrix:**
 

--- a/docs/dev-notes.md
+++ b/docs/dev-notes.md
@@ -146,13 +146,21 @@ and project identifiers in every `mention_pending` payload.
 
 Do not grow `sw.js` beyond lifecycle + push responsibilities. The current handler implements `install` / `activate` / `push` / `notificationclick`, intentionally omits `fetch`/cache handling to avoid stale cache poisoning, normalizes malformed push payloads, and sanitizes notification click targets to same-origin paths. Any additional SW responsibility (offline queue, asset precache) waits for the TS rewrite.
 
-### `task_comments.author_id ON DELETE RESTRICT` blocks account deletion
+### Account deletion user-reference blockers
 
-**Active. Target: Wave 34 (Admin Management).** `task_comments.author_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT` (Wave 26). This matches `tasks.creator` / `project_members.user_id` — the RESTRICT was chosen deliberately per the Wave 26 plan so a comment can't go authorless while the app's `TaskCommentWithAuthor.author` contract treats non-soft-deleted rows as having an author. Trade-off: deleting an `auth.users` row is blocked if they've ever posted a comment (same blocker exists on the other two FKs).
+**Resolved (Release hardening PR 4).** The old Wave 26 note that
+`task_comments.author_id ON DELETE RESTRICT` blocked `auth.users` deletion is
+no longer accurate. `task_comments.author_id`, `tasks.creator`,
+`tasks.assignee_id`, and `activity_log.actor_id` are nullable `auth.users`
+references with `ON DELETE SET NULL`, so historical comments, tasks,
+assignments, and activity rows survive deleted/anonymized accounts.
 
-The right fix is cross-cutting, not local: when the admin / account-deletion flow ships (Wave 34 Admin Management — the original Licensing/Monetization track that would have owned account deletion was descoped during the post-Wave-31 renumber), it needs to decide how to anonymise or reassign user-owned rows across all three tables (`tasks.creator`, `project_members.user_id`, `task_comments.author_id`, plus whatever Wave 27 adds on `activity_log` / presence). Options: (a) nullable FKs with `ON DELETE SET NULL` + tombstone display everywhere, (b) a `public.deleted_users` row-retention table that every FK can reassign to during account-deletion, (c) hard-delete cascade gated by an admin-only "purge" action. (b) is cleanest for GDPR audit trails.
-
-Flagging at the Wave 26 level so the admin-flow plan doesn't miss `task_comments` when it audits the FK surface.
+Rows that are private to the account, or only meaningful while the account
+exists, intentionally cascade: `project_members`, `admin_users`,
+`notification_preferences`, `notification_log`, `push_subscriptions`, and
+`ics_feed_tokens`. The behavior is covered by
+`supabase/tests/pgtap_account_lifecycle.sql` and mirrored in the schema-source
+unit test.
 
 ### Gantt PDF export
 

--- a/supabase/tests/pgtap_account_lifecycle.sql
+++ b/supabase/tests/pgtap_account_lifecycle.sql
@@ -1,8 +1,9 @@
 BEGIN;
 
-SELECT plan(12);
+SELECT plan(14);
 
 TRUNCATE TABLE
+    public.admin_users,
     public.activity_log,
     public.notification_log,
     public.push_subscriptions,
@@ -86,9 +87,34 @@ VALUES (
     '{}'::jsonb
 );
 
+INSERT INTO public.admin_users (user_id, email)
+VALUES (
+    '00000000-0000-0000-0000-000000000402',
+    'lifecycle-deleted@example.com'
+);
+
+INSERT INTO public.activity_log (
+    id,
+    project_id,
+    actor_id,
+    entity_type,
+    entity_id,
+    action,
+    payload
+)
+VALUES (
+    '77777777-7777-7777-7777-777777777401',
+    NULL,
+    '00000000-0000-0000-0000-000000000402',
+    'member',
+    '00000000-0000-0000-0000-000000000402',
+    'admin_granted',
+    '{}'::jsonb
+);
+
 SELECT lives_ok(
     $$ DELETE FROM auth.users WHERE id = '00000000-0000-0000-0000-000000000402' $$,
-    'auth user deletion succeeds when the user authored comments, created tasks, assignments, memberships, and private rows'
+    'auth user deletion succeeds when the user authored comments, created tasks, assignments, memberships, admin rows, and private rows'
 );
 
 SELECT is(
@@ -143,6 +169,18 @@ SELECT is(
     (SELECT count(*) FROM public.notification_log WHERE user_id = '00000000-0000-0000-0000-000000000402'),
     0::bigint,
     'deleted users lose private notification log rows by cascade'
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.admin_users WHERE user_id = '00000000-0000-0000-0000-000000000402'),
+    0::bigint,
+    'deleted users lose admin whitelist rows by cascade'
+);
+
+SELECT is(
+    (SELECT actor_id::text FROM public.activity_log WHERE id = '77777777-7777-7777-7777-777777777401'),
+    NULL::text,
+    'historical activity rows survive with actor_id nulled'
 );
 
 SET LOCAL ROLE authenticated;


### PR DESCRIPTION
## Summary
- Confirmed account deletion/anonymization blockers are already remediated in current schema/migrations, then expanded regression coverage for the remaining user-linked account lifecycle tables.
- Replaced stale dev-note guidance that still described `task_comments.author_id ON DELETE RESTRICT` as active.
- Documented current account deletion semantics in the Auth/RBAC architecture SSoT.

## Findings addressed
- PR 4 / Security + data integrity / P0: account deletion no longer blocked by `task_comments.author_id`, `tasks.creator`, or `project_members.user_id`; this PR adds coverage for `activity_log.actor_id` anonymization and `admin_users` cascade while documenting the verified current behavior.

## Evidence inspected
- Files: `src/shared/api/planterClient.ts`, `src/shared/contexts/AuthContext.tsx`, `src/pages/Settings.tsx`, `supabase/functions/admin-user-moderation/handler.ts`
- Docs/ADRs: `docs/architecture/auth-rbac.md`, `docs/dev-notes.md`, `docs/db/schema.sql`
- Migrations/RLS/RPC/Edge: `supabase/migrations/20260506000000_account_lifecycle_user_delete_fks.sql`, admin moderation edge function actions (`suspend`, `unsuspend`, `reset_password` only)
- Tests: `supabase/tests/pgtap_account_lifecycle.sql`, `Testing/unit/shared/db/schema-source.test.ts`, existing task comment hydration tests

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Supabase Auth user deletion preserves historical project data | No self-service delete UI present | No app delete RPC present | `task_comments.author_id`, `tasks.creator`, `tasks.assignee_id`, and `activity_log.actor_id` use `ON DELETE SET NULL`; account-private rows cascade | `admin-user-moderation` has no delete action | Expanded pgTAP + schema-source assertions | None for existing delete surface |
| Arbitrary authenticated-user delete attempt | Not exposed | Not exposed | Auth schema permissions reject direct delete | N/A | Existing pgTAP assertion retained | None |

## Data/security impact
- Strengthens regression coverage for account deletion semantics without changing runtime schema or product behavior.
- Clarifies that historical authored/assigned content is anonymized, while private/account-scoped rows cascade.

## Tests added/updated
- Added pgTAP assertions for `admin_users` cascade and `activity_log.actor_id ON DELETE SET NULL` behavior.
- Expanded schema-source unit assertions for `activity_log` anonymization and account-private cascade constraints.

## Commands run
```bash
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run db:local:test
npm test -- auth
npm run test:e2e:release -- --list
npm run test:e2e:release
```

## Bot review follow-up
- PR opened at: 2026-05-09T10:07:29Z
- Waited 360 seconds before merge review: yes; post-wait review/check sweep completed by 2026-05-09T10:15:51Z
- Gemini Code Assist comments: none found
- Codex Connector Bot comments: none found
- Other review comments: only Vercel deployment comment; no action needed
- Follow-up commits/checks: no follow-up commits; GitHub checks all green (`Build & Test`, `E2E Tests`, CodeQL, Vercel, release draft, CodeQL analysis)

## Rollback
- Revert this PR. It only changes tests and documentation, so rollback does not require database repair.

## Deferred/non-blocking follow-ups
- A future product/account-management PR can add a self-service or admin deletion workflow if required; this PR only documents and tests the existing Supabase Auth deletion path.