### PR TITLE
test(db): tighten account lifecycle fk assertions

### DIFF
--- a/Testing/unit/shared/db/schema-source.test.ts
+++ b/Testing/unit/shared/db/schema-source.test.ts
@@ -314,10 +314,8 @@ describe('docs/db/schema.sql source of truth', () => {
    'project_members_user_id_fkey',
    'push_subscriptions_user_id_fkey',
   ].forEach((constraintName) => {
-   expect(schema).toMatch(
-    new RegExp(
-     `ADD CONSTRAINT "${constraintName}" FOREIGN KEY \\("user_id"\\) REFERENCES "auth"\\."users"\\("id"\\) ON DELETE CASCADE;`,
-    ),
+   expect(schema).toContain(
+    `ADD CONSTRAINT "${constraintName}" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;`,
    );
   });
   expect(schema).not.toContain(

--- a/Testing/unit/shared/db/schema-source.test.ts
+++ b/Testing/unit/shared/db/schema-source.test.ts
@@ -314,7 +314,11 @@ describe('docs/db/schema.sql source of truth', () => {
    'project_members_user_id_fkey',
    'push_subscriptions_user_id_fkey',
   ].forEach((constraintName) => {
-   expect(schema).toMatch(new RegExp(`ADD CONSTRAINT "${constraintName}" FOREIGN KEY \\("user_id"\\).*ON DELETE CASCADE;`));
+   expect(schema).toMatch(
+    new RegExp(
+     `ADD CONSTRAINT "${constraintName}" FOREIGN KEY \\("user_id"\\) REFERENCES "auth"\\."users"\\("id"\\) ON DELETE CASCADE;`,
+    ),
+   );
   });
   expect(schema).not.toContain(
    'ADD CONSTRAINT "task_comments_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE RESTRICT;',


### PR DESCRIPTION
## Summary
- Tighten the account-lifecycle schema-source test so each cascading `user_id` foreign key must explicitly reference `auth.users(id)`.
- Address the remaining substantive unresolved Gemini review comment found during the PR #238-257 review gate.
- Apply Gemini's PR #258 follow-up suggestion to use `toContain` for the exact source assertion.

## Findings addressed
- PR-review/account-lifecycle/P2: PR #240 left a broad regex in `schema-source.test.ts` that could match a cascading `user_id` FK against the wrong referenced table.

## Evidence inspected
- Files: `Testing/unit/shared/db/schema-source.test.ts`
- Docs/ADRs: `docs/testing/release-readiness-ledger.md`, `docs/testing/release-regression-closeout.md`
- Migrations/RLS/RPC/Edge: `docs/db/schema.sql` FK declarations through the schema-source test fixture
- Tests: PR #238-257 merged PR metadata, comments, review threads, and checks; local review-gate checks; targeted schema-source test

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Account lifecycle FK schema guard | N/A | N/A | DB FK source-of-truth declarations remain unchanged | N/A | `schema-source.test.ts` now requires cascading `user_id` FKs to reference `auth.users(id)` exactly | None for this review comment |

## Data/security impact
- Test-only change; no runtime, schema, migration, RLS, RPC, or edge behavior changed.
- Reduces false-positive risk in account-deletion/anonymization schema assertions.

## Tests added/updated
- Updated `Testing/unit/shared/db/schema-source.test.ts`.

## Commands run
```bash
# Review gate before branch
npm run verify-dependencies
npm run verify-architecture
npm run lint
npm test
npm run build

# PR-specific checks
npm test -- schema-source
git diff --check
npm run lint
npm run build

# After Gemini follow-up
npm test -- schema-source
git diff --check
npm run lint
npm run build
gh pr checks 258 --watch --interval 10
```

## Bot review follow-up
- PR opened at: 2026-05-09T17:41:57Z
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: one low-priority inline suggestion to replace `toMatch(new RegExp(...))` with `toContain(...)`; addressed in follow-up commit `8f4f1e8a`; thread resolved.
- Codex Connector Bot comments: none found.
- Other review comments: Vercel preview comment only; deployment is Ready.
- Follow-up commits/checks: after `8f4f1e8a`, local targeted test/lint/build passed; GitHub Build & Test, E2E Tests, CodeQL, Vercel, Vercel Preview Comments, and Release Drafter are green.

## Rollback
- Revert this test-only commit to restore the broader FK regex. No runtime or database rollback is required.

## Deferred/non-blocking follow-ups
- Continue the cleanup sequence with the task-details dialog description warning after this PR merges.
