### PR TITLE
fix: harden ics token lifecycle

### DIFF
--- a/Testing/unit/shared/api/planterClient.integrations.ics.test.ts
+++ b/Testing/unit/shared/api/planterClient.integrations.ics.test.ts
@@ -82,7 +82,7 @@ describe('planter.integrations.ics (Wave 35)', () => {
         const insertArg = (chain.insert as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
         expect(insertArg.user_id).toBe('user-1');
         expect(typeof insertArg.token).toBe('string');
-        expect((insertArg.token as string).length).toBeGreaterThanOrEqual(32);
+        expect(insertArg.token).toMatch(/^[0-9a-f]{64}$/);
         expect(row.id).toBe('new-id');
     });
 

--- a/Testing/unit/supabase/functions/ics-feed.handler.test.ts
+++ b/Testing/unit/supabase/functions/ics-feed.handler.test.ts
@@ -198,6 +198,41 @@ describe('handleIcsFeedRequest', () => {
         expect(db.tokens[0].last_accessed_at).toBeNull();
     });
 
+    it('returns 404 for unknown tokens without stamping any token row', async () => {
+        const db: FakeDb = {
+            tokens: [token({})],
+            memberships: [{ user_id: 'user-1', project_id: 'project-a' }],
+            tasks: [task({ id: 'owner-task' })],
+        };
+
+        const response = await handleIcsFeedRequest(requestFor('unknown-token-000000000000000000000000000000'), {
+            supabase: makeSupabase(db),
+            now: NOW,
+        });
+
+        expect(response.status).toBe(404);
+        expect(db.tokens[0].last_accessed_at).toBeNull();
+    });
+
+    it('does not echo the feed token into the rendered calendar body', async () => {
+        const db: FakeDb = {
+            tokens: [token({})],
+            memberships: [{ user_id: 'user-1', project_id: 'project-a' }],
+            tasks: [task({ id: 'owner-task' })],
+        };
+
+        const response = await handleIcsFeedRequest(requestFor(db.tokens[0].token), {
+            supabase: makeSupabase(db),
+            now: NOW,
+        });
+        const body = await response.text();
+
+        expect(response.status).toBe(200);
+        expect(body).not.toContain(db.tokens[0].token);
+        expect(body).not.toContain('token=');
+        expect(body).not.toContain('X-WR-SOURCE');
+    });
+
     it('treats a rotated old token as revoked while the replacement token works', async () => {
         const db: FakeDb = {
             tokens: [

--- a/Testing/unit/supabase/functions/ics-feed.handler.test.ts
+++ b/Testing/unit/supabase/functions/ics-feed.handler.test.ts
@@ -179,6 +179,7 @@ describe('handleIcsFeedRequest', () => {
         expect(response.headers.get('Content-Type')).toBe('text/calendar; charset=utf-8');
         expect(body).toContain('UID:task-owner-task@planterplan');
         expect(body).not.toContain('UID:task-other-task@planterplan');
+        expect(body).toContain('DTSTAMP:20260422T120000Z');
         expect(db.tokens[0].last_accessed_at).toBe(NOW.toISOString());
     });
 

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -32,6 +32,8 @@ Indexes on `(token)` (public lookup) and `(user_id)` (per-user listing).
 - **Rendering:** pure `renderIcsDocument` in `ics.ts` (no Deno imports, so vitest drives it). RFC 5545 VCALENDAR with one all-day VEVENT per task + VALARM `-PT24H` reminder. RFC escaping + 75-octet line folding implemented in helpers. All-day `DTEND` is an exclusive calendar rendering boundary and therefore uses the edge `calendarDayBusinessCalendar`, not date-project business-day scheduling.
 - **Side effect:** awaited UPDATE on `last_accessed_at`. Deno edge runtimes can cancel unawaited promises after returning a response, so the access audit stamp is intentionally part of the success path; stamp failures are logged but do not fail the feed response.
 - **Response headers:** `Content-Type: text/calendar; charset=utf-8`, `Cache-Control: private, max-age=300`, `Content-Disposition: inline; filename="planterplan.ics"`.
+- **Credential handling:** the token is used for lookup only. The rendered
+  calendar body does not echo the token or full subscribed URL.
 
 Not scheduled / cron-bound — pull-only.
 

--- a/supabase/functions/ics-feed/README.md
+++ b/supabase/functions/ics-feed/README.md
@@ -16,6 +16,8 @@ Returns `text/calendar; charset=utf-8` (RFC 5545). The token *is* the credential
 - **`last_accessed_at` bumped** on every successful fetch. The update is awaited because Deno edge runtimes can cancel unawaited promises once the response is returned; stamp failures are logged and do not fail the feed response.
 - **Tasks returned** are the token owner's assigned tasks, intersected with current project membership, with a non-null `due_date` inside `[now - 30d, +∞)`. Optional `project_filter: uuid[]` on the token narrows within that membership scope by `root_id IN (...)`.
 - **All-day VEVENT per task** (DATE value type on DTSTART / DTEND) + VALARM `-PT24H` reminder. `DTEND` advances by one literal calendar day via `calendarDayBusinessCalendar`; it does not use date-project business-day scheduling.
+- **Token handling** uses the token only for lookup. The rendered calendar body
+  does not echo the token or full subscribed URL.
 - Limited to 500 tasks per response to keep payload bounded.
 
 ## Deploy

--- a/supabase/functions/ics-feed/handler.ts
+++ b/supabase/functions/ics-feed/handler.ts
@@ -110,6 +110,7 @@ export async function handleIcsFeedRequest(req: Request, deps: IcsFeedHandlerDep
     if (projectScope.length === 0) {
         const emptyBody = renderIcsDocument([], {
             calendarName: 'PlanterPlan',
+            now,
         });
         return new Response(emptyBody, {
             status: 200,
@@ -147,6 +148,7 @@ export async function handleIcsFeedRequest(req: Request, deps: IcsFeedHandlerDep
 
     const icsBody = renderIcsDocument(tasks ?? [], {
         calendarName: 'PlanterPlan',
+        now,
     });
 
     return new Response(icsBody, {

--- a/supabase/functions/ics-feed/handler.ts
+++ b/supabase/functions/ics-feed/handler.ts
@@ -110,7 +110,6 @@ export async function handleIcsFeedRequest(req: Request, deps: IcsFeedHandlerDep
     if (projectScope.length === 0) {
         const emptyBody = renderIcsDocument([], {
             calendarName: 'PlanterPlan',
-            feedUrl: url.toString(),
         });
         return new Response(emptyBody, {
             status: 200,
@@ -148,7 +147,6 @@ export async function handleIcsFeedRequest(req: Request, deps: IcsFeedHandlerDep
 
     const icsBody = renderIcsDocument(tasks ?? [], {
         calendarName: 'PlanterPlan',
-        feedUrl: url.toString(),
     });
 
     return new Response(icsBody, {


### PR DESCRIPTION
## Summary
- Hardened the public ICS feed handler so subscribed calendar output no longer echoes the bearer token or full token-bearing URL.
- Added characterization coverage for unknown-token 404s, no token leakage in rendered calendar bodies, and 256-bit hex token generation.
- Clarified architecture and edge-function docs that ICS tokens are lookup-only credentials and are not rendered back into feed output.

## Findings addressed
- Calendar/ICS/P1: bearer feed tokens were not logged, but the edge handler passed the full subscribed URL into ICS rendering, which emitted `X-WR-SOURCE` and exposed the token in the calendar body.
- Calendar/ICS/P1: unknown-token 404 behavior and no-body-leak behavior needed explicit regression coverage.
- Calendar/ICS/P1: token-generation strength was implemented with Web Crypto but only loosely asserted by tests.
- Calendar/ICS/P1: edge-rendered `DTSTAMP` now uses the same injected `now` as the access audit stamp.

## Evidence inspected
- Files: `src/features/settings/components/IcsFeedsCard.tsx`, `src/shared/api/planterClient.ts`, `supabase/functions/ics-feed/handler.ts`, `supabase/functions/ics-feed/ics.ts`, `supabase/functions/ics-feed/README.md`
- Docs/ADRs: `docs/architecture/integrations.md`, `docs/operations/edge-function-schedules.md`
- Migrations/RLS/RPC/Edge: `supabase/migrations/20260506006000_ics_token_revocation_guard.sql`, `supabase/functions/ics-feed/**`
- Tests: `Testing/unit/supabase/functions/ics-feed.handler.test.ts`, `Testing/unit/shared/api/planterClient.integrations.ics.test.ts`, `supabase/tests/pgtap_ics_feed_tokens.sql`, release E2E calendar token lifecycle scenario

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Calendar/ICS feed creation, revocation, rotation, token security | Existing `IcsFeedsCard` mirrors create/revoke/rotate and warns feed URLs are sensitive. | `planter.integrations.createIcsFeedToken` uses Web Crypto 32-byte random tokens rendered as 64 hex chars; list/revoke are scoped to the current authenticated user. | Existing RLS/trigger coverage prevents cross-user creation, reactivation, token in-place rotation, project retargeting, and normal-user hard delete. | Revoked/unknown tokens return 404; tasks are scoped to assignee plus current project membership; feed response no longer echoes token-bearing source URL; `DTSTAMP` uses the injected request clock. | Added unknown-token/no-leak/strong-token/timestamp tests; existing pgTAP covers lifecycle guardrails; release E2E covers token lifecycle. | Two-way sync, HMAC expiration, and single-task downloads remain intentionally out of scope and are documented as not implemented/future only. |

## Data/security impact
- Reduces bearer-token exposure by removing token-bearing URL emission from generated calendar bodies.
- No schema or data migration; existing tokens keep working unless revoked.

## Tests added/updated
- `Testing/unit/supabase/functions/ics-feed.handler.test.ts`
- `Testing/unit/shared/api/planterClient.integrations.ics.test.ts`
- `docs/architecture/integrations.md`
- `supabase/functions/ics-feed/README.md`

## Commands run
```bash
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
git diff --check
npm test -- ics
npm run db:local:test
npm test
npm run build
node scripts/seed-e2e.js
npm run test:e2e:release

# After Gemini follow-up
npm run lint
git diff --check
npm test -- ics
npm run build
node scripts/seed-e2e.js && npm run test:e2e:release
```

## Bot review follow-up
- PR opened at: 2026-05-09T11:28:11Z
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: two low-priority inline comments requesting the injected `now` be passed to `renderIcsDocument`; addressed in `8dba3afa` and both review threads resolved.
- Codex Connector Bot comments: none observed.
- Other review comments: Vercel preview comment only.
- Follow-up commits/checks: `fix: align ics feed timestamps`; local affected checks passed; GitHub Analyze, Build & Test, CodeQL, E2E Tests, Vercel, Vercel Preview Comments, and update_release_draft passed.

## Rollback
- Revert `fix: harden ics token lifecycle`; no database rollback required.

## Deferred/non-blocking follow-ups
- None for this PR.
