### PR TITLE
fix: surface missing env configuration safely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 
+# If either required Vite Supabase key is missing, the app renders a boot-safe
+# configuration error that lists only missing variable names, never values.
+
 # Wave 30 — Web Push (bundle-shipped public key; private key is a Supabase secret)
 VITE_VAPID_PUBLIC_KEY=
 

--- a/Testing/unit/app/App.env.test.tsx
+++ b/Testing/unit/app/App.env.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { I18nextProvider } from 'react-i18next';
+import { i18n } from '@/shared/i18n';
+import { BootConfigGate } from '@/app/App';
+
+describe('BootConfigGate', () => {
+    it('renders children when public env validation passes', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BootConfigGate
+                    validation={{
+                        isValid: true,
+                        missingKeys: [],
+                        supabaseUrl: 'https://project.supabase.co',
+                        supabaseAnonKey: 'sb_publishable_test',
+                    }}
+                >
+                    <div data-testid="boot-child" />
+                </BootConfigGate>
+            </I18nextProvider>,
+        );
+
+        expect(screen.getByTestId('boot-child')).toBeInTheDocument();
+    });
+
+    it('shows missing env names without exposing configured values', () => {
+        render(
+            <I18nextProvider i18n={i18n}>
+                <BootConfigGate
+                    validation={{
+                        isValid: false,
+                        missingKeys: ['VITE_SUPABASE_ANON_KEY'],
+                        supabaseUrl: 'https://sensitive-project.supabase.co',
+                        supabaseAnonKey: null,
+                    }}
+                >
+                    <div data-testid="boot-child" />
+                </BootConfigGate>
+            </I18nextProvider>,
+        );
+
+        expect(screen.getByTestId('boot-config-error')).toBeInTheDocument();
+        expect(screen.getByText('VITE_SUPABASE_ANON_KEY')).toBeInTheDocument();
+        expect(screen.queryByTestId('boot-child')).not.toBeInTheDocument();
+        expect(screen.queryByText('https://sensitive-project.supabase.co')).not.toBeInTheDocument();
+    });
+});

