### PR TITLE
test(i18n): enforce Spanish release gate

### DIFF
--- a/Testing/unit/shared/i18n/en-json.test.ts
+++ b/Testing/unit/shared/i18n/en-json.test.ts
@@ -9,9 +9,6 @@ interface JsonObject {
 
 describe('en.json', () => {
   it('matches the runtime namespace catalog', () => {
-    for (const ns of NAMESPACES) {
-      expect(en).toHaveProperty(ns);
-    }
     expect(Object.keys(en).sort()).toEqual([...NAMESPACES].sort());
   });
 

--- a/Testing/unit/shared/i18n/en-json.test.ts
+++ b/Testing/unit/shared/i18n/en-json.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { NAMESPACES } from '@/shared/i18n';
 import en from '@/shared/i18n/locales/en.json';
 
 type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
@@ -6,28 +7,12 @@ interface JsonObject {
   [key: string]: JsonValue;
 }
 
-const REQUIRED_NAMESPACES = [
-  'common',
-  'nav',
-  'onboarding',
-  'auth',
-  'tasks',
-  'activity',
-  'projects',
-  'library',
-  'settings',
-  'notifications',
-  'errors',
-  'ics',
-  'gantt',
-  'admin',
-] as const;
-
 describe('en.json', () => {
-  it('has every required namespace', () => {
-    for (const ns of REQUIRED_NAMESPACES) {
+  it('matches the runtime namespace catalog', () => {
+    for (const ns of NAMESPACES) {
       expect(en).toHaveProperty(ns);
     }
+    expect(Object.keys(en).sort()).toEqual([...NAMESPACES].sort());
   });
 
   it('no empty string values', () => {

--- a/Testing/unit/shared/i18n/es-json.test.ts
+++ b/Testing/unit/shared/i18n/es-json.test.ts
@@ -39,6 +39,8 @@ describe('es.json', () => {
     const meta = (es as JsonObject)._meta as JsonObject;
     const spanishLocale = SUPPORTED_LOCALES.find((locale) => locale.code === 'es');
 
+    expect(meta.status).toContain('machine-translated');
+    expect(meta.review_required_before_marketing).toBe(true);
     expect(spanishLocale).toMatchObject({
       code: 'es',
       launchStatus: 'review_required',

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -19,7 +19,7 @@
 ## Namespace structure
 `common, nav, onboarding, auth, tasks, activity, projects, library, settings, notifications, errors, ics, gantt, admin`. Snake_case keys. Pluralization via i18next built-in (`_one`, `_other`).
 
-`src/shared/i18n/index.ts` is the runtime namespace catalog; `Testing/unit/shared/i18n/en-json.test.ts` asserts the English baseline matches that catalog exactly so docs and runtime keys do not drift.
+`src/shared/i18n/index.ts` is the runtime namespace catalog; keep this manual list in sync with that source when adding or removing namespaces. `Testing/unit/shared/i18n/en-json.test.ts` asserts the English baseline matches the runtime catalog exactly.
 
 ## Date / number split
 * **Display** (anything user-facing) → `formatDateLocalized` / `formatNumberLocalized` / `formatCurrencyLocalized` from `src/shared/i18n/formatters.ts`.

--- a/docs/architecture/i18n.md
+++ b/docs/architecture/i18n.md
@@ -17,7 +17,9 @@
 * `src/features/settings/components/LocaleSwitcher.tsx` — Settings → Profile tab.
 
 ## Namespace structure
-`common, auth, tasks, projects, library, settings, notifications, errors, ics, gantt, admin`. Snake_case keys. Pluralization via i18next built-in (`_one`, `_other`).
+`common, nav, onboarding, auth, tasks, activity, projects, library, settings, notifications, errors, ics, gantt, admin`. Snake_case keys. Pluralization via i18next built-in (`_one`, `_other`).
+
+`src/shared/i18n/index.ts` is the runtime namespace catalog; `Testing/unit/shared/i18n/en-json.test.ts` asserts the English baseline matches that catalog exactly so docs and runtime keys do not drift.
 
 ## Date / number split
 * **Display** (anything user-facing) → `formatDateLocalized` / `formatNumberLocalized` / `formatCurrencyLocalized` from `src/shared/i18n/formatters.ts`.


### PR DESCRIPTION
## Summary
- Derive the English locale namespace test from the runtime `NAMESPACES` catalog to prevent locale/runtime drift.
- Make the Spanish machine-translation marketing block explicit in the i18n metadata test.
- Update the i18n architecture namespace list to match the current runtime catalog.

## Findings addressed
- PR18/localization/P2: current `main` already gates Spanish as machine-translated and not marketing-ready, but the architecture namespace list had drifted from the runtime locale catalog. No marketing or release copy claiming Spanish-market readiness was found.

## Evidence inspected
- Files: `src/shared/i18n/index.ts`, `src/shared/i18n/locales/en.json`, `src/shared/i18n/locales/es.json`, `src/features/settings/components/LocaleSwitcher.tsx`
- Docs/ADRs: `docs/architecture/i18n.md`, `docs/dev-notes.md`, `docs/AGENT_CONTEXT.md`, `AGENTS.md`, `CLAUDE.md`, `README.md`
- Migrations/RLS/RPC/Edge: N/A; no data-boundary changes
- Tests: `Testing/unit/shared/i18n/en-json.test.ts`, `Testing/unit/shared/i18n/es-json.test.ts`, `Testing/unit/features/settings/components/LocaleSwitcher.test.tsx`, release E2E suite

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Spanish locale release gate | LocaleSwitcher continues to show beta/review-required warning for Spanish | N/A | N/A | N/A | `es-json.test.ts` asserts machine-translated metadata, review-required flag, `launchStatus: review_required`, and `marketingReady: false` | Human review still required before marketing Spanish support |
| Runtime namespace catalog | N/A | N/A | N/A | N/A | `en-json.test.ts` asserts `en.json` exactly matches runtime `NAMESPACES` | None |
| Architecture docs | N/A | N/A | N/A | N/A | Docs updated to match runtime catalog and point to the runtime/test source of truth | None |

## Data/security impact
- No database, RLS, RPC, Edge, dependency, or environment changes.
- No secrets or connection strings added.

## Tests added/updated
- Updated `Testing/unit/shared/i18n/en-json.test.ts` to use `NAMESPACES` as the namespace source of truth.
- Updated `Testing/unit/shared/i18n/es-json.test.ts` to explicitly assert the Spanish machine-translation review gate.
- Updated `docs/architecture/i18n.md` namespace documentation.

## Commands run
```bash
npm test -- i18n LocaleSwitcher
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run test:e2e:release
git diff --check

# Review-fix checks after Gemini comments
npm test -- i18n
npm run lint
npm run build
git diff --check
```

## Bot review follow-up
- PR opened at: 2026-05-09T15:51:26Z
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: 2 low-priority inline comments; both addressed in follow-up commit `c97c0f49`
- Codex Connector Bot comments: none found
- Other review comments: Vercel preview comment only
- Follow-up commits/checks: `c97c0f49`; reran affected local checks; GitHub checks green, including Build & Test, E2E, CodeQL, Vercel, and Release Drafter

## Rollback
- Revert this PR. Spanish runtime gating remains as it was on `main`, but namespace docs/tests lose this stricter drift guard.

## Deferred/non-blocking follow-ups
- Human Spanish review remains required before changing `es._meta.review_required_before_marketing`, `SUPPORTED_LOCALES.es.marketingReady`, or any external Spanish support claims.
