### PR TITLE
docs(release): add readiness ledger

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -4,6 +4,8 @@ Testing artifacts live here so the repository root stays focused on entrypoint
 files and tool-specific instructions.
 
 * [strategy.md](strategy.md): current testing strategy and validation commands.
+* [release-readiness-ledger.md](release-readiness-ledger.md): final
+  release-hardening validation ledger, accepted risks, and deployment blockers.
 * [release-regression-closeout.md](release-regression-closeout.md): current
   release-hardening coverage matrix and contradicted/non-gate items.
 * [implementation-plan.md](implementation-plan.md): historical phased plan that

--- a/docs/testing/release-readiness-ledger.md
+++ b/docs/testing/release-readiness-ledger.md
@@ -1,0 +1,93 @@
+# Release Readiness Ledger
+
+This ledger records the release-hardening close-out state as of 2026-05-09,
+after PR #256 (`1a01d981`). It is intentionally evidence-based: passing checks
+and merged PRs are listed separately from accepted risks and blocked validation.
+
+## Scope
+
+- Runtime: Vite, React `18.3.1`, TypeScript, Supabase.
+- Client env names: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and optional
+  public `VITE_VAPID_PUBLIC_KEY`.
+- Unsupported assumptions: Create React App, `REACT_APP_*` env names, React 19,
+  broad dependency upgrades, two-way calendar sync, and template
+  reconciliation/sync.
+
+## Merged release-hardening work
+
+| Area | PR | Outcome |
+| --- | --- | --- |
+| Project creation smoke | #213 `test: add project creation smoke coverage` | Already on `main`; PR20 reconfirmed blank project, official-template creation, and no-note-copy coverage. |
+| Critical release E2E gate | #229 `Add critical release E2E regressions` | Added the release BDD suite and fixed phase-unlock plus table-grant blockers exposed by it. |
+| RBAC matrix | #238 `fix: harden task role matrix enforcement` | Owner/editor/admin/coach/viewer/limited behavior characterized and enforced below UI. |
+| Template scaffold policy | #239 `test: harden template scaffold policy docs` | Protected scaffold behavior documented and covered against DB trigger behavior. |
+| Account lifecycle | #240 `test: harden account lifecycle coverage` | Deletion/anonymization behavior characterized without weakening auditability. |
+| Task hierarchy | #241 `test: harden task hierarchy invariants` | Depth and cycle invariants covered below UI. |
+| Date envelopes | #242 `test: harden date envelope rollup coverage` | Parent/child date envelope and rollup behavior covered. |
+| Completion rollups | #243 `fix: harden completion rollup regressions` | Completion cascade, reopen, phase unlock, and mixed-field regressions covered. |
+| ICS tokens | #244 `fix: harden ics token lifecycle` | Token revocation, one-way lifecycle, and scoping covered. |
+| Comments and mentions | #245 `fix: scope comment mention notifications` | Mention metadata and hydration behavior hardened. |
+| Admin moderation | #246 `fix: secure admin reset link display` | Admin moderation UI no longer exposes reset links casually; server authorization remains the gate. |
+| Boot configuration | #247 `fix: surface missing env configuration safely` | Missing Vite envs render a safe boot error instead of crashing at import time. |
+| Project realtime | #248 `fix(projects): centralize project realtime subscription` | Project task realtime subscriptions centralized and test-covered. |
+| Gantt export | #249 `docs(gantt): document print-backed PDF export` | Launch-visible export surface clarified as browser print/save-as-PDF, not dead PDF generation. |
+| PWA service worker | #250 `fix(pwa): harden service worker push payload fallback` | Push payload parsing and service worker guardrails improved. |
+| Tasks first-run empty state | #251 `fix(tasks): guide first-run project creation` | Primary task surface guides empty users to project creation flows. |
+| Mobile/accessibility | #252 `fix(a11y): add mobile-safe task movement` | Mobile-safe task movement path added and covered. |
+| Large-tree guardrails | #253 `perf(tasks): add large-tree guardrails` | Large task-tree regressions covered without broad virtualization rewrites. |
+| Spanish release gate | #254 `test(i18n): enforce Spanish release gate` | Spanish remains machine-translated and explicitly not marketing-ready. |
+| Metadata/docs guardrails | #255 `chore(release): refresh metadata and guardrail docs` | Package metadata and docs match Vite/React 18/pinned dependency reality. |
+| Regression close-out | #256 `test(release): document regression coverage closeout` | Release checklist mapped to executable coverage and SSoT contradictions. |
+
+## Final validation status
+
+| Command | Status | Notes |
+| --- | --- | --- |
+| `npm ci` | Passed | 0 vulnerabilities reported. |
+| `npm run verify-dependencies` | Passed | React/React DOM/React Is pins, Gantt pin, type packages, and dnd-kit guardrails verified. |
+| `npm run verify-architecture` | Passed | No structural violations found. |
+| `npm run lint` | Passed | Zero ESLint errors. |
+| `npm test` | Passed | 138 files, 1128 tests. |
+| `npm run build` | Passed | Vite emitted the known chunk-size warning; no build failure. |
+| `npm run db:local:test` | Passed | 16 pgTAP files, 223 tests. This reset the local Supabase public schema only. |
+| `node scripts/seed-e2e.js` | Passed | Local E2E user already existed; public anon key was redacted by the script. |
+| `npm run test:e2e:release` | Passed | 8 release-tagged Playwright tests. |
+| `npm run test:e2e:mobile` | Passed | 11 mobile tests; existing Radix `DialogContent` description warning was non-fatal. |
+| `npm run test:e2e:a11y` | Passed | 14 accessibility tests. |
+| `git diff --check` | Passed | No whitespace errors in the PR21 diff. |
+| `vercel env run -e preview -- npm run build` | Blocked locally | `vercel` is not installed on PATH. `npx --yes vercel@latest whoami` failed with an invalid token; `npx --yes vercel@latest env run -e preview -- npm run build` entered a device-login flow and was terminated without authenticating. |
+| `vercel env run -e preview -- npm test` | Not run | Same local Vercel authentication blocker; no Vercel env values were printed. |
+
+## Deployment and environment posture
+
+- GitHub CI on PR #256 was green for Build & Test, E2E Tests, CodeQL, Vercel,
+  Vercel Preview Comments, and Release Drafter after the final follow-up commit.
+- Vercel GitHub preview deployment for PR #256 reported Ready.
+- Local Vercel preview-env validation is not complete because the Vercel CLI is
+  not installed on PATH and the available `npx` flow cannot authenticate
+  non-interactively in this environment. The smallest later verification step
+  is:
+
+  ```bash
+  vercel login
+  vercel env run -e preview -- npm run build
+  vercel env run -e preview -- npm test
+  ```
+
+- Do not commit `.vercel/`, `.env.local`, or pulled Vercel/Supabase secrets.
+
+## Remaining accepted risks
+
+| Severity | Risk | Current decision |
+| --- | --- | --- |
+| P1 | Local Vercel preview-env build/test validation is blocked by missing or invalid CLI authentication. | Do not declare production release-ready until an operator refreshes Vercel auth and reruns the preview-env build/test commands. |
+| P2 | Dependency-order completion warning prompts are not a current trusted feature. | Contradicted by `docs/architecture/tasks-subtasks.md`; future work requires DB/API enforcement before becoming a release gate. |
+| P2 | Legacy full E2E inventory is broader than the curated release gate. | Keep `npm run test:e2e:release`, mobile, and accessibility suites as release gates until stale legacy scenarios are curated. |
+| P2 | Spanish is machine-translated. | Keep `es` marked review-required and do not market Spanish support until native-speaker review lands. |
+| P3 | Vite emits a large chunk warning during production build. | Accepted non-blocker unless bundle work becomes a separate performance PR. |
+
+## Release statement
+
+As of this ledger, the codebase passes the local release-candidate validation
+gate. Production release readiness remains conditional on completing Vercel
+preview-env build/test validation with valid operator credentials.


