### PR TITLE
fix(tasks): guide first-run project creation

### DIFF
--- a/Testing/unit/pages/TasksPage.test.tsx
+++ b/Testing/unit/pages/TasksPage.test.tsx
@@ -237,6 +237,41 @@ describe('TasksPage — global tasks view + details dialog', () => {
         expect(screen.queryByTestId('task-row-p-alpha')).not.toBeInTheDocument();
     });
 
+    it('shows first-run project creation choices when no projects or tasks are visible', async () => {
+        vi.mocked(planter.entities.Task.list).mockResolvedValueOnce([]);
+
+        renderTasksPage();
+
+        expect(await screen.findByRole('heading', { name: 'Start your first project' })).toBeInTheDocument();
+        expect(screen.getByText('Create a blank project or use the Launch Large template to add your first project workspace.')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /start blank project/i })).toHaveAttribute('href', '/tasks?action=new-project');
+        expect(screen.getByRole('link', { name: /use launch large template/i })).toHaveAttribute(
+            'href',
+            '/tasks?action=new-project&template=launch_large',
+        );
+    });
+
+    it('keeps the normal empty task copy when a project exists without visible work items', async () => {
+        vi.mocked(planter.entities.Task.list).mockResolvedValueOnce([
+            {
+                id: 'p-empty',
+                title: 'Empty Project',
+                parent_task_id: null,
+                root_id: 'p-empty',
+                origin: 'instance',
+                creator: 'u1',
+                status: 'in_progress',
+                task_type: 'project',
+            },
+        ]);
+
+        renderTasksPage();
+
+        expect(await screen.findByText('No tasks in any of your projects.')).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Start your first project' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /start blank project/i })).not.toBeInTheDocument();
+    });
+
     it('keeps priority available as an explicit quick filter', async () => {
         const user = userEvent.setup();
         renderTasksPage();

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { DndContext, closestCorners, useSensor, useSensors, PointerSensor, KeyboardSensor } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
@@ -9,7 +10,7 @@ import { planter } from '@/shared/api/planterClient';
 import { STALE_TIMES } from '@/shared/lib/react-query-config';
 import TaskItem from '@/features/tasks/components/TaskItem';
 import TaskDetailsPanel from '@/features/tasks/components/TaskDetailsPanel';
-import { Loader2, List, LayoutGrid, Search, X } from 'lucide-react';
+import { FileText, Loader2, List, LayoutGrid, Plus, Search, X } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
 import ProjectBoardView from '@/features/tasks/components/board/ProjectBoardView';
@@ -230,6 +231,10 @@ export default function TasksPage() {
               () => tasks.filter((task) => task.origin === 'instance' && task.parent_task_id !== null).length,
               [tasks],
        );
+       const instanceProjectCount = useMemo(
+              () => tasks.filter((task) => task.origin === 'instance' && task.parent_task_id === null).length,
+              [tasks],
+       );
        const filteredTasks = useTaskFilters({ tasks, filter, sort: effectiveSort, dueDateRange, currentUserId });
        const normalizedSearchQuery = searchQuery.trim().toLowerCase();
        const visibleTasks = useMemo(() => {
@@ -248,6 +253,12 @@ export default function TasksPage() {
                      return haystack.includes(normalizedSearchQuery);
               });
        }, [filteredTasks, normalizedSearchQuery, projectTitleByRootId]);
+       const showFirstRunEmptyState = instanceProjectCount === 0
+              && actionableTaskCount === 0
+              && visibleTasks.length === 0
+              && filter === 'all_tasks'
+              && !normalizedSearchQuery
+              && !hasDueRange;
        const childrenByParentForStatus = useMemo(() => {
               const map = new Map<string, TaskRow[]>();
               for (const task of tasks) {
@@ -473,11 +484,34 @@ export default function TasksPage() {
                                           <div className="h-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-8 w-full">
                                                  {visibleTasks.length === 0 ? (
                                                         <div className="bg-card rounded-xl border border-border shadow-sm p-12 text-center">
-                                                               <p className="text-muted-foreground">
-                                                                      {normalizedSearchQuery
-                                                                             ? t('tasks.search_empty')
-                                                                             : t(`tasks.filters.empty.${filter}`)}
-                                                               </p>
+                                                               {showFirstRunEmptyState ? (
+                                                                      <div className="mx-auto flex max-w-xl flex-col items-center gap-5" data-testid="tasks-first-run-empty-state">
+                                                                             <div className="space-y-2">
+                                                                                    <h2 className="text-xl font-semibold text-card-foreground">{t('tasks.first_run.title')}</h2>
+                                                                                    <p className="text-muted-foreground">{t('tasks.first_run.description')}</p>
+                                                                             </div>
+                                                                             <div className="flex flex-col gap-3 sm:flex-row">
+                                                                                    <Button asChild>
+                                                                                           <Link to="/tasks?action=new-project">
+                                                                                                  <Plus className="w-4 h-4" aria-hidden="true" />
+                                                                                                  {t('tasks.first_run.blank_cta')}
+                                                                                           </Link>
+                                                                                    </Button>
+                                                                                    <Button asChild variant="outline">
+                                                                                           <Link to="/tasks?action=new-project&template=launch_large">
+                                                                                                  <FileText className="w-4 h-4" aria-hidden="true" />
+                                                                                                  {t('tasks.first_run.template_cta')}
+                                                                                           </Link>
+                                                                                    </Button>
+                                                                             </div>
+                                                                      </div>
+                                                               ) : (
+                                                                      <p className="text-muted-foreground">
+                                                                             {normalizedSearchQuery
+                                                                                    ? t('tasks.search_empty')
+                                                                                    : t(`tasks.filters.empty.${filter}`)}
+                                                                      </p>
+                                                               )}
                                                         </div>
                                                  ) : (
                                                         viewMode === 'list' ? (

--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -485,10 +485,10 @@ export default function TasksPage() {
                                                  {visibleTasks.length === 0 ? (
                                                         <div className="bg-card rounded-xl border border-border shadow-sm p-12 text-center">
                                                                {showFirstRunEmptyState ? (
-                                                                      <div className="mx-auto flex max-w-xl flex-col items-center gap-5" data-testid="tasks-first-run-empty-state">
+                                                                      <div className="mx-auto flex max-w-xl flex-col items-center gap-4" data-testid="tasks-first-run-empty-state">
                                                                              <div className="space-y-2">
-                                                                                    <h2 className="text-xl font-semibold text-card-foreground">{t('tasks.first_run.title')}</h2>
-                                                                                    <p className="text-muted-foreground">{t('tasks.first_run.description')}</p>
+                                                                                    <h2 className="text-xl font-semibold text-slate-900">{t('tasks.first_run.title')}</h2>
+                                                                                    <p className="text-slate-600">{t('tasks.first_run.description')}</p>
                                                                              </div>
                                                                              <div className="flex flex-col gap-3 sm:flex-row">
                                                                                     <Button asChild>
@@ -506,7 +506,7 @@ export default function TasksPage() {
                                                                              </div>
                                                                       </div>
                                                                ) : (
-                                                                      <p className="text-muted-foreground">
+                                                                      <p className="text-slate-600">
                                                                              {normalizedSearchQuery
                                                                                     ? t('tasks.search_empty')
                                                                                     : t(`tasks.filters.empty.${filter}`)}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -173,6 +173,12 @@
     "sort_chronological": "Chronological",
     "sort_alphabetical": "Alphabetical",
     "no_tasks": "No tasks yet",
+    "first_run": {
+      "title": "Start your first project",
+      "description": "Create a blank project or use the Launch Large template to add your first project workspace.",
+      "blank_cta": "Start blank project",
+      "template_cta": "Use Launch Large template"
+    },
     "panel": {
       "edit_named_task": "Edit {{title}}",
       "edit_task": "Edit Task",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -179,6 +179,12 @@
     "sort_chronological": "Cronológica",
     "sort_alphabetical": "Alfabética",
     "no_tasks": "Aún no hay tareas",
+    "first_run": {
+      "title": "Inicia tu primer proyecto",
+      "description": "Crea un proyecto en blanco o usa la plantilla Launch Large para agregar tu primer espacio de trabajo de proyecto.",
+      "blank_cta": "Iniciar proyecto en blanco",
+      "template_cta": "Usar plantilla Launch Large"
+    },
     "panel": {
       "edit_named_task": "Editar {{title}}",
       "edit_task": "Editar tarea",


### PR DESCRIPTION
## Summary
- Added a `/tasks` first-run empty state when the user has no visible instance projects and no actionable work items.
- Added CTAs into the existing creation action flow for a blank project and the seeded Launch Large template.
- Preserved existing search/filter empty-state copy when the user has projects or is viewing a filtered empty result.

## Findings addressed
- PR15/UI-UX/P1-P2: `/tasks` defaulted to a generic empty card for first-run users instead of guiding them to create a blank project or use an official template.

## Evidence inspected
- Files: `src/pages/TasksPage.tsx`, `src/layouts/CreationActionHost.tsx`, `src/features/projects/components/CreateProjectModal.tsx`, `src/shared/i18n/locales/en.json`, `src/shared/i18n/locales/es.json`
- Docs/ADRs: `planterplan_release_hardening_context.md` PR15 task, `docs/architecture/user-testing-baseline.md`
- Migrations/RLS/RPC/Edge: no schema/RLS/Edge changes; verified seeded template key in `supabase/seeds/02_production_templates.sql`
- Tests: `Testing/unit/pages/TasksPage.test.tsx`, release E2E scenarios under `Testing/e2e/features/dashboard/create-project.feature`

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| `/tasks` first-run creation guidance | Shows first-run copy and CTAs only when no instance project roots and no actionable tasks are returned; routes through `/tasks?action=new-project` and `template=launch_large` | Existing `CreationActionHost` and `useCreateProject` creation flow unchanged | Existing project/template creation policies unchanged | N/A | `TasksPage` unit coverage for true first-run and existing-project empty states; release E2E still covers blank and Launch Large project creation | None for PR15 |

## Data/security impact
- No data model, RLS, RPC, or Edge Function changes.
- The CTAs route through existing authenticated project creation paths; no new creation surface or bypass was added.

## Tests added/updated
- Added `TasksPage` coverage for first-run CTAs when no projects/tasks are visible.
- Added regression coverage that an existing empty project keeps the normal task empty-state copy and does not show first-run CTAs.
- Added en/es localization keys for the new empty-state text.

## Commands run
```bash
npm test -- TasksPage
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run test:e2e:release
npm test -- TasksPage
npm run lint
npm run build
```

## Bot review follow-up
- PR opened at: 2026-05-09T07:16:01-07:00
- Waited 360 seconds before merge review: yes, completed at 2026-05-09T07:22:28-07:00
- Gemini Code Assist comments: four low-priority style comments on spacing and text colors; addressed in `c7324538`, rechecked, and threads resolved.
- Codex Connector Bot comments: none found in PR comments, reviews, inline comments, or review threads.
- Other review comments: Vercel preview ready comment only; no actionable requested changes.
- Follow-up commits/checks: ran `npm test -- TasksPage`, `npm run lint`, and `npm run build` after the follow-up commit; GitHub checks are green including Build & Test, E2E Tests, CodeQL, Vercel, and release draft.

## Rollback
- Revert this PR to restore the previous generic `/tasks` empty card; project creation behavior remains on the existing action route.

## Deferred/non-blocking follow-ups
- None for this first-run empty state.
