### PR TITLE
fix(pwa): harden service worker push payload fallback

### DIFF
--- a/Testing/unit/public/service-worker.test.ts
+++ b/Testing/unit/public/service-worker.test.ts
@@ -117,6 +117,29 @@ describe('public/sw.js', () => {
         }));
     });
 
+    it('falls back to defaults when push JSON and text parsing both fail', async () => {
+        const { listeners, showNotification } = loadWorker();
+        const { event, waits } = makeWaitEvent({
+            data: {
+                json: () => {
+                    throw new Error('invalid json');
+                },
+                text: () => {
+                    throw new Error('unreadable payload');
+                },
+            },
+        });
+
+        listeners.get('push')?.(event);
+        await Promise.all(waits);
+
+        expect(showNotification).toHaveBeenCalledWith('PlanterPlan', expect.objectContaining({
+            body: '',
+            icon: '/icon-192.png',
+            data: { url: '/' },
+        }));
+    });
+
     it('opens only sanitized same-origin paths from notification clicks', async () => {
         const { listeners, openWindow } = loadWorker();
         const close = vi.fn();

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -98,7 +98,11 @@ file was descoped during the post-Wave-31 roadmap renumber).
 See `docs/dev-notes.md`.
 
 `dispatch-push` contract: `{ user_ids, title, body, url?, tag?, event_type }`.
-For each user/sub pair: send via web-push, DELETE on 410, log outcome.
+For each user/sub pair: send via web-push, DELETE on 410, log outcome. If
+VAPID env is missing, `dispatch-push` returns `success: false` with
+`error: 'vapid_unconfigured'` to its service-role caller instead of writing
+per-user transport rows; the caller's state machine owns the terminal
+`notification_log` entry.
 
 ## Dispatch state machine (mention path)
 
@@ -183,8 +187,9 @@ Triggers (preferred), GitHub Actions, or external pingers.
 
 * **No notifications firing** — check `SUPABASE_SERVICE_ROLE_KEY` is set
   on each function; confirm `EMAIL_PROVIDER_API_KEY` + `RESEND_FROM_ADDRESS`
-  for email; VAPID keys for push. Each missing env degrades to log-only
-  with a canonical `error` string.
+  for email; VAPID keys for push. Missing email env degrades to log-only;
+  missing VAPID env is returned to the caller as `vapid_unconfigured` so the
+  notification dispatcher can write the terminal failure once.
 * **Specific user not receiving** — `SELECT * FROM notification_log
   WHERE user_id = '<uid>' ORDER BY sent_at DESC LIMIT 20`. The `error`
   column tells you which skip/fail branch fired.

--- a/public/sw.js
+++ b/public/sw.js
@@ -40,9 +40,7 @@ function parsePushPayload(data) {
   let payload;
   try {
     payload = data.json();
-  } catch {
-    payload = { body: safePayloadText(data) };
-  }
+  } catch {}
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
     payload = { body: safePayloadText(data) };
   }

--- a/public/sw.js
+++ b/public/sw.js
@@ -28,15 +28,23 @@ function safePath(value, fallback = '/') {
   }
 }
 