### PR DESCRIPTION
## Summary
- Add a final release-readiness ledger for the release-hardening sequence.
- Record merged hardening PRs, final local validation status, accepted risks, and the remaining Vercel preview-env validation blocker.
- Link the ledger from the testing docs index.

## Findings addressed
- PR21/Deployment-Vercel/Gate: Final local release-candidate validation is green, but Vercel preview-env build/test remains blocked by missing or invalid local Vercel authentication.
- PR21/Documentation-ADR-drift/P2: Release status is now captured in a single docs ledger without claiming Spanish market readiness, CRA env names, unsupported dependency versions, or completed Vercel CLI validation.

## Evidence inspected
- Files: `package.json`, `package-lock.json`, `.env.example`, `.github/workflows/ci.yml`, `vercel.json`, `README.md`, `docs/testing/README.md`, `docs/testing/release-regression-closeout.md`
- Docs/ADRs: `docs/AGENT_CONTEXT.md`, `docs/architecture/user-testing-baseline.md`, `docs/architecture/i18n.md`, `docs/operations/edge-function-schedules.md`, `docs/operations/local_development.md`, `docs/operations/SAFE_MIGRATION.md`, `spec.md`, `repo-context.yaml`
- Migrations/RLS/RPC/Edge: no schema/RLS/RPC/Edge changes in this PR; ledger references already-merged pgTAP/release-hardening coverage.
- Tests: final local release gate plus DB, release E2E, mobile E2E, accessibility E2E, and final build/whitespace checks.

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Release readiness ledger | N/A | N/A | N/A | N/A | Documents final validation commands and results; links to PR20 coverage matrix | Vercel preview-env build/test must be rerun by an authenticated operator before production release. |
| Deployment/env assumptions | Boot-safe config behavior is already implemented; docs list Vite env names only | Existing app config paths use Vite envs | N/A | Supabase function secrets documented separately from client envs | `npm run build` passed locally; GitHub Vercel preview on PR20 and PR21 was Ready | Local Vercel CLI auth unavailable, so `vercel env run` validation is blocked. |

