### PR TITLE
test: harden date envelope rollup coverage

### DIFF
--- a/Testing/unit/features/gantt/hooks/useGanttDragShift.test.ts
+++ b/Testing/unit/features/gantt/hooks/useGanttDragShift.test.ts
@@ -96,6 +96,23 @@ describe('useGanttDragShift (Wave 28)', () => {
         expect(toastError).toHaveBeenCalledWith('Move the parent phase first.');
     });
 
+    it('rejects when drag starts before the parent phase start-date', async () => {
+        const tasks = [
+            makeTask({ id: 'ph1', parent_task_id: 'p1', task_type: 'phase', start_date: '2026-01-05', due_date: '2026-01-31' }),
+            makeTask({ id: 'm1', parent_task_id: 'ph1', start_date: '2026-01-10', due_date: '2026-01-15' }),
+        ];
+
+        const { result } = renderHook(
+            () => useGanttDragShift({ projectId: 'p1', tasks, updateTaskDates: mutateAsync }),
+            { wrapper },
+        );
+
+        await result.current('m1', new Date('2026-01-01T00:00:00Z'), new Date('2026-01-12T00:00:00Z'));
+
+        expect(mutateAsync).not.toHaveBeenCalled();
+        expect(toastError).toHaveBeenCalledWith('Move the parent phase first.');
+    });
+
     it('rejects inverted dates (end before start)', async () => {
         const tasks = [
             makeTask({ id: 'ph1', parent_task_id: 'p1', task_type: 'phase', start_date: '2026-01-01', due_date: '2026-01-31' }),

--- a/supabase/tests/pgtap_task_date_envelope.sql
+++ b/supabase/tests/pgtap_task_date_envelope.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(12);
+SELECT plan(14);
 
 TRUNCATE TABLE
     public.activity_log,
@@ -144,6 +144,23 @@ SELECT throws_like(
     'child due-only date cannot precede a dated parent envelope'
 );
 
+SELECT throws_like(
+    $$ INSERT INTO public.tasks (id, title, origin, creator, root_id, parent_task_id, status, start_date, due_date)
+       VALUES (
+           '55555555-5555-5555-5555-555555555801',
+           'Inserted Outside Envelope',
+           'instance',
+           '00000000-0000-0000-0000-000000000801',
+           '11111111-1111-1111-1111-111111111801',
+           '33333333-3333-3333-3333-333333333801',
+           'todo',
+           '2026-01-01 00:00:00+00'::timestamptz,
+           '2026-01-09 00:00:00+00'::timestamptz
+       ) $$,
+    '%task dates must stay within parent task dates%',
+    'inserting a dated child outside a dated parent envelope is rejected'
+);
+
 SELECT lives_ok(
     $$ UPDATE public.tasks
        SET start_date = '2026-01-12 00:00:00+00'::timestamptz,
@@ -162,6 +179,14 @@ SELECT is(
     (SELECT due_date::date FROM public.tasks WHERE id = '33333333-3333-3333-3333-333333333801'),
     '2026-01-18'::date,
     'valid child date edit rolls the parent due date upward'
+);
+
+SELECT throws_like(
+    $$ UPDATE public.tasks
+       SET start_date = '2026-01-13 00:00:00+00'::timestamptz
+       WHERE id = '33333333-3333-3333-3333-333333333801' $$,
+    '%existing child task dates are outside parent task dates%',
+    'parent start date cannot shrink around existing child dates'
 );
 
 SELECT throws_like(


### PR DESCRIPTION
## Summary
- Added DB characterization coverage for inserting dated children outside a parent envelope and shrinking a parent start date around existing child dates.
- Added Gantt drag-shift coverage for the symmetric start-before-parent bound rejection.
- No runtime behavior change; current date-engine/business-calendar/date-envelope implementation already enforces the inspected rules.

## Findings addressed
- PR 6 / Date scheduling + data integrity / P0-P1: existing app, edge, DB, and UI layers already cover business calendars, checkpoint carve-outs, date envelopes, and release workflows; this PR closes narrow test gaps around insert-time envelope enforcement and parent start shrink validation.

## Evidence inspected
- Files: `src/shared/lib/date-engine/index.ts`, `src/shared/lib/date-engine/business-calendar.ts`, `src/features/gantt/hooks/useGanttDragShift.ts`, `src/features/projects/hooks/useProjectMutations.ts`, `src/features/tasks/hooks/useTaskMutations.ts`
- Docs/ADRs: `docs/architecture/date-engine.md`, `docs/architecture/date-engine-business-calendar-adr.md`, `docs/AGENT_CONTEXT.md`
- Migrations/RLS/RPC/Edge: `supabase/migrations/20260506004000_task_date_envelope_guard.sql`, `supabase/functions/_shared/business-calendar.ts`, `supabase/functions/_shared/date.ts`, `supabase/functions/nightly-sync/urgency.ts`
- Tests: `Testing/unit/shared/lib/date-engine/*`, `Testing/unit/supabase/functions/_shared/business-calendar.test.ts`, `Testing/unit/supabase/functions/nightly-sync/urgency.test.ts`, `Testing/unit/features/gantt/hooks/useGanttDragShift.test.ts`, `supabase/tests/pgtap_task_date_envelope.sql`

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Date-kind project scheduling | Project mutation/date-engine uses `dateProjectBusinessCalendar` | `planterClient` writes normalized ISO dates | DB envelopes validate persisted writes | Nightly due-soon uses edge `dateProjectBusinessCalendar` | Existing app/edge parity + urgency tests | None found |
| Parent/child date envelopes | Gantt drag rejects out-of-parent moves and invalid ranges | Task mutations still hit DB trigger and roll up parent dates | `trg_enforce_task_date_envelope` rejects inverted ranges, child outside parent, incompatible reparent, and parent shrink | N/A | Expanded pgTAP + Gantt coverage | None found |
| Checkpoint project exclusions | Project kind helpers suppress shifts/urgency | Existing mutation/date-engine carve-out | Existing root settings constraint | Nightly-sync skips checkpoint roots | Existing checkpoint/parity tests | None found |

## Data/security impact
- Strengthens regression coverage for date integrity without changing runtime schema or production behavior.
- Reduces risk that future DB/UI changes allow invalid child dates or parent shrink edits to persist.

## Tests added/updated
- Added pgTAP assertions for insert-time child envelope rejection and parent start-date shrink rejection.
- Added Gantt drag-shift unit test for start-before-parent validation.

## Commands run
```bash
npm test -- date-engine
npm test -- useGanttDragShift
git diff --check
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run db:local:test
npm run test:e2e:release
```

## Bot review follow-up
- PR opened at: 2026-05-09T10:42:20Z
- Waited 360 seconds before merge review: yes; post-wait review/check sweep completed by 2026-05-09T10:50:34Z
- Gemini Code Assist comments: summary only; explicitly no review comments
- Codex Connector Bot comments: none found
- Other review comments: Vercel deployment comment only; no action needed
- Follow-up commits/checks: no follow-up commits; GitHub checks all green (`Build & Test`, `E2E Tests`, CodeQL, Vercel, release draft, CodeQL analysis)

## Rollback
- Revert this PR. It only changes tests, so rollback does not require database repair.

## Deferred/non-blocking follow-ups
- None for current date-envelope/date-engine enforcement.