+function safePayloadText(data) {
+  try {
+    return data.text();
+  } catch {
+    return '';
+  }
+}
+
 function parsePushPayload(data) {
   let payload;
   try {
     payload = data.json();
   } catch {
-    payload = { body: data.text() };
+    payload = { body: safePayloadText(data) };
   }
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    payload = { body: data.text() };
+    payload = { body: safePayloadText(data) };
   }
   return {
     title: safeText(payload.title, 'PlanterPlan'),

--- a/supabase/functions/dispatch-push/README.md
+++ b/supabase/functions/dispatch-push/README.md
@@ -40,9 +40,11 @@ Generate VAPID keys once: `npx web-push generate-vapid-keys`. Put the public
 key in `.env.example` (shipped to the bundle as `VITE_VAPID_PUBLIC_KEY`);
 the private key is a Supabase secret only.
 
-When any VAPID env is missing the function short-circuits to log-only (writes
-`error = 'vapid_unconfigured'` to `notification_log` so the operator can spot
-the misconfiguration at a glance).
+When any VAPID env is missing the function short-circuits before transport and
+returns `{ success: false, error: 'vapid_unconfigured' }` to its service-role
+caller. The caller (`dispatch-notifications` / `overdue-digest`) owns the
+terminal `notification_log` row so one misconfigured fan-out cannot create
+duplicate per-user transport logs.
 
 ## Scheduling
 
@@ -61,7 +63,7 @@ Not scheduled. Invoked by other edge functions only. Schedule the callers
 supabase functions serve dispatch-push --env-file ./supabase/.env.local
 
 curl -X POST http://127.0.0.1:54321/functions/v1/dispatch-push \
-  -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
   -H "Content-Type: application/json" \
   -d '{ "user_ids": ["<uid>"], "title": "Hello", "body": "World", "event_type": "mentions" }'
 ```


### PR DESCRIPTION
## Summary
- Hardened `public/sw.js` push payload parsing so unreadable JSON and unreadable text payloads fall back to safe default notification fields instead of throwing.
- Renamed the worker unit test to `service-worker.test.ts` so the required `npm test -- service-worker` validation target runs the actual worker coverage.
- Corrected push transport docs: `dispatch-push` requires a service-role bearer and returns `vapid_unconfigured` to its caller instead of writing duplicate per-user transport logs.

## Findings addressed
- PR14/PWA-build/P2: service worker push parsing had JSON fallback coverage, but still assumed `data.text()` could not throw.
- PR14/docs/P2: dispatch-push README and notifications architecture docs were stale about VAPID-missing behavior and local smoke auth.

## Evidence inspected
- Files: `public/sw.js`, `src/features/settings/hooks/usePushSubscription.ts`, `supabase/functions/dispatch-push/index.ts`, `supabase/functions/dispatch-push/dispatch.ts`, `vite.config.ts`
- Docs/ADRs: `docs/architecture/notifications.md`, `docs/operations/edge-function-schedules.md`, `supabase/functions/dispatch-push/README.md`, `docs/dev-notes.md`
- Migrations/RLS/RPC/Edge: `dispatch-push` service-role transport path and existing notification logs / push subscriptions behavior
- Tests: `Testing/unit/public/service-worker.test.ts`, `Testing/unit/features/settings/hooks/usePushSubscription.test.tsx`, `Testing/unit/supabase/functions/dispatch-push.test.ts`

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Browser push service worker | Existing registration failures are caught in `usePushSubscription`; worker has no fetch/cache handler | Client writes subscriptions through `planter.entities.PushSubscription` | Existing RLS remains unchanged | `dispatch-push` remains service-role only and returns VAPID config failures to its caller | Service-worker tests cover no fetch handler, URL/icon sanitization, malformed JSON, unreadable text fallback, and safe notificationclick URLs | No TS worker pipeline; intentionally out of scope |

## Data/security impact
- No schema or RLS changes.
- Reduces crash risk for malformed push payloads and keeps service-worker cache poisoning risk low by preserving the no-fetch/no-cache contract.
- Documentation now avoids advising anon-key access to the service-role-only push transport.

## Tests added/updated
- Added service worker coverage for JSON and text parsing failure fallback.
- Renamed the worker test file so `npm test -- service-worker` exercises it.
- Updated notification docs for actual VAPID-missing behavior.

## Commands run
```bash
npm test -- service-worker
npm test -- dispatch-push
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run verify-architecture
npm test -- service-worker
npm run lint
npm run build
```

## Bot review follow-up
- PR opened at: 2026-05-09T06:53:00-07:00
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: one low-priority parsing simplification; addressed in `9abb9e33`, rechecked, and the thread is resolved.
- Codex Connector Bot comments: none found in PR comments, reviews, inline comments, or review threads.
- Other review comments: Vercel preview ready comment only; no actionable requested changes.
- Follow-up commits/checks: ran `npm test -- service-worker`, `npm run lint`, and `npm run build` after the follow-up commit; GitHub checks are green including Build & Test, E2E Tests, CodeQL, Vercel, and release draft.

## Rollback
- Revert this PR to restore the previous service-worker text fallback and docs; push registration, dispatching, and cache behavior otherwise remain unchanged.

## Deferred/non-blocking follow-ups
- None for this guardrail. A TypeScript/workbox service-worker pipeline remains intentionally out of scope unless separately approved.