## Data/security impact
- No runtime, database, RLS, RPC, or edge behavior changed.
- The ledger explicitly avoids exposing secrets and keeps `.vercel/`, `.env.local`, and pulled env files out of scope.
- Production release readiness is not declared until Vercel preview-env build/test is completed with valid operator credentials.

## Tests added/updated
- Added `docs/testing/release-readiness-ledger.md`.
- Updated `docs/testing/README.md`.

## Commands run
```bash
npm ci
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build
npm run db:local:test
node scripts/seed-e2e.js
npm run test:e2e:release
npm run test:e2e:mobile
npm run test:e2e:a11y
npx --yes vercel@latest whoami
npx --yes vercel@latest env run -e preview -- npm run build
git diff --check
npm run verify-architecture
npm run build
git diff --check
gh pr checks 257 --watch --interval 10
```

Vercel result: `vercel` was not installed on PATH; `npx --yes vercel@latest whoami` failed with an invalid token; `npx --yes vercel@latest env run -e preview -- npm run build` entered a device-login flow and was terminated without authenticating. No Vercel env values were printed.

## Bot review follow-up
- PR opened at: 2026-05-09T17:05:10Z
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: summary-only review with no feedback; no inline comments.
- Codex Connector Bot comments: none found.
- Other review comments: Vercel preview comment only; deployment is Ready.
- Follow-up commits/checks: no follow-up commits after opening; GitHub Build & Test, E2E Tests, CodeQL, Vercel, Vercel Preview Comments, and Release Drafter are green.

## Rollback
- Revert this docs-only commit to remove the ledger and testing-index link. No runtime or database rollback is required.

## Deferred/non-blocking follow-ups
- Operator must refresh Vercel authentication and run:
  - `vercel env run -e preview -- npm run build`
  - `vercel env run -e preview -- npm test`
- Spanish remains machine-translated and must not be marketed as ready until human review lands.
- Dependency-order completion blocking remains out of release scope until a future product PR adds trusted DB/API enforcement.