--- a/Testing/unit/shared/config/public-env.test.ts
+++ b/Testing/unit/shared/config/public-env.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getSupabaseClientEnv, validatePublicEnv } from '@/shared/config/public-env';
+
+describe('public env validation', () => {
+    it('reports missing required Vite Supabase keys without throwing', () => {
+        const result = validatePublicEnv({});
+
+        expect(result.isValid).toBe(false);
+        expect(result.missingKeys).toEqual(['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY']);
+        expect(getSupabaseClientEnv(result)).toEqual({
+            supabaseUrl: 'http://127.0.0.1:54321',
+            supabaseAnonKey: 'missing-vite-supabase-anon-key',
+        });
+    });
+
+    it('trims configured values and does not report them as missing', () => {
+        const result = validatePublicEnv({
+            VITE_SUPABASE_URL: ' https://project.supabase.co ',
+            VITE_SUPABASE_ANON_KEY: ' sb_publishable_test ',
+        });
+
+        expect(result).toMatchObject({
+            isValid: true,
+            supabaseUrl: 'https://project.supabase.co',
+            supabaseAnonKey: 'sb_publishable_test',
+            missingKeys: [],
+        });
+    });
+});

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -119,7 +119,7 @@ This is wired in `src/features/tasks/hooks/useTaskMutations.ts` (`useCreateTask`
 ## 5. Deployment / Build
 
 - **Build**: `npm run build` (tsc -b && vite build).
-- **Environment**: Local Supabase (`127.0.0.1:54321`) mimics Sync/Realtime.
+- **Environment**: Local Supabase (`127.0.0.1:54321`) mimics Sync/Realtime. Required Vite client env keys are `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`; missing keys render the boot-safe configuration error from `BootConfigGate` instead of throwing during `src/shared/db/client.ts` import. The error surface lists variable names only and never prints env values.
 
 ## 6. Ignorable Files (Context Noise)
 

--- a/docs/operations/local_development.md
+++ b/docs/operations/local_development.md
@@ -18,34 +18,36 @@
 2. **Install dependencies**:
 
    ```bash
-   npm install
+   npm ci
    ```
 
 3. **Set up environment variables**:
-   Create a `.env` file in the root directory and add:
+   Copy `.env.example` to `.env.local` and fill in the required Vite client
+   variables:
    ```env
    VITE_SUPABASE_URL=your_supabase_url
    VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
    ```
-   > [!NOTE]
-   > For integration tests, you may also need `TEST_USER_PASSWORD` and `TEST_USER_EMAIL`.
+   Keep server-only secrets such as `SUPABASE_SERVICE_ROLE_KEY`,
+   `VAPID_PRIVATE_KEY`, `EMAIL_PROVIDER_API_KEY`, and `RESEND_FROM_ADDRESS`
+   out of local client env files; configure those as Supabase function
+   secrets. If either required Vite key is missing, the app renders a boot
+   configuration error that lists only missing variable names, never values.
 
 ## Running the App
 
 ```bash
 npm run dev
-# or
-npm start
 ```
 
-Runs the app in development mode at [http://localhost:3000](http://localhost:3000).
+Runs the Vite app in development mode at [http://localhost:5173](http://localhost:5173).
 
-## Linting & Formatting
+## Linting & Build
 
 We use ESLint and Prettier to maintain code quality.
 
 - **Lint**: `npm run lint`
-- **Format**: `npm run format`
+- **Build**: `npm run build`
 
 ## Testing
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -49,16 +49,20 @@ export function BootConfigGate({
 
  return (
  <main className="flex min-h-screen items-center justify-center bg-slate-50 p-6" data-testid="boot-config-error">
- <section className="w-full max-w-xl rounded-lg border border-red-200 bg-white p-6 shadow-sm" role="alert">
- <h1 className="text-xl font-semibold text-slate-900">{t('errors.boot_config_title')}</h1>
- <p className="mt-2 text-sm text-slate-700">{t('errors.boot_config_description')}</p>
+ <section
+ className="w-full max-w-xl rounded-lg border border-red-200 bg-white p-6 shadow-sm"
+ role="alert"
+ aria-labelledby="boot-error-title"
+ >
+ <h1 id="boot-error-title" className="text-xl font-semibold text-slate-900">{t('errors.boot_config_title')}</h1>
+ <p className="mt-2 text-sm text-slate-600">{t('errors.boot_config_description')}</p>
  <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-3">
  <p className="text-xs font-medium uppercase text-slate-500">{t('errors.boot_config_missing_label')}</p>
  <code className="mt-1 block break-all text-sm text-slate-900">
  {validation.missingKeys.join(', ')}
  </code>
  </div>
- <p className="mt-4 text-sm text-slate-700">{t('errors.boot_config_help')}</p>
+ <p className="mt-4 text-sm text-slate-600">{t('errors.boot_config_help')}</p>
  <p className="mt-2 text-xs text-slate-500">{t('errors.boot_config_no_values')}</p>
  </section>
  </main>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,12 +2,13 @@ import { lazy, Suspense } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
-import { I18nextProvider } from 'react-i18next';
+import { I18nextProvider, useTranslation } from 'react-i18next';
 import { i18n } from '@/shared/i18n';
 import { AuthProvider } from '@/shared/contexts/AuthContext';
 import { useAuth } from '@/shared/contexts/auth-context';
 import { TooltipProvider } from '@/shared/ui/tooltip';
 import { ConfirmDialogProvider } from '@/shared/ui/confirm-dialog';
+import { publicEnvValidation, type PublicEnvValidation } from '@/shared/config/public-env';
 import AppShellLayout from '@/layouts/AppShellLayout';
 import Project from '@/pages/Project';
 import Settings from '@/pages/Settings';
@@ -35,10 +36,40 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
  return user ? <>{children}</> : <Navigate to="/login" />;
 }
 
+export function BootConfigGate({
+ children,
+ validation = publicEnvValidation,
+}: {
+ children: React.ReactNode;
+ validation?: PublicEnvValidation;
+}) {
+ const { t } = useTranslation();
+
+ if (validation.isValid) return <>{children}</>;
+
+ return (
+ <main className="flex min-h-screen items-center justify-center bg-slate-50 p-6" data-testid="boot-config-error">
+ <section className="w-full max-w-xl rounded-lg border border-red-200 bg-white p-6 shadow-sm" role="alert">
+ <h1 className="text-xl font-semibold text-slate-900">{t('errors.boot_config_title')}</h1>
+ <p className="mt-2 text-sm text-slate-700">{t('errors.boot_config_description')}</p>
+ <div className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-3">
+ <p className="text-xs font-medium uppercase text-slate-500">{t('errors.boot_config_missing_label')}</p>
+ <code className="mt-1 block break-all text-sm text-slate-900">
+ {validation.missingKeys.join(', ')}
+ </code>
+ </div>
+ <p className="mt-4 text-sm text-slate-700">{t('errors.boot_config_help')}</p>
+ <p className="mt-2 text-xs text-slate-500">{t('errors.boot_config_no_values')}</p>
+ </section>
+ </main>
+ );
+}
+
 export default function App() {
  return (
  <QueryClientProvider client={queryClient}>
  <I18nextProvider i18n={i18n}>
+ <BootConfigGate>
  <AuthProvider>
  <TooltipProvider delayDuration={300}>
  <ConfirmDialogProvider>
@@ -85,6 +116,7 @@ export default function App() {
  </ConfirmDialogProvider>
  </TooltipProvider>
  </AuthProvider>
+ </BootConfigGate>
  </I18nextProvider>
  </QueryClientProvider >
  );

--- a/src/shared/config/public-env.ts
+++ b/src/shared/config/public-env.ts
@@ -19,6 +19,11 @@ function readEnvValue(source: PublicEnvSource, key: RequiredPublicEnvKey): strin
     return value ? value : null;
 }
 
+/**
+ * Validates that all required public environment variables are present and non-empty.
+ * @param source The environment variable source to validate.
+ * @returns A validation result with parsed values and missing variable names.
+ */
 export function validatePublicEnv(source: PublicEnvSource = import.meta.env): PublicEnvValidation {
     const supabaseUrl = readEnvValue(source, 'VITE_SUPABASE_URL');
     const supabaseAnonKey = readEnvValue(source, 'VITE_SUPABASE_ANON_KEY');
@@ -34,6 +39,11 @@ export function validatePublicEnv(source: PublicEnvSource = import.meta.env): Pu
 
 export const publicEnvValidation = validatePublicEnv();
 
+/**
+ * Extracts Supabase client configuration without throwing during module import.
+ * @param validation The public environment validation result to read from.
+ * @returns Supabase client URL and anon key, falling back to inert local values when invalid.
+ */
 export function getSupabaseClientEnv(validation: PublicEnvValidation = publicEnvValidation) {
     return {
         supabaseUrl: validation.supabaseUrl ?? FALLBACK_SUPABASE_URL,

--- a/src/shared/config/public-env.ts
+++ b/src/shared/config/public-env.ts
@@ -1,0 +1,42 @@
+const REQUIRED_PUBLIC_ENV_KEYS = ['VITE_SUPABASE_URL', 'VITE_SUPABASE_ANON_KEY'] as const;
+
+export type RequiredPublicEnvKey = typeof REQUIRED_PUBLIC_ENV_KEYS[number];
+
+type PublicEnvSource = Partial<Record<RequiredPublicEnvKey, string | undefined>>;
+
+export interface PublicEnvValidation {
+    supabaseUrl: string | null;
+    supabaseAnonKey: string | null;
+    missingKeys: RequiredPublicEnvKey[];
+    isValid: boolean;
+}
+
+const FALLBACK_SUPABASE_URL = 'http://127.0.0.1:54321';
+const FALLBACK_SUPABASE_ANON_KEY = 'missing-vite-supabase-anon-key';
+
+function readEnvValue(source: PublicEnvSource, key: RequiredPublicEnvKey): string | null {
+    const value = source[key]?.trim();
+    return value ? value : null;
+}
+
+export function validatePublicEnv(source: PublicEnvSource = import.meta.env): PublicEnvValidation {
+    const supabaseUrl = readEnvValue(source, 'VITE_SUPABASE_URL');
+    const supabaseAnonKey = readEnvValue(source, 'VITE_SUPABASE_ANON_KEY');
+    const missingKeys = REQUIRED_PUBLIC_ENV_KEYS.filter((key) => !readEnvValue(source, key));
+
+    return {
+        supabaseUrl,
+        supabaseAnonKey,
+        missingKeys,
+        isValid: missingKeys.length === 0,
+    };
+}
+
+export const publicEnvValidation = validatePublicEnv();
+
+export function getSupabaseClientEnv(validation: PublicEnvValidation = publicEnvValidation) {
+    return {
+        supabaseUrl: validation.supabaseUrl ?? FALLBACK_SUPABASE_URL,
+        supabaseAnonKey: validation.supabaseAnonKey ?? FALLBACK_SUPABASE_ANON_KEY,
+    };
+}

--- a/src/shared/db/client.ts
+++ b/src/shared/db/client.ts
@@ -1,11 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import { Database } from './database.types'
+import { getSupabaseClientEnv } from '@/shared/config/public-env'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
-
-if (!supabaseUrl || !supabaseAnonKey) {
- throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY')
-}
+const { supabaseUrl, supabaseAnonKey } = getSupabaseClientEnv()
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -799,7 +799,12 @@
     "login_failed": "Login failed",
     "user_must_be_logged_in": "User must be logged in",
     "project_not_found_or_no_access": "This project doesn't exist, or you no longer have access to it.",
-    "back_to_tasks": "Back to tasks"
+    "back_to_tasks": "Back to tasks",
+    "boot_config_title": "App configuration is incomplete",
+    "boot_config_description": "PlanterPlan could not start because required public environment variables are missing.",
+    "boot_config_missing_label": "Missing variables",
+    "boot_config_help": "Set these in your local .env.local file or Vercel project settings, then rebuild or reload the app.",
+    "boot_config_no_values": "Only variable names are shown here; secret or token values are never displayed."
   },
   "ics": {
     "card_title": "Calendar feeds (ICS)",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -805,7 +805,12 @@
     "login_failed": "Falló el inicio de sesión",
     "project_not_found_or_no_access": "Este proyecto no existe o ya no tienes acceso.",
     "back_to_tasks": "Volver a tareas",
-    "user_must_be_logged_in": "El usuario debe haber iniciado sesión"
+    "user_must_be_logged_in": "El usuario debe haber iniciado sesión",
+    "boot_config_title": "La configuración de la app está incompleta",
+    "boot_config_description": "PlanterPlan no pudo iniciar porque faltan variables de entorno públicas obligatorias.",
+    "boot_config_missing_label": "Variables faltantes",
+    "boot_config_help": "Configúralas en el archivo local .env.local o en la configuración del proyecto de Vercel, luego recompila o recarga la app.",
+    "boot_config_no_values": "Aquí solo se muestran los nombres de las variables; nunca se muestran secretos ni tokens."
   },
   "ics": {
     "card_title": "Feeds de calendario (ICS)",


### PR DESCRIPTION
## Summary
- Replaced the import-time Supabase env throw with a validated public-env helper and safe fallback client config.
- Added a localized boot-time error surface that lists only missing variable names before auth/query work starts.
- Updated env/deployment-facing docs for `.env.local`, Vite port/script names, and redacted missing-env behavior.

## Findings addressed
- PR11/deployment boot/security/P1: missing `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` could throw during `src/shared/db/client.ts` import and produce a blank app instead of an actionable, redacted error.

## Evidence inspected
- Files: `src/shared/db/client.ts`, `src/app/App.tsx`, `vite.config.ts`, `vercel.json`, `.env.example`
- Docs/ADRs: `docs/operations/local_development.md`, `docs/AGENT_CONTEXT.md`
- Migrations/RLS/RPC/Edge: not changed; this PR is client boot/config only.
- Tests: new public-env helper tests and boot gate rendering tests.

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Vercel/deployment boot behavior | `BootConfigGate` renders a localized boot-safe error when required public Vite env keys are missing and shows only variable names. | Supabase client creation uses validated config with inert fallback values so module import does not crash. | N/A | N/A | Added unit coverage for missing-key validation, value trimming, child render on valid config, and redacted boot error rendering. Local and GitHub CI checks passed. | Optional `vercel env run -e preview -- npm run build` could not run because `vercel` CLI is not installed locally. |

## Data/security impact
- Prevents blank-app crashes from missing public env vars.
- The error surface never prints env values, tokens, or connection strings; it only lists required variable names.
- Keeps the approved Vite names: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.

## Tests added/updated
- `Testing/unit/shared/config/public-env.test.ts`
- `Testing/unit/app/App.env.test.tsx`
- Updated `.env.example`, `docs/operations/local_development.md`, and `docs/AGENT_CONTEXT.md`.

## Commands run
```bash
npm test -- Testing/unit/shared/config/public-env.test.ts Testing/unit/app/App.env.test.tsx
vercel --version && vercel whoami
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run verify-architecture
# after Gemini follow-up commit
npm run lint
npm test -- Testing/unit/shared/config/public-env.test.ts Testing/unit/app/App.env.test.tsx
npm run build
```

`vercel --version && vercel whoami` failed with `zsh:1: command not found: vercel`, so `vercel env run -e preview -- npm run build` was not available in this local environment. No Vercel/Supabase env values were printed or pulled.

## Bot review follow-up
- PR opened at: 2026-05-09T12:45:16Z
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: three low-priority comments for JSDoc and boot-error styling/ARIA; fixed in `6ec23768` and all threads resolved.
- Codex Connector Bot comments: none found.
- Other review comments: Vercel preview deployment only.
- Follow-up commits/checks: `6ec23768`; reran `npm run lint`, focused env tests, and `npm run build`; GitHub Build & Test, E2E Tests, CodeQL, Vercel, and release-draft checks all passed.

## Rollback
- Revert this PR to restore the previous import-time throw behavior in `src/shared/db/client.ts`.

## Deferred/non-blocking follow-ups
- Run `vercel env run -e preview -- npm run build` from an environment with the Vercel CLI installed and authenticated, without printing env values.