### PR TITLE
perf(tasks): add large-tree guardrails

### DIFF
--- a/Testing/unit/features/gantt/lib/gantt-adapter.test.ts
+++ b/Testing/unit/features/gantt/lib/gantt-adapter.test.ts
@@ -133,6 +133,57 @@ describe('tasksToGanttRows (Wave 28)', () => {
         expect(on.rows.map((r) => r.id)).toEqual(['ph1', 'm1', 't1']);
     });
 
+    it('maps a 500+ row hierarchy with leaf-task rendering enabled', () => {
+        const root = makeTask({ id: 'large-project', parent_task_id: null, task_type: 'project' });
+        const phases = Array.from({ length: 12 }, (_, phaseIndex) =>
+            makeTask({
+                id: `large-phase-${phaseIndex}`,
+                parent_task_id: root.id,
+                task_type: 'phase',
+                title: `Phase ${phaseIndex}`,
+                start_date: '2026-01-01',
+                due_date: '2026-12-31',
+                position: phaseIndex,
+            }),
+        );
+        const milestones = phases.flatMap((phase, phaseIndex) =>
+            Array.from({ length: 10 }, (_, milestoneIndex) =>
+                makeTask({
+                    id: `large-milestone-${phaseIndex}-${milestoneIndex}`,
+                    parent_task_id: phase.id,
+                    task_type: 'milestone',
+                    title: `Milestone ${phaseIndex}.${milestoneIndex}`,
+                    start_date: '2026-02-01',
+                    due_date: '2026-11-30',
+                    position: milestoneIndex,
+                }),
+            ),
+        );
+        const leafTasks = milestones.flatMap((milestone, milestoneIndex) =>
+            Array.from({ length: 4 }, (_, taskIndex) =>
+                makeTask({
+                    id: `large-task-${milestoneIndex}-${taskIndex}`,
+                    parent_task_id: milestone.id,
+                    task_type: 'task',
+                    title: `Task ${milestoneIndex}.${taskIndex}`,
+                    start_date: '2026-03-01',
+                    due_date: '2026-03-15',
+                    position: taskIndex,
+                }),
+            ),
+        );
+
+        const result = tasksToGanttRows(
+            [root, ...phases, ...milestones, ...leafTasks],
+            { includeLeafTasks: true },
+        );
+
+        expect(result.skippedCount).toBe(0);
+        expect(result.rows).toHaveLength(612);
+        expect(result.rows[0].id).toBe('large-phase-0');
+        expect(result.rows.at(-1)?.id).toBe('large-task-119-3');
+    });
+
     it('always excludes subtasks', () => {
         const tasks: HierarchyTask[] = [
             makeTask({ id: 'p1', parent_task_id: null, task_type: 'project' }),

--- a/Testing/unit/features/projects/hooks/useProjectBoard.test.ts
+++ b/Testing/unit/features/projects/hooks/useProjectBoard.test.ts
@@ -432,8 +432,10 @@ describe('useProjectBoard', () => {
 
       const { result } = renderProjectBoard(projectId, tasks);
 
-      expect(result.current.computed.tasksWithState).toHaveLength(520);
-      const mappedParent = result.current.computed.tasksWithState.find((task) => task.id === 'parent-0');
+      const milestoneTasks = result.current.computed.getTasksWithStateForParent('milestone-0');
+
+      expect(milestoneTasks).toHaveLength(5);
+      const mappedParent = milestoneTasks.find((task) => task.id === 'parent-0');
       expect(mappedParent?.children).toHaveLength(25);
       expect(mappedParent?.children?.[0].id).toBe('child-0-24');
       expect(mappedParent?.children?.[24].id).toBe('child-0-0');

--- a/Testing/unit/features/projects/hooks/useProjectBoard.test.ts
+++ b/Testing/unit/features/projects/hooks/useProjectBoard.test.ts
@@ -410,5 +410,33 @@ describe('useProjectBoard', () => {
       const mapped = result.current.computed.mapTaskWithState(selfRef);
       expect(mapped.id).toBe('self');
     });
+
+    it('builds board state for a 500+ task tree from the shared child index', () => {
+      const parents = Array.from({ length: 20 }, (_, parentIndex) =>
+        makeTask({
+          id: `parent-${parentIndex}`,
+          parent_task_id: `milestone-${parentIndex % 4}`,
+          position: parentIndex,
+        }),
+      );
+      const children = parents.flatMap((parent, parentIndex) =>
+        Array.from({ length: 25 }, (_, childIndex) =>
+          makeTask({
+            id: `child-${parentIndex}-${childIndex}`,
+            parent_task_id: parent.id,
+            position: 25 - childIndex,
+          }),
+        ),
+      );
+      const tasks = [...parents, ...children];
+
+      const { result } = renderProjectBoard(projectId, tasks);
+
+      expect(result.current.computed.tasksWithState).toHaveLength(520);
+      const mappedParent = result.current.computed.tasksWithState.find((task) => task.id === 'parent-0');
+      expect(mappedParent?.children).toHaveLength(25);
+      expect(mappedParent?.children?.[0].id).toBe('child-0-24');
+      expect(mappedParent?.children?.[24].id).toBe('child-0-0');
+    });
   });
 });

--- a/Testing/unit/features/tasks/hooks/useTaskFilters.test.ts
+++ b/Testing/unit/features/tasks/hooks/useTaskFilters.test.ts
@@ -239,6 +239,56 @@ describe('filterAndSortTasks — views', () => {
   expect(result.map((t) => t.id).sort()).toEqual([...ALL_INSTANCE_CHILDREN].sort());
  });
 
+ it("'all_tasks' handles a 500+ row tree without dropping hierarchy rows", () => {
+  const project = makeProject({ id: 'large-project', origin: 'instance' });
+  const phases = Array.from({ length: 10 }, (_, phaseIndex) =>
+   makeTask({
+    id: `large-phase-${phaseIndex}`,
+    parent_task_id: project.id,
+    root_id: project.id,
+    origin: 'instance',
+    task_type: 'phase',
+    position: phaseIndex,
+   }),
+  );
+  const milestones = phases.flatMap((phase, phaseIndex) =>
+   Array.from({ length: 5 }, (_, milestoneIndex) =>
+    makeTask({
+     id: `large-milestone-${phaseIndex}-${milestoneIndex}`,
+     parent_task_id: phase.id,
+     root_id: project.id,
+     origin: 'instance',
+     task_type: 'milestone',
+     position: milestoneIndex,
+    }),
+   ),
+  );
+  const leafTasks = milestones.flatMap((milestone, milestoneIndex) =>
+   Array.from({ length: 10 }, (_, taskIndex) =>
+    makeTask({
+     id: `large-task-${milestoneIndex}-${taskIndex}`,
+     parent_task_id: milestone.id,
+     root_id: project.id,
+     origin: 'instance',
+     task_type: 'task',
+     due_date: `2026-05-${String((taskIndex % 28) + 1).padStart(2, '0')}`,
+     position: taskIndex,
+    }),
+   ),
+  );
+
+  const result = filterAndSortTasks({
+   tasks: [project, ...phases, ...milestones, ...leafTasks],
+   filter: 'all_tasks',
+   sort: 'chronological',
+   now: NOW,
+  });
+
+  expect(result).toHaveLength(560);
+  expect(new Set(result.map((task) => task.id)).size).toBe(560);
+  expect(result).not.toContainEqual(expect.objectContaining({ id: project.id }));
+ });
+
  it("'milestones' returns ONLY rows with task_type='milestone'", () => {
   const tasks = buildFixture();
   const result = filterAndSortTasks({ tasks, filter: 'milestones', sort: 'chronological', now: NOW });

--- a/src/features/projects/hooks/useProjectBoard.ts
+++ b/src/features/projects/hooks/useProjectBoard.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { toast } from 'sonner';
@@ -20,6 +20,12 @@ export interface ProjectBoardTaskActions {
         options?: { onSuccess?: () => void; onError?: (error: Error) => void },
     ) => void;
 }
+
+type TaskWithBoardState = TaskRow & {
+    isExpanded?: boolean;
+    isAddingInline?: boolean;
+    children?: TaskWithBoardState[];
+};
 
 /**
  * Copies only behavior flags that project instances may inherit as read-only behavior.
@@ -60,6 +66,20 @@ export function useProjectBoard(
     const [inlineAddingParentId, setInlineAddingParentId] = useState<string | null>(null);
     const [showInviteModal, setShowInviteModal] = useState(false);
 
+    const childrenByParentId = useMemo(() => {
+        const index = new Map<string, TaskRow[]>();
+        for (const task of tasks) {
+            if (!task.parent_task_id || task.parent_task_id === task.id) continue;
+            const children = index.get(task.parent_task_id) ?? [];
+            children.push(task);
+            index.set(task.parent_task_id, children);
+        }
+        for (const children of index.values()) {
+            children.sort((a, b) => (a.position || 0) - (b.position || 0));
+        }
+        return index;
+    }, [tasks]);
+
     const handleTaskUpdate = (taskId: string, data: Partial<TaskUpdate>) => {
         if (!projectId) {
             toast.error(t('errors.project_not_found_or_no_access'));
@@ -84,23 +104,25 @@ export function useProjectBoard(
         });
     };
 
-    const mapTaskWithState = (task: TaskRow): Record<string, unknown> => {
+    const mapTaskWithState = useCallback((task: TaskRow): TaskWithBoardState => {
         const visited = new Set<string>();
-        const buildNode = (t: TaskRow): Record<string, unknown> => {
+        const buildNode = (t: TaskRow): TaskWithBoardState => {
             if (visited.has(t.id)) return { ...t, children: [] };
             visited.add(t.id);
             return {
                 ...t,
                 isExpanded: expandedTaskIds.has(t.id) || inlineAddingParentId === t.id,
                 isAddingInline: inlineAddingParentId === t.id,
-                children: tasks
-                    .filter((c) => c.parent_task_id === t.id && c.id !== t.id)
-                    .map(buildNode)
-                    .sort((a, b) => ((a as TaskRow).position || 0) - ((b as TaskRow).position || 0)),
+                children: (childrenByParentId.get(t.id) ?? []).map(buildNode),
             };
         };
         return buildNode(task);
-    };
+    }, [childrenByParentId, expandedTaskIds, inlineAddingParentId]);
+
+    const tasksWithState = useMemo(
+        () => tasks.map(mapTaskWithState),
+        [mapTaskWithState, tasks],
+    );
 
     const handleStartInlineAdd = (parentTask: TaskRow) => {
         setInlineAddingParentId(parentTask.id);
@@ -159,7 +181,8 @@ export function useProjectBoard(
             handleStartInlineAdd, handleInlineCommit, handleDeleteTask
         },
         computed: {
-            mapTaskWithState
+            mapTaskWithState,
+            tasksWithState
         }
     };
 }

--- a/src/features/projects/hooks/useProjectBoard.ts
+++ b/src/features/projects/hooks/useProjectBoard.ts
@@ -21,7 +21,7 @@ export interface ProjectBoardTaskActions {
     ) => void;
 }
 
-type TaskWithBoardState = TaskRow & {
+export type TaskWithBoardState = TaskRow & {
     isExpanded?: boolean;
     isAddingInline?: boolean;
     children?: TaskWithBoardState[];
@@ -119,9 +119,9 @@ export function useProjectBoard(
         return buildNode(task);
     }, [childrenByParentId, expandedTaskIds, inlineAddingParentId]);
 
-    const tasksWithState = useMemo(
-        () => tasks.map(mapTaskWithState),
-        [mapTaskWithState, tasks],
+    const getTasksWithStateForParent = useCallback(
+        (parentId: string): TaskWithBoardState[] => (childrenByParentId.get(parentId) ?? []).map(mapTaskWithState),
+        [childrenByParentId, mapTaskWithState],
     );
 
     const handleStartInlineAdd = (parentTask: TaskRow) => {
@@ -182,7 +182,7 @@ export function useProjectBoard(
         },
         computed: {
             mapTaskWithState,
-            tasksWithState
+            getTasksWithStateForParent
         }
     };
 }

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -238,7 +238,6 @@ export default function Project() {
         ((milestones || []) as TaskRow[]).sort((a: TaskRow, b: TaskRow) => compareDateAsc(a.due_date, b.due_date)),
         [milestones]
     );
-    const tasksWithBoardState = computed.tasksWithState as TaskRow[];
 
     const phaseMilestones = projectMilestones
         .filter((m: TaskRow) => m.parent_task_id === activePhase?.id)
@@ -377,7 +376,7 @@ export default function Project() {
                                                     <MilestoneSection
                                                         key={milestone.id}
                                                         milestone={milestone}
-                                                        tasks={tasksWithBoardState}
+                                                        tasks={computed.getTasksWithStateForParent(milestone.id)}
                                                         onTaskUpdate={handlers.handleTaskUpdate as (id: string, updates: Partial<TaskRow>) => void}
                                                         onAddChildTask={canCreateTasks ? handlers.handleStartInlineAdd : undefined}
                                                         onMoveTask={canReorderTasks ? openMoveTaskDialog : undefined}

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -238,6 +238,7 @@ export default function Project() {
         ((milestones || []) as TaskRow[]).sort((a: TaskRow, b: TaskRow) => compareDateAsc(a.due_date, b.due_date)),
         [milestones]
     );
+    const tasksWithBoardState = computed.tasksWithState as TaskRow[];
 
     const phaseMilestones = projectMilestones
         .filter((m: TaskRow) => m.parent_task_id === activePhase?.id)
@@ -376,7 +377,7 @@ export default function Project() {
                                                     <MilestoneSection
                                                         key={milestone.id}
                                                         milestone={milestone}
-                                                        tasks={(tasks as TaskRow[] || []).map(computed.mapTaskWithState) as TaskRow[]}
+                                                        tasks={tasksWithBoardState}
                                                         onTaskUpdate={handlers.handleTaskUpdate as (id: string, updates: Partial<TaskRow>) => void}
                                                         onAddChildTask={canCreateTasks ? handlers.handleStartInlineAdd : undefined}
                                                         onMoveTask={canReorderTasks ? openMoveTaskDialog : undefined}


### PR DESCRIPTION
## Summary
- Index project-board child rows once and map only the board-state rows needed for each milestone parent.
- Add 500+ row characterization coverage for project board state, `/tasks` filtering, and Gantt row adaptation.

## Findings addressed
- PR17/performance-reliability/P1-P2: large project renders could recompute task board state once per visible milestone, with each row mapper recursively filtering the full task list. Current `/tasks` filtering and Gantt adapter behavior were already mostly linear, so this PR adds large-tree guardrails instead of a broad rewrite.

## Evidence inspected
- Files: `src/pages/TasksPage.tsx`, `src/pages/Project.tsx`, `src/pages/Gantt.tsx`, `src/features/projects/hooks/useProjectData.ts`, `src/features/projects/hooks/useProjectBoard.ts`, `src/features/tasks/components/MilestoneSection.tsx`, `src/features/tasks/components/TaskItem.tsx`, `src/features/tasks/hooks/useTaskFilters.ts`, `src/features/tasks/lib/priority-tasks.ts`, `src/features/gantt/lib/gantt-adapter.ts`, `src/shared/api/planterClient.ts`
- Docs/ADRs: `docs/architecture/tasks-subtasks.md`
- Migrations/RLS/RPC/Edge: no DB/RLS/RPC/Edge changes; existing task hierarchy and RLS enforcement unchanged
- Tests: existing Project/Tasks/Gantt unit coverage and release E2E; new large-tree unit guardrails in project board, task filters, and Gantt adapter tests

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Project hierarchy render/DnD state | Project now asks `useProjectBoard` for mapped rows per milestone parent; child lookup is indexed once | Existing task mutation hooks unchanged | Existing hierarchy/RLS triggers unchanged | N/A | `useProjectBoard` 520-row board-state guard | No virtualization; not needed by current evidence |
| Unified `/tasks` filters | Existing memoized filter path unchanged | Existing `planter.entities.Task.list()` path unchanged | RLS-visible task list remains the source boundary | N/A | `useTaskFilters` 560-row all-tasks guard | Server-side pagination deferred unless unbounded fetch becomes a measured blocker |
| Gantt adaptation | Existing memoized `tasksToGanttRows` call unchanged | Existing project hierarchy query unchanged | Existing hierarchy/RLS unchanged | N/A | `gantt-adapter` 612-row leaf-render guard | Gantt library rendering itself is not virtualized |

## Data/security impact
- No database schema, RLS, RPC, dependency, or environment changes.
- No secrets or connection strings added. Existing authorized task mutation and RLS paths are unchanged.

## Tests added/updated
- Added a 520-row board-state guard in `Testing/unit/features/projects/hooks/useProjectBoard.test.ts`.
- Added a 560-row `/tasks` filter guard in `Testing/unit/features/tasks/hooks/useTaskFilters.test.ts`.
- Added a 612-row Gantt adapter guard in `Testing/unit/features/gantt/lib/gantt-adapter.test.ts`.

## Commands run
```bash
npm test -- useProjectBoard useTaskFilters gantt-adapter
npm test -- TasksPage
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run test:e2e:release
git diff --check

# Review-fix checks after Gemini comments
npm test -- useProjectBoard TasksPage
npm run lint
npm run build
git diff --check
```

## Bot review follow-up
- PR opened at: 2026-05-09T15:29:44Z
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: 2 substantive inline comments; both addressed in follow-up commit `ecbf4bf6` and now outdated
- Codex Connector Bot comments: none found
- Other review comments: Vercel preview comment only
- Follow-up commits/checks: `ecbf4bf6`; reran affected local checks; GitHub checks green, including Build & Test, E2E, CodeQL, Vercel, and Release Drafter

## Rollback
- Revert this PR. Project renders return to per-milestone board-state mapping; the added large-tree guardrails are removed.

## Deferred/non-blocking follow-ups
- Consider server-side pagination or virtualization only if a measured production trace shows current 500+ row behavior is still a blocker.
