### PR TITLE
fix(a11y): describe tasks detail dialog

### DIFF
--- a/src/pages/TasksPage.tsx
+++ b/src/pages/TasksPage.tsx
@@ -41,6 +41,7 @@ import {
 import {
        Dialog,
        DialogContent,
+       DialogDescription,
        DialogHeader,
        DialogTitle,
 } from '@/shared/ui/dialog';
@@ -614,6 +615,7 @@ export default function TasksPage() {
                             >
                                    <DialogHeader className="sr-only">
                                           <DialogTitle>{selectedTaskForPanel?.title ?? t('tasks.panel.details')}</DialogTitle>
+                                          <DialogDescription>{t('tasks.panel.description')}</DialogDescription>
                                    </DialogHeader>
                                    {selectedTaskForPanel && (
                                           <TaskDetailsPanel

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -198,6 +198,7 @@
       "new_item_in_parent": "New {{item}} in {{title}}",
       "new_item": "New {{item}}",
       "details": "Details",
+      "description": "View task details, status, dates, resources, and available actions.",
       "close_panel": "Close panel",
       "add_phase": "Add Phase",
       "add_task": "Add Task"

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -204,6 +204,7 @@
       "new_item_in_parent": "Nueva {{item}} en {{title}}",
       "new_item": "Nueva {{item}}",
       "details": "Detalles",
+      "description": "Ver detalles de la tarea, estado, fechas, recursos y acciones disponibles.",
       "close_panel": "Cerrar panel",
       "add_phase": "Agregar fase",
       "add_task": "Agregar tarea"


### PR DESCRIPTION
## Summary
- Add a hidden Radix `DialogDescription` to the `/tasks` task details dialog.
- Add matching `tasks.panel.description` locale keys in English and Spanish.

## Findings addressed
- Cleanup/a11y/P2: the mobile task details panel emitted Radix's missing dialog description warning.

## Evidence inspected
- Files: `src/pages/TasksPage.tsx`, `src/shared/i18n/locales/en.json`, `src/shared/i18n/locales/es.json`
- Docs/ADRs: `planterplan_release_hardening_context.md` cleanup plan
- Migrations/RLS/RPC/Edge: not applicable; UI accessibility metadata only
- Tests: targeted TasksPage, i18n, mobile E2E, accessibility E2E, build, CI rerun

## Enforcement layer
| Flow | UI | API/RPC | DB/RLS | Edge | Tests | Remaining gap |
|---|---|---|---|---|---|---|
| Mobile/accessibility critical workflows | Hidden dialog description mirrors the existing task details dialog | N/A | N/A | N/A | Mobile and a11y E2E plus targeted unit/i18n tests | None for this warning |

## Data/security impact
- No data model, API, RLS, RPC, Edge Function, auth, or persistence changes.

## Tests added/updated
- Locale key coverage is handled by existing i18n parity tests.
- No new test file was needed because the cleanup is covered by existing page, mobile, and accessibility suites.

## Commands run
```bash
npm test -- TasksPage
npm test -- i18n
npm run test:e2e:mobile
grep -F 'Missing `Description`' /tmp/task-details-dialog-mobile.log || true
npm run test:e2e:a11y
npm run build
git diff --check
gh pr checks 259 --watch --interval 10
```

## Bot review follow-up
- PR opened at: 2026-05-09T18:02:57Z
- Waited 360 seconds before merge review: yes
- Gemini Code Assist comments: review comment said no feedback to provide
- Codex Connector Bot comments: none found
- Other review comments: Vercel preview comment only
- Follow-up commits/checks: no code follow-up; reran failed CI `Build & Test` after Supabase Docker image-pull timeout, then `Build & Test` and downstream `E2E Tests` passed

## Rollback
- Revert this PR to remove the added dialog description and locale keys.