### PR TITLE
test: harden task hierarchy invariants

### DIFF
--- a/Testing/unit/features/tasks/lib/task-hierarchy.test.ts
+++ b/Testing/unit/features/tasks/lib/task-hierarchy.test.ts
@@ -42,6 +42,7 @@ describe('task hierarchy guard helpers', () => {
     it('rejects malformed reparent payloads with missing active tasks or parents', () => {
         expect(canReparentTask('missing-task', 'task-b', rows)).toBe(false);
         expect(canReparentTask('task-a', 'missing-parent', rows)).toBe(false);
+        expect(canReparentTask('task-a', 'task-b', [])).toBe(false);
     });
 
     it('hides child-creation affordances only at the final subtask level', () => {

--- a/Testing/unit/features/tasks/lib/task-hierarchy.test.ts
+++ b/Testing/unit/features/tasks/lib/task-hierarchy.test.ts
@@ -33,9 +33,15 @@ describe('task hierarchy guard helpers', () => {
     });
 
     it('rejects subtask children, cycle moves, and moves that push descendants too deep', () => {
+        expect(canReparentTask('task-a', 'task-a', rows)).toBe(false);
         expect(canReparentTask('task-a', 'subtask-a', rows)).toBe(false);
         expect(canReparentTask('task-with-subtask', 'task-b', rows)).toBe(false);
         expect(canReparentTask('task-with-subtask', 'subtask-a', rows)).toBe(false);
+    });
+
+    it('rejects malformed reparent payloads with missing active tasks or parents', () => {
+        expect(canReparentTask('missing-task', 'task-b', rows)).toBe(false);
+        expect(canReparentTask('task-a', 'missing-parent', rows)).toBe(false);
     });
 
     it('hides child-creation affordances only at the final subtask level', () => {

--- a/Testing/unit/pages/hooks/useProjectDnd.test.ts
+++ b/Testing/unit/pages/hooks/useProjectDnd.test.ts
@@ -54,6 +54,21 @@ describe('useProjectDnd hierarchy guard', () => {
         expect(onToggleExpand).not.toHaveBeenCalled();
     });
 
+    it('rejects drops that would move a parent under its own descendant', () => {
+        const onTaskUpdate = vi.fn();
+        const onToggleExpand = vi.fn();
+        const onInvalidDrop = vi.fn();
+        const { result } = renderHook(() => useProjectDnd(rows, onTaskUpdate, onToggleExpand, onInvalidDrop));
+
+        act(() => result.current.handleDragStart(startEvent('task-b')));
+        act(() => result.current.handleDragOver(containerOverEvent('task-b', 'subtask-a')));
+        act(() => result.current.handleDragEnd(containerEndEvent('task-b', 'subtask-a')));
+
+        expect(onInvalidDrop).toHaveBeenCalledTimes(1);
+        expect(onTaskUpdate).not.toHaveBeenCalled();
+        expect(onToggleExpand).not.toHaveBeenCalled();
+    });
+
     it('allows valid childless task reparenting under another task', () => {
         const onTaskUpdate = vi.fn();
         const onToggleExpand = vi.fn();

--- a/supabase/tests/pgtap_task_hierarchy_depth.sql
+++ b/supabase/tests/pgtap_task_hierarchy_depth.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(10);
 
 TRUNCATE TABLE
     public.activity_log,
@@ -45,6 +45,21 @@ SELECT throws_like(
        VALUES ('66666666-6666-6666-6666-666666666701', 'Grandchild Attempt', 'instance', '00000000-0000-0000-0000-000000000701', '11111111-1111-1111-1111-111111111701', '55555555-5555-5555-5555-555555555701', 'todo') $$,
     '%task hierarchy depth exceeded: subtasks cannot have child tasks%',
     'cannot insert a child under a subtask'
+);
+
+SELECT throws_like(
+    $$ INSERT INTO public.tasks (id, title, origin, creator, root_id, parent_task_id, status)
+       VALUES ('66666666-6666-6666-6666-666666666702', 'Self Parent Attempt', 'instance', '00000000-0000-0000-0000-000000000701', '11111111-1111-1111-1111-111111111701', '66666666-6666-6666-6666-666666666702', 'todo') $$,
+    '%task hierarchy cannot parent a task to itself%',
+    'cannot insert a task parented to itself'
+);
+
+SELECT throws_like(
+    $$ UPDATE public.tasks
+       SET parent_task_id = id
+       WHERE id = '44444444-4444-4444-4444-444444444702' $$,
+    '%task hierarchy cannot parent a task to itself%',
+    'cannot update a task to parent itself'
 );
 
 SELECT lives_ok(


### PR DESCRIPTION
## Summary
- Added characterization coverage for task hierarchy self-parent and cycle rejection at the DB trigger and Project drag/drop guard layers.
- Verified the current supported depth remains `project -> phase -> milestone -> task -> subtask` with DB enforcement below UI affordances.
- No runtime behavior change; current implementation already rejects invalid nesting and exposes recoverable invalid-drop toast handling.

## Findings addressed
- PR 5 / Data integrity + UI/UX / P0-P1: DB/API/UI hierarchy invariants are already enforced; this PR closes test gaps for self-parent writes, malformed helper inputs, empty hierarchy context, and parent-under-descendant drag/drop attempts.

## Evidence inspected
- Files: `src/features/tasks/lib/task-hierarchy.ts`, `src/pages/hooks/useProjectDnd.ts`, `src/pages/Project.tsx`, `src/pages/TasksPage.tsx`, `src/features/tasks/components/TaskItem.tsx`, `src/features/tasks/components/TaskDetailsView.tsx`, `src/shared/api/planterClient.ts`
- Docs/ADRs: `docs/architecture/tasks-subtasks.md`, `docs/architecture/projects-phases.md`, `docs/AGENT_CONTEXT.md`
- Migrations/RLS/RPC/Edge: `supabase/migrations/20260506003000_task_hierarchy_depth_guard.sql`, `docs/db/schema.sql`
- Tests: `supabase/tests/pgtap_task_hierarchy_depth.sql`, `Testing/unit/features/tasks/lib/task-hierarchy.test.ts`, `Testing/unit/pages/hooks/useProjectDnd.test.ts`, existing TaskDetailsView subtask affordance tests

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Child under subtask / excess depth | `canReparentTask` prevents Project DnD mutation; child-action affordances hide for subtasks | `planterClient` writes still hit DB trigger | `trg_enforce_task_hierarchy_depth` rejects inserts/reparents beyond max depth | N/A | Existing + expanded helper/DnD/pgTAP coverage | None found |
| Parent moved under descendant / self-parent cycle | Project DnD rejects descendant drops and calls invalid-drop handler | Direct update still hits DB trigger | Trigger rejects self-parent and descendant cycles | N/A | Added DnD cycle test and pgTAP self-parent tests | None found |

## Data/security impact
- Strengthens regression coverage for hierarchy integrity without changing database schema or runtime code.
- Reduces risk of future UI or trigger drift allowing corrupt task trees.

## Tests added/updated
- Added pgTAP assertions for INSERT/UPDATE self-parent rejection.
- Added Project DnD hook test for parent-under-descendant rejection.
- Added task hierarchy helper assertions for self, missing-context, and empty-hierarchy reparent payloads.

## Commands run
```bash
npm test -- task-hierarchy
npm test -- useProjectDnd
git diff --check
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run db:local:test
npm run test:e2e:release
# Follow-up after Gemini comment:
npm test -- task-hierarchy
git diff --check
npm test
npm run build
```

## Bot review follow-up
- PR opened at: 2026-05-09T10:21:27Z
- Waited 360 seconds before merge review: yes; post-wait review/check sweep completed after 2026-05-09T10:27Z
- Gemini Code Assist comments: one low-priority empty-hierarchy helper test suggestion; addressed in `743bc78e` and review thread resolved
- Codex Connector Bot comments: none found
- Other review comments: Vercel deployment comment only; no action needed
- Follow-up commits/checks: `743bc78e` added the empty-list assertion; reran `npm test -- task-hierarchy`, `git diff --check`, `npm test`, `npm run build`; refreshed GitHub checks all green by 2026-05-09T10:37:23Z

## Rollback
- Revert this PR. It only changes tests, so rollback does not require database repair.

## Deferred/non-blocking follow-ups
- None for current hierarchy invariant enforcement